### PR TITLE
Include LICENSE in Paper shadow JAR

### DIFF
--- a/paper/build.gradle
+++ b/paper/build.gradle
@@ -30,6 +30,10 @@ shadowJar {
     configurations = [project.configurations.runtimeClasspath]
     exclude 'org/slf4j/**'
     exclude 'META-INF/maven/org.slf4j/**'
+
+    from(rootProject.file("LICENSE")) {
+        rename { "${it}_lod-server-support-paper" }
+    }
 }
 
 tasks.withType(JavaCompile).configureEach {


### PR DESCRIPTION
## Summary

- The Fabric `jar` task already includes the project LICENSE, but the Paper `shadowJar` task did not
- Adds the same `from(rootProject.file("LICENSE"))` inclusion to `paper/build.gradle` so both distributed JARs ship the license file

## Test plan

- [x] Verified both JARs build successfully
- [x] Confirmed `LICENSE_lod-server-support-paper` appears in the Paper shadow JAR
- [x] Confirmed Fabric JAR still contains `LICENSE_lod-server-support-fabric`

🤖 Generated with [Claude Code](https://claude.com/claude-code)