### PR TITLE
Add Minecraft 26.2 support (v0.6.0)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,14 +98,12 @@ jobs:
           modrinth-id: lKiXKLvv
           modrinth-token: ${{ secrets.MODRINTH_TOKEN }}
           files: fabric/build/libs/lod-server-support-fabric-*.jar
-          name: ${{ github.ref_name }} - Fabric (MC 26.1)
-          version: ${{ github.ref_name }}+fabric+mc26.1
+          name: ${{ github.ref_name }} - Fabric (MC 26.2)
+          version: ${{ github.ref_name }}+fabric+mc26.2
           version-type: release
           loaders: fabric
           game-versions: |
-            26.1
-            26.1.1
-            26.1.2
+            26.2
           changelog: ${{ steps.release_notes.outputs.notes }}
 
       - name: Upload Paper to Modrinth
@@ -114,8 +112,8 @@ jobs:
           modrinth-id: lKiXKLvv
           modrinth-token: ${{ secrets.MODRINTH_TOKEN }}
           files: paper/build/libs/lod-server-support-paper-*.jar
-          name: ${{ github.ref_name }} - Paper/Folia (MC 26.1.2)
-          version: ${{ github.ref_name }}+paper+mc26.1.2
+          name: ${{ github.ref_name }} - Paper/Folia (MC 26.2)
+          version: ${{ github.ref_name }}+paper+mc26.2
           version-type: release
           # One artifact serves all three Bukkit-family loaders (plugin.yml declares
           # folia-supported: true; release_check.py gates it). Folia support is experimental —
@@ -125,5 +123,5 @@ jobs:
             purpur
             folia
           game-versions: |
-            26.1.2
+            26.2
           changelog: ${{ steps.release_notes.outputs.notes }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,16 +112,16 @@ jobs:
           modrinth-id: lKiXKLvv
           modrinth-token: ${{ secrets.MODRINTH_TOKEN }}
           files: paper/build/libs/lod-server-support-paper-*.jar
-          name: ${{ github.ref_name }} - Paper/Folia (MC 26.2)
+          name: ${{ github.ref_name }} - Paper/Purpur (MC 26.2)
           version: ${{ github.ref_name }}+paper+mc26.2
           version-type: release
-          # One artifact serves all three Bukkit-family loaders (plugin.yml declares
-          # folia-supported: true; release_check.py gates it). Folia support is experimental —
-          # release notes must say so (CLAUDE.md, Release Notes Format rules).
+          # The jar still declares folia-supported: true, but Folia has not published a 26.2
+          # build yet, so v0.6.0 advertises only paper + purpur on Modrinth. Re-add `folia` here
+          # once Folia ships 26.2 and the soak passes (Folia support is experimental —
+          # CLAUDE.md, Release Notes Format rules).
           loaders: |
             paper
             purpur
-            folia
           game-versions: |
             26.2
           changelog: ${{ steps.release_notes.outputs.notes }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,7 +29,7 @@ Output JARs:
 - `fabric/build/libs/lod-server-support-fabric.jar` — Fabric mod (client + server)
 - `paper/build/libs/lod-server-support-paper.jar` — Paper/Folia plugin (server only, shadow JAR; one artifact serves Paper, Purpur, and Folia via `folia-supported: true`)
 
-CI builds (env `CI=true`) name the jars `lod-server-support-<platform>-<mod_version>+<minecraft_version>.jar` (e.g. `lod-server-support-fabric-0.5.1+26.2.jar`); the release workflow feeds `mod_version` from the tag. Local dev builds keep the stable unversioned names.
+CI builds (env `CI=true`) name the jars `lod-server-support-<platform>-<mod_version>+<minecraft_version>.jar` (e.g. `lod-server-support-fabric-0.6.0+26.2.jar`); the release workflow feeds `mod_version` from the tag. Local dev builds keep the stable unversioned names.
 
 ## Test Commands
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,8 +13,8 @@ Multi-project Gradle build with three subprojects:
 ```
 lod-server-support/
 ├── common/   Pure Java utilities (no MC deps) — shared by fabric/ and paper/
-├── fabric/   Fabric mod (client + server), Minecraft 26.1.2
-└── paper/    Paper/Folia plugin (server only), Minecraft 26.1.2
+├── fabric/   Fabric mod (client + server), Minecraft 26.2
+└── paper/    Paper/Folia plugin (server only), Minecraft 26.2
 ```
 
 ## Build Commands
@@ -29,7 +29,7 @@ Output JARs:
 - `fabric/build/libs/lod-server-support-fabric.jar` — Fabric mod (client + server)
 - `paper/build/libs/lod-server-support-paper.jar` — Paper/Folia plugin (server only, shadow JAR; one artifact serves Paper, Purpur, and Folia via `folia-supported: true`)
 
-CI builds (env `CI=true`) name the jars `lod-server-support-<platform>-<mod_version>+<minecraft_version>.jar` (e.g. `lod-server-support-fabric-0.4.0+26.1.2.jar`); the release workflow feeds `mod_version` from the tag. Local dev builds keep the stable unversioned names.
+CI builds (env `CI=true`) name the jars `lod-server-support-<platform>-<mod_version>+<minecraft_version>.jar` (e.g. `lod-server-support-fabric-0.5.1+26.2.jar`); the release workflow feeds `mod_version` from the tag. Local dev builds keep the stable unversioned names.
 
 ## Test Commands
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ https://github.com/user-attachments/assets/721fb344-890e-4e03-ab36-539444427f7b
 
 | LSS Version | Minecraft | Fabric | Paper | Voxy | Java |
 |---|---|---|---|---|---|
+| **v0.6.x** | **26.2** | Server + Client | Server + Folia (experimental) | 0.2.16-beta+ | 25+ |
 | **v0.5.x** | **26.1.x** | Server + Client | Server + Folia (experimental) | 0.2.16-beta+ | 25+ |
 | **v0.5.x+mc1.21.11** | **1.21.11** | Server + Client | Server + Folia (experimental) | 0.2.15-beta+ | 21+ |
 | **v0.5.x+mc1.20.1** | **1.20.1** | Server + Client | Server (no Folia) | — (no public Voxy build) | 17+ |
@@ -17,10 +18,14 @@ https://github.com/user-attachments/assets/721fb344-890e-4e03-ab36-539444427f7b
 | v0.3.x | 26.1.x | Server + Client | — | 0.2.14-alpha+ | 25+ |
 | v0.2.x | 1.21.11 | Server + Client | Server | 0.2.13-alpha | 21+ |
 
+v0.6.0 moves the primary Fabric and Paper/Folia builds to **Minecraft 26.2**, carrying the
+full v0.5.x feature set with no gameplay changes. The 26.1.x line stays available at v0.5.1.
+Some 26.2 upstreams (Sodium, C2ME) are currently in alpha/beta.
+
 v0.5.0 adds **Folia** support (experimental — see the Paper Server section) and a set of
 client-sync correctness fixes; after upgrading, clients rebuild their local LOD cache once
 (the cache format changed), so the first rejoin re-syncs from the server. Paper server
-support is built against Paper 26.1.2 and also runs on Purpur.
+support is built against Paper 26.2 and also runs on Purpur.
 
 The full v0.5.0 feature set is also published for two older Minecraft versions from
 long-lived support branches:
@@ -51,6 +56,7 @@ The result: players see fully rendered terrain out to hundreds of chunks on mult
 
 Download from [Modrinth](https://modrinth.com/plugin/lod-server-support):
 
+- **v0.6.x (MC 26.2):** `lod-server-support-fabric` — Fabric mod JAR (client + server) — and `lod-server-support-paper` — Paper/Purpur/Folia server plugin
 - **v0.5.x (MC 26.1.x):** `lod-server-support-fabric` — Fabric mod JAR (client + server) — and `lod-server-support-paper` — Paper/Purpur/Folia server plugin
 - **v0.5.x+mc1.21.11 (MC 1.21.11):** the same Fabric + Paper artifacts built for 1.21.11 — the full v0.5.0 feature set (incl. Folia) for the older line
 - **v0.5.x+mc1.20.1 (MC 1.20.1):** the same artifacts built for 1.20.1 (Paper/Purpur only; requires an `LSSApi` consumer — no public Voxy build exists for 1.20.1)
@@ -71,7 +77,7 @@ Download from [Modrinth](https://modrinth.com/plugin/lod-server-support):
 
 ### Paper Server
 
-Requires Paper, Purpur, or Folia for Minecraft 26.1.2.
+Requires Paper, Purpur, or Folia for Minecraft 26.2.
 
 1. Place `lod-server-support-paper.jar` in the server's `plugins/` directory
 2. Install the Fabric mod **and** [Voxy](https://modrinth.com/mod/voxy) on all clients
@@ -84,20 +90,20 @@ are less tested, so treat it as experimental and report issues. `/reload` is not
 Folia (restart the server instead), and runtime plugin managers (enable/disable without a
 restart) are best-effort.
 
-## Requirements (v0.5.x — MC 26.1.x)
+## Requirements (v0.6.x — MC 26.2)
 
 ### Fabric Server
-- Minecraft 26.1.x
+- Minecraft 26.2
 - Fabric Loader 0.18.4+
 - Fabric API
 - Java 25+
 
 ### Paper Server
-- Paper, Purpur, or Folia (experimental) for Minecraft 26.1.2
+- Paper, Purpur, or Folia (experimental) for Minecraft 26.2
 - Java 25+
 
 ### Client
-- Minecraft 26.1.x
+- Minecraft 26.2
 - Fabric Loader 0.18.4+
 - Fabric API
 - [Voxy](https://modrinth.com/mod/voxy) 0.2.16-beta+

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ https://github.com/user-attachments/assets/721fb344-890e-4e03-ab36-539444427f7b
 
 | LSS Version | Minecraft | Fabric | Paper | Voxy | Java |
 |---|---|---|---|---|---|
-| **v0.6.x** | **26.2** | Server + Client | Server + Folia (experimental) | 0.2.16-beta+ | 25+ |
+| **v0.6.x** | **26.2** | Server + Client | Server (Folia pending 26.2) | 0.2.16-beta+ | 25+ |
 | **v0.5.x** | **26.1.x** | Server + Client | Server + Folia (experimental) | 0.2.16-beta+ | 25+ |
 | **v0.5.x+mc1.21.11** | **1.21.11** | Server + Client | Server + Folia (experimental) | 0.2.15-beta+ | 21+ |
 | **v0.5.x+mc1.20.1** | **1.20.1** | Server + Client | Server (no Folia) | — (no public Voxy build) | 17+ |
@@ -18,14 +18,15 @@ https://github.com/user-attachments/assets/721fb344-890e-4e03-ab36-539444427f7b
 | v0.3.x | 26.1.x | Server + Client | — | 0.2.14-alpha+ | 25+ |
 | v0.2.x | 1.21.11 | Server + Client | Server | 0.2.13-alpha | 21+ |
 
-v0.6.0 moves the primary Fabric and Paper/Folia builds to **Minecraft 26.2**, carrying the
-full v0.5.x feature set with no gameplay changes. The 26.1.x line stays available at v0.5.1.
-Some 26.2 upstreams (Sodium, C2ME) are currently in alpha/beta.
+v0.6.0 moves the primary Fabric and Paper builds to **Minecraft 26.2**, carrying the
+full v0.5.x feature set with no gameplay changes. Paper server support is built against
+Paper 26.2 and also runs on Purpur. The 26.1.x line stays available at v0.5.1. Several 26.2
+upstreams are still pre-release at the time of writing — Paper and C2ME are in alpha, Sodium
+in beta, and Folia has not yet published a 26.2 build — so treat the 26.2 line as a preview.
 
 v0.5.0 adds **Folia** support (experimental — see the Paper Server section) and a set of
 client-sync correctness fixes; after upgrading, clients rebuild their local LOD cache once
-(the cache format changed), so the first rejoin re-syncs from the server. Paper server
-support is built against Paper 26.2 and also runs on Purpur.
+(the cache format changed), so the first rejoin re-syncs from the server.
 
 The full v0.5.0 feature set is also published for two older Minecraft versions from
 long-lived support branches:
@@ -56,7 +57,7 @@ The result: players see fully rendered terrain out to hundreds of chunks on mult
 
 Download from [Modrinth](https://modrinth.com/plugin/lod-server-support):
 
-- **v0.6.x (MC 26.2):** `lod-server-support-fabric` — Fabric mod JAR (client + server) — and `lod-server-support-paper` — Paper/Purpur/Folia server plugin
+- **v0.6.x (MC 26.2):** `lod-server-support-fabric` — Fabric mod JAR (client + server) — and `lod-server-support-paper` — Paper/Purpur server plugin (Folia returns once Folia ships 26.2)
 - **v0.5.x (MC 26.1.x):** `lod-server-support-fabric` — Fabric mod JAR (client + server) — and `lod-server-support-paper` — Paper/Purpur/Folia server plugin
 - **v0.5.x+mc1.21.11 (MC 1.21.11):** the same Fabric + Paper artifacts built for 1.21.11 — the full v0.5.0 feature set (incl. Folia) for the older line
 - **v0.5.x+mc1.20.1 (MC 1.20.1):** the same artifacts built for 1.20.1 (Paper/Purpur only; requires an `LSSApi` consumer — no public Voxy build exists for 1.20.1)
@@ -77,14 +78,16 @@ Download from [Modrinth](https://modrinth.com/plugin/lod-server-support):
 
 ### Paper Server
 
-Requires Paper, Purpur, or Folia for Minecraft 26.2.
+Requires Paper or Purpur for Minecraft 26.2. Folia support returns once Folia publishes a 26.2 build.
 
 1. Place `lod-server-support-paper.jar` in the server's `plugins/` directory
 2. Install the Fabric mod **and** [Voxy](https://modrinth.com/mod/voxy) on all clients
 3. Restart the server — config is generated at `plugins/LodServerSupport/lss-server-config.json`
 
-**Folia notes (experimental, since v0.5.0):** the same plugin JAR runs on Folia's regionized
-threading — the request pipeline runs on Folia's global region tick. Support is validated by
+**Folia notes (experimental, since v0.5.0):** Folia has not yet published a Minecraft 26.2
+build, so Folia support on 26.2 is pending its release; the notes here apply once it ships. The
+same plugin JAR runs on Folia's regionized threading — the request pipeline runs on Folia's
+global region tick. Support is validated by
 an automated single-player soak suite against a real Folia server; busy multi-region servers
 are less tested, so treat it as experimental and report issues. `/reload` is not supported on
 Folia (restart the server instead), and runtime plugin managers (enable/disable without a
@@ -99,7 +102,7 @@ restart) are best-effort.
 - Java 25+
 
 ### Paper Server
-- Paper, Purpur, or Folia (experimental) for Minecraft 26.2
+- Paper or Purpur for Minecraft 26.2 (Folia, experimental, once Folia publishes 26.2)
 - Java 25+
 
 ### Client

--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -40,8 +40,8 @@ dependencies {
     testImplementation "net.fabricmc:fabric-loader-junit:${project.loader_version}"
     implementation project(':common')
     include project(':common')
-    compileOnly "maven.modrinth:sodium:mc26.1.2-0.8.12-fabric"
-    compileOnly "maven.modrinth:modmenu:18.0.0-beta.1"
+    compileOnly "maven.modrinth:sodium:mc26.2-0.9.1-beta.3-fabric"
+    compileOnly "maven.modrinth:modmenu:20.0.0-beta.4"
 }
 
 test {

--- a/fabric/src/gametest/java/dev/vox/lss/test/LSSClientGameTests.java
+++ b/fabric/src/gametest/java/dev/vox/lss/test/LSSClientGameTests.java
@@ -11,6 +11,7 @@ import net.fabricmc.fabric.api.client.gametest.v1.context.ClientGameTestContext;
 import net.fabricmc.fabric.api.client.gametest.v1.context.TestSingleplayerContext;
 import net.minecraft.client.multiplayer.ClientLevel;
 import net.minecraft.resources.ResourceKey;
+import net.minecraft.server.MinecraftServer;
 import net.minecraft.util.HttpUtil;
 import net.minecraft.world.level.GameType;
 import net.minecraft.world.level.Level;
@@ -297,10 +298,12 @@ public class LSSClientGameTests implements FabricClientGameTest {
                 throw new AssertionError("No LodRequestManager may exist before LAN publish");
             }
 
-            // Publish from the client thread, exactly like ShareToLanScreen does.
+            // Publish from the client thread, exactly like ShareToLanScreen does. MC 26.2 added a
+            // leading MultiplayerScope argument (LAN = share to LAN).
             boolean published = context.computeOnClient(client ->
                     client.getSingleplayerServer().publishServer(
-                            GameType.SURVIVAL, false, HttpUtil.getAvailablePort()));
+                            MinecraftServer.MultiplayerScope.LAN, GameType.SURVIVAL, false,
+                            HttpUtil.getAvailablePort()));
             if (!published) {
                 throw new AssertionError("publishServer must succeed (LAN port bind failed?)");
             }

--- a/fabric/src/main/java/dev/vox/lss/mixin/IntegratedServerLanHook.java
+++ b/fabric/src/main/java/dev/vox/lss/mixin/IntegratedServerLanHook.java
@@ -11,9 +11,12 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 @Mixin(IntegratedServer.class)
 public class IntegratedServerLanHook {
-    // MC 26.2 added a leading MultiplayerScope parameter to IntegratedServer#publishServer; the
-    // injected handler's descriptor must match the target or the mixin fails to apply.
-    @Inject(method = "publishServer", at = @At("RETURN"))
+    // MC 26.2 added a leading MultiplayerScope parameter to IntegratedServer#publishServer AND a
+    // second publishServer(MultiplayerScope, int) overload. Pin the full descriptor so the inject
+    // targets exactly the (scope, gameType, allowCheats, port) overload — the bare "publishServer"
+    // selector now matches both, and the injected handler's descriptor must match the target.
+    @Inject(method = "publishServer(Lnet/minecraft/server/MinecraftServer$MultiplayerScope;Lnet/minecraft/world/level/GameType;ZI)Z",
+            at = @At("RETURN"))
     private void lss$onLanPublished(MinecraftServer.MultiplayerScope scope, GameType gameType,
                                      boolean allowCheats, int port,
                                      CallbackInfoReturnable<Boolean> cir) {

--- a/fabric/src/main/java/dev/vox/lss/mixin/IntegratedServerLanHook.java
+++ b/fabric/src/main/java/dev/vox/lss/mixin/IntegratedServerLanHook.java
@@ -2,6 +2,7 @@ package dev.vox.lss.mixin;
 
 import dev.vox.lss.networking.server.LSSServerNetworking;
 import net.minecraft.client.server.IntegratedServer;
+import net.minecraft.server.MinecraftServer;
 import net.minecraft.world.level.GameType;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
@@ -10,8 +11,11 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 @Mixin(IntegratedServer.class)
 public class IntegratedServerLanHook {
+    // MC 26.2 added a leading MultiplayerScope parameter to IntegratedServer#publishServer; the
+    // injected handler's descriptor must match the target or the mixin fails to apply.
     @Inject(method = "publishServer", at = @At("RETURN"))
-    private void lss$onLanPublished(GameType gameType, boolean allowCheats, int port,
+    private void lss$onLanPublished(MinecraftServer.MultiplayerScope scope, GameType gameType,
+                                     boolean allowCheats, int port,
                                      CallbackInfoReturnable<Boolean> cir) {
         if (cir.getReturnValue()) {
             LSSServerNetworking.startServiceForLan((IntegratedServer) (Object) this);

--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -31,7 +31,7 @@
     "lss.mixins.json"
   ],
   "depends": {
-    "minecraft": ">=26.1",
+    "minecraft": ">=26.2",
     "fabricloader": ">=0.18.4",
     "fabric-api": ">=0.146.0"
   },

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,9 +3,9 @@ org.gradle.parallel=true
 
 # Fabric Properties
 # check these on https://fabricmc.net/develop
-minecraft_version=26.1.2
+minecraft_version=26.2
 loader_version=0.19.3
-loom_version=1.17.3
+loom_version=1.17.13
 
 # Mod Properties
 mod_version=0.5.0
@@ -13,4 +13,4 @@ maven_group=dev.vox
 archives_base_name=lod-server-support-fabric
 
 # Dependencies
-fabric_version=0.151.0+26.1.2
+fabric_version=0.154.0+26.2

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ loader_version=0.19.3
 loom_version=1.17.13
 
 # Mod Properties
-mod_version=0.5.0
+mod_version=0.6.0
 maven_group=dev.vox
 archives_base_name=lod-server-support-fabric
 

--- a/paper/build.gradle
+++ b/paper/build.gradle
@@ -17,7 +17,7 @@ repositories {
 
 dependencies {
     implementation project(':common')
-    paperweight.paperDevBundle('26.1.2.build.69-stable')
+    paperweight.paperDevBundle('26.2.build.48-alpha')
     testImplementation 'org.junit.jupiter:junit-jupiter:5.11.4'
     testImplementation 'org.mockito:mockito-core:5.20.0'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/paper/src/main/resources/plugin.yml
+++ b/paper/src/main/resources/plugin.yml
@@ -1,7 +1,7 @@
 name: LodServerSupport
 version: '${version}'
 main: dev.vox.lss.paper.LSSPaperPlugin
-api-version: '26.1.2'
+api-version: '26.2'
 folia-supported: true
 description: Paper Plugin that provides unofficial multiplayer support for Voxy.
 author: VoX

--- a/test-server.sh
+++ b/test-server.sh
@@ -239,6 +239,16 @@ setup_folia() {
     local plugins_dir="$FOLIA_DIR/plugins"
     mkdir -p "$FOLIA_DIR" "$plugins_dir"
 
+    # Folia lags Paper when a new Minecraft version lands — it may not have a build for
+    # FOLIA_MC_VERSION yet. Skip the local Folia server gracefully (the Paper plugin jar already
+    # carries Folia support) instead of aborting the whole script under `set -e`.
+    if ! curl -fsSL -A "lod-server-support/test-server" -o /dev/null \
+            "https://fill.papermc.io/v3/projects/folia/versions/${FOLIA_MC_VERSION}/builds" 2>/dev/null; then
+        echo "  NOTE: Folia has no MC ${FOLIA_MC_VERSION} build published upstream yet — skipping the local Folia server."
+        echo "  (Folia support ships inside the Paper plugin jar; only the standalone Folia test server is skipped.)"
+        return 0
+    fi
+
     download_papermc_jar folia "$FOLIA_MC_VERSION" "$FOLIA_DIR/folia.jar"
 
     if [ ! -f "$FOLIA_DIR/eula.txt" ]; then
@@ -259,6 +269,10 @@ setup_folia() {
 }
 
 run_folia() {
+    if [ ! -f "$FOLIA_DIR/folia.jar" ]; then
+        echo "Folia server not set up (no MC ${FOLIA_MC_VERSION} build upstream yet) — nothing to run."
+        return 0
+    fi
     cd "$FOLIA_DIR"
     java -Xmx${SERVER_RAM} -Xms${SERVER_RAM} -jar folia.jar nogui
 }
@@ -293,9 +307,11 @@ run_all() {
 
     sleep 2
 
-    cd "$FOLIA_DIR"
-    java -Xmx${SERVER_RAM} -Xms${SERVER_RAM} -jar folia.jar nogui &
-    SERVER_PIDS+=($!)
+    if [ -f "$FOLIA_DIR/folia.jar" ]; then
+        cd "$FOLIA_DIR"
+        java -Xmx${SERVER_RAM} -Xms${SERVER_RAM} -jar folia.jar nogui &
+        SERVER_PIDS+=($!)
+    fi
 
     wait "${SERVER_PIDS[@]}" 2>/dev/null
 }

--- a/test-server.sh
+++ b/test-server.sh
@@ -11,23 +11,23 @@ PAPER_DIR="$SCRIPT_DIR/test-server/paper"
 FOLIA_DIR="$SCRIPT_DIR/test-server/folia"
 
 # --- Fabric versions ---
-FABRIC_MC_VERSION="26.1.2"
+FABRIC_MC_VERSION="26.2"
 FABRIC_LOADER_VERSION="0.19.3"
 FABRIC_INSTALLER_VERSION="1.1.1"
 
 # --- Paper/Folia versions ---
-PAPER_MC_VERSION="26.1.2"
-FOLIA_MC_VERSION="26.1.2"
+PAPER_MC_VERSION="26.2"
+FOLIA_MC_VERSION="26.2"
 
 # --- Download URLs ---
 FABRIC_SERVER_URL="https://meta.fabricmc.net/v2/versions/loader/${FABRIC_MC_VERSION}/${FABRIC_LOADER_VERSION}/${FABRIC_INSTALLER_VERSION}/server/jar"
-FABRIC_API_URL="https://cdn.modrinth.com/data/P7dR8mSH/versions/yALY9gHM/fabric-api-0.151.0%2B26.1.2.jar"
-C2ME_URL="https://cdn.modrinth.com/data/VSNURh3q/versions/MmyZoUyp/c2me-fabric-mc26.1.2-0.4.0-alpha.0.4.jar"
+FABRIC_API_URL="https://cdn.modrinth.com/data/P7dR8mSH/versions/Cpy2Px2f/fabric-api-0.154.0%2B26.2.jar"
+C2ME_URL="https://cdn.modrinth.com/data/VSNURh3q/versions/nvOkOiyi/c2me-fabric-mc26.2-0.4.2-alpha.0.9.jar"
 
 # --- Java version check ---
 JAVA_MAJOR=$(java -version 2>&1 | head -1 | sed 's/.*"\([0-9]\+\).*/\1/')
 if [ "$JAVA_MAJOR" -lt 25 ] 2>/dev/null; then
-    echo "ERROR: Java 25+ required for MC 26.1. Found: Java $JAVA_MAJOR" >&2
+    echo "ERROR: Java 25+ required for MC 26.2. Found: Java $JAVA_MAJOR" >&2
     echo "  Set JAVA_HOME to a JDK 25+ installation." >&2
     exit 1
 fi


### PR DESCRIPTION
## Minecraft 26.2 support — v0.6.0

Retargets LSS from Minecraft 26.1.2 to **26.2**, making 26.2 the new primary line as **v0.6.0**. Redone cleanly (not cherry-picked) after multi-round multi-agent review.

### Changes
- **Build/deps → 26.2**: `minecraft_version` 26.2, loom 1.17.13, fabric-api 0.154.0+26.2, sodium/modmenu betas, paperweight `26.2.build.48-alpha`; `mod_version` → 0.6.0.
- **Code adaptations** for 26.2's changed `IntegratedServer#publishServer` (new leading `MultiplayerScope` param + a second overload): the `IntegratedServerLanHook` mixin pins the full descriptor; `LSSClientGameTests` passes `MultiplayerScope.LAN`. `fabric.mod.json` floor raised to `>=26.2`.
- **Release metadata**: `release.yml`, README (v0.6.x/26.2 primary; 26.1.x stays at v0.5.1), `test-server.sh` (26.2 servers + deps), CLAUDE.md.
- **Folia**: dropped from the v0.6.0 Modrinth listing (paper + purpur only) — Folia has not published a 26.2 build yet, so it can't be run or tested there. The jar keeps `folia-supported: true`; `test-server.sh` + soak skip Folia gracefully. Re-add once Folia ships 26.2.

### Validation
- Tier 1 (Fabric) + Paper (243) + Tier 3 (client/LAN-hook) green on 26.2; both `0.6.0+26.2` artifacts build; `release_check.py --version 0.6.0` OK.
- Tier 2: only `RegionFaultGameTests` fails, and only on the WSL2 dev box (established environmental, version-robust) — clean CI is the gate.
- Six review agents across three rounds (completeness, runtime-API-breakage via `javap`, release/CI, docs, shell, adversarial) — all findings addressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)