### PR TITLE
Deflake TwoPlayerGameTests step 1 (post-edit re-ask retry)

### DIFF
--- a/common/src/main/java/dev/vox/lss/common/processing/AbstractPlayerRequestState.java
+++ b/common/src/main/java/dev/vox/lss/common/processing/AbstractPlayerRequestState.java
@@ -274,6 +274,11 @@ public abstract class AbstractPlayerRequestState<T> {
         return this.incomingRequests;
     }
 
+    /** Number of requests currently queued for routing (not yet polled). */
+    public int getIncomingRequestCount() {
+        return this.incomingRequestCount.get();
+    }
+
     public void addReadyPayload(QueuedPayload<T> payload) {
         this.enqueuedColumns.merge(payload.packedPos(), 1, Integer::sum);
         this.readyPayloads.add(payload);

--- a/fabric/src/gametest/java/dev/vox/lss/test/TwoPlayerGameTests.java
+++ b/fabric/src/gametest/java/dev/vox/lss/test/TwoPlayerGameTests.java
@@ -314,15 +314,27 @@ public class TwoPlayerGameTests {
                     liveFilter.contentChanged(level, chunk, dim);
                     helper.assertTrue(!liveFilter.contentChanged(level, chunk, dim),
                             "premise: live filter baselined pre-edit");
-                    // B's edit, then A's re-ask: the probe re-serve lands between edit and save.
+                    // B's edit; A's re-ask is issued (and retried) in step 1 — the probe re-serve
+                    // must land between edit and save.
                     var edit = level.getBlockState(editPos).is(Blocks.STONE)
                             ? Blocks.COBBLESTONE : Blocks.STONE;
                     level.setBlock(editPos, edit.defaultBlockState(), 3);
-                    stateA.addRequest(packed, -1L);
                     step.set(1);
                     helper.assertTrue(false, "edit placed, awaiting A's post-edit probe re-serve");
                 }
                 case 1 -> {
+                    // A's ts<=0 re-ask re-resolves the flushed position via the loaded-chunk
+                    // probe. That probe needs the chunk resident at snapshot-build time and the
+                    // send pipeline clear; on slow (2-core) CI either can miss, and the design
+                    // expects the client to RETRY (the one-shot re-ask was a documented flake).
+                    // Keep the chunk resident and re-issue until the re-serve lands — but only
+                    // when no re-ask is in flight, so A re-serves EXACTLY once (step 2 asserts A==3).
+                    level.getChunk(chunkPos.x(), chunkPos.z());
+                    if (stateA.getTotalSectionsSent() < 2 && stateA.getIncomingRequestCount() == 0
+                            && !stateA.hasEnqueuedColumn(packed)
+                            && !stateA.hasPendingRequest(chunkPos.x(), chunkPos.z())) {
+                        stateA.addRequest(packed, -1L);
+                    }
                     service.tick();
                     helper.assertTrue(stateA.getTotalSectionsSent() == 2,
                             "waiting for A's post-edit re-serve (a ts<=0 re-ask of a flushed "


### PR DESCRIPTION
Fixes the high-rate 2-core-CI flake in `editedColumnPropagatesToBothHoldersThroughBroadcastFanout` **step 1** (it failed 2 of 4 CI runs during the v0.5.1 release, on identical code — see the v0.5.1 PR #18 history).

**Root cause:** A's `ts<=0` re-ask re-resolves the flushed position via the loaded-chunk probe (`resolvedFromLoadedProbe`), which needs the chunk resident at snapshot-build time (`probeLoadedChunks` → `getChunkNow`) and the send pipeline clear. On slow CI either can miss, and the router's own comment (`IncomingRequestRouter.resolvedAsDuplicate`) documents that the client is expected to **retry**. The test issued the re-ask once, so a single miss left A stuck at `sectionsSent==1` until maxTicks.

**Fix:** step 1 keeps the probe target chunk resident and re-issues the `ts<=0` re-ask each tick until the re-serve lands — but only when no re-ask is in flight (new `getIncomingRequestCount()` + enqueued/pending guards), so A re-serves **exactly once** (step 2 asserts A==3). Mirrors a real client retrying.

Verified: `TwoPlayerGameTests` passes 3/3 under a 2-core `taskset` limit; Tier 1 + Paper green. Test-only + a one-line accessor; no runtime behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)