### PR TITLE
README: brief outreach to Xantha

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,10 @@ Client config is generated at `config/lss-client-config.json` on first run.
 | `lodDistanceChunks` | `0` | Max LOD request distance in chunks (0 = use server limit) |
 | `offThreadSectionProcessing` | `true` | Process received sections off the render thread |
 
+## Xantha
+
+Email me at **vox@bitvox.me** — let's work together.
+
 ## License
 
 MIT


### PR DESCRIPTION
Shorter version per your feedback — drops the structural receipts + MIT framing, just an open email offer.