### PR TITLE
Fix release-notes extraction (annotated tag re-fetch)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,12 @@ jobs:
           set -euo pipefail
           TAG="${GITHUB_REF_NAME}"
 
+          # actions/checkout leaves a LIGHTWEIGHT tag on tag-triggered runs, which drops the
+          # annotated tag's message (our release notes) and makes objecttype read 'commit'. Re-fetch
+          # the real annotated object so the notes below are used instead of the commit-subject
+          # fallback. Non-fatal (|| true): a fetch hiccup degrades to the fallback, never blocks publish.
+          git fetch --force origin "refs/tags/${TAG}:refs/tags/${TAG}" || true
+
           # Annotated tags have objecttype 'tag'; lightweight have 'commit'
           TAG_TYPE=$(git for-each-ref --format='%(objecttype)' "refs/tags/${TAG}")
           if [ "$TAG_TYPE" = "tag" ]; then


### PR DESCRIPTION
`release.yml`'s "Extract release notes from tag" step fell back to a raw commit-subject dump for v0.4.0 (both the GitHub release body and the Modrinth changelog), because `actions/checkout` leaves a **lightweight** tag on tag-triggered runs — so `git for-each-ref --format='%(objecttype)'` returned `commit`, not `tag`, and the annotation was never read.

Fix: force-fetch the real annotated tag object from origin before the type check. Non-fatal (`|| true`) so a fetch hiccup degrades to the existing fallback rather than failing a publish.

Workflow-only; no code change, does not affect the already-published v0.4.0 artifacts. Verified the YAML parses.