### PR TITLE
Fix console spam: throttle saturation warnings, demote cache-save log

### DIFF
--- a/common/src/main/java/dev/vox/lss/common/LogThrottle.java
+++ b/common/src/main/java/dev/vox/lss/common/LogThrottle.java
@@ -1,0 +1,35 @@
+package dev.vox.lss.common;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Rate limiter for a recurring log line: counts every event, but releases the accumulated
+ * count for logging at most once per interval. The first event is released immediately so
+ * the condition surfaces as soon as it starts; later events stay silent until the interval
+ * elapses, then the next event carries the total suppressed since the last release.
+ *
+ * <p>Thread-safe. Callers supply the clock ({@code nowMs}) so the windowing is testable.
+ */
+public final class LogThrottle {
+
+    private final long intervalMs;
+    private final AtomicLong count = new AtomicLong();
+    private final AtomicLong nextReleaseMs = new AtomicLong(Long.MIN_VALUE);
+
+    public LogThrottle(long intervalMs) {
+        this.intervalMs = intervalMs;
+    }
+
+    /**
+     * Records one event. Returns the number of events (this one included) since the last
+     * release if the caller should log now, or 0 to stay silent.
+     */
+    public long recordAndTryAcquire(long nowMs) {
+        this.count.incrementAndGet();
+        long due = this.nextReleaseMs.get();
+        if (nowMs >= due && this.nextReleaseMs.compareAndSet(due, nowMs + this.intervalMs)) {
+            return this.count.getAndSet(0);
+        }
+        return 0;
+    }
+}

--- a/common/src/main/java/dev/vox/lss/common/LogThrottle.java
+++ b/common/src/main/java/dev/vox/lss/common/LogThrottle.java
@@ -8,7 +8,9 @@ import java.util.concurrent.atomic.AtomicLong;
  * the condition surfaces as soon as it starts; later events stay silent until the interval
  * elapses, then the next event carries the total suppressed since the last release.
  *
- * <p>Thread-safe. Callers supply the clock ({@code nowMs}) so the windowing is testable.
+ * <p>Thread-safe. Callers supply the clock ({@code nowMs}) so the windowing is testable —
+ * use a monotonic source (e.g. {@code System.nanoTime() / 1_000_000}), not the wall clock:
+ * a backwards wall-clock step would silence releases until real time catches back up.
  */
 public final class LogThrottle {
 

--- a/common/src/main/java/dev/vox/lss/common/processing/AbstractChunkDiskReader.java
+++ b/common/src/main/java/dev/vox/lss/common/processing/AbstractChunkDiskReader.java
@@ -38,7 +38,8 @@ public abstract class AbstractChunkDiskReader {
     // demand it can reject many reads per second — one WARN per position floods the console
     // (#32). Aggregate to at most one warning per minute carrying the rejected count;
     // per-delivery detail stays on the debug path in OffThreadProcessor.
-    private final LogThrottle saturationWarn = new LogThrottle(60_000);
+    private static final long SATURATION_WARN_INTERVAL_MS = 60_000;
+    private final LogThrottle saturationWarn = new LogThrottle(SATURATION_WARN_INTERVAL_MS);
 
     private final ExecutorService executor;
     private final ConcurrentHashMap<UUID, ConcurrentLinkedQueue<ChunkReadResult>> playerResults = new ConcurrentHashMap<>();
@@ -86,7 +87,9 @@ public abstract class AbstractChunkDiskReader {
                 }
             });
         } catch (RejectedExecutionException e) {
-            long rejected = this.saturationWarn.recordAndTryAcquire(System.currentTimeMillis());
+            // nanoTime, not currentTimeMillis: the wall clock can step backwards (NTP), which
+            // would silence the aggregate warning exactly while the pool is behind demand.
+            long rejected = this.saturationWarn.recordAndTryAcquire(System.nanoTime() / 1_000_000);
             if (rejected > 0) {
                 LSSLogger.warn("Disk reader saturated: " + rejected + " chunk read(s) bounced as rate-limited"
                         + " since the last warning — clients retry automatically; raise diskReaderThreads"

--- a/common/src/main/java/dev/vox/lss/common/processing/AbstractChunkDiskReader.java
+++ b/common/src/main/java/dev/vox/lss/common/processing/AbstractChunkDiskReader.java
@@ -2,6 +2,7 @@ package dev.vox.lss.common.processing;
 
 import dev.vox.lss.common.LSSConstants;
 import dev.vox.lss.common.LSSLogger;
+import dev.vox.lss.common.LogThrottle;
 
 import java.util.UUID;
 import java.util.concurrent.ArrayBlockingQueue;
@@ -31,6 +32,13 @@ public abstract class AbstractChunkDiskReader {
 
     private static final AtomicInteger THREAD_COUNTER = new AtomicInteger();
     private static final int QUEUE_CAPACITY_PER_THREAD = 32;
+
+    // Saturation is a normal, self-healing protocol path (the bounced request comes back as
+    // rate-limited and the client retries on a later scan), but while the pool is behind
+    // demand it can reject many reads per second — one WARN per position floods the console
+    // (#32). Aggregate to at most one warning per minute carrying the rejected count;
+    // per-delivery detail stays on the debug path in OffThreadProcessor.
+    private final LogThrottle saturationWarn = new LogThrottle(60_000);
 
     private final ExecutorService executor;
     private final ConcurrentHashMap<UUID, ConcurrentLinkedQueue<ChunkReadResult>> playerResults = new ConcurrentHashMap<>();
@@ -78,7 +86,12 @@ public abstract class AbstractChunkDiskReader {
                 }
             });
         } catch (RejectedExecutionException e) {
-            LSSLogger.warn("Disk reader executor saturated, returning rate-limited for " + chunkX + "," + chunkZ);
+            long rejected = this.saturationWarn.recordAndTryAcquire(System.currentTimeMillis());
+            if (rejected > 0) {
+                LSSLogger.warn("Disk reader saturated: " + rejected + " chunk read(s) bounced as rate-limited"
+                        + " since the last warning — clients retry automatically; raise diskReaderThreads"
+                        + " in lss-server-config.json if this persists");
+            }
             this.diag.recordSaturation();
             this.diag.recordCompleted(0);
             addResult(playerUuid, ChunkReadResult.saturated(playerUuid, chunkX, chunkZ, dimension, submissionOrder));

--- a/common/src/main/java/dev/vox/lss/common/processing/OffThreadProcessor.java
+++ b/common/src/main/java/dev/vox/lss/common/processing/OffThreadProcessor.java
@@ -126,11 +126,13 @@ public abstract class OffThreadProcessor<PlayerState extends AbstractPlayerReque
         this.players = players;
         this.diskReader = diskReader;
         this.generationAvailable = generationAvailable;
-        this.dataDir = dataDir;
+        // normalize(): both platforms derive this from getWorldPath(LevelResource.ROOT), which
+        // ends in "/." and otherwise prints as "./world/./data/..." in every cache log line (#32)
+        this.dataDir = dataDir == null ? null : dataDir.normalize();
         this.timestampCache = new ColumnTimestampCache(
                 ColumnTimestampCache.mbToEntries(perDimensionTimestampCacheSizeMB));
-        if (dataDir != null) {
-            this.timestampCache.load(dataDir);
+        if (this.dataDir != null) {
+            this.timestampCache.load(this.dataDir);
         }
         this.ctx = new ProcessingContext(this.sendActions, this.generationTicketRequests,
                 new ProcessingDiagnostics(), new SequenceCounter());

--- a/common/src/main/java/dev/vox/lss/common/voxel/ColumnTimestampCache.java
+++ b/common/src/main/java/dev/vox/lss/common/voxel/ColumnTimestampCache.java
@@ -213,7 +213,9 @@ public class ColumnTimestampCache {
             // debug, not info: besides the ~5-min periodic save, the invalidation debounce
             // saves within ~2s of any dirty-broadcast — on a busy server that is a console
             // line every few seconds (#32). Failures below still WARN.
-            LSSLogger.debug("Saved " + size() + " timestamp cache entries to " + file);
+            if (LSSLogger.isDebugEnabled()) {
+                LSSLogger.debug("Saved " + size() + " timestamp cache entries to " + file);
+            }
         } catch (IOException e) {
             LSSLogger.warn("Failed to save timestamp cache to " + file, e);
             try { Files.deleteIfExists(tmpFile); } catch (IOException e2) {

--- a/common/src/main/java/dev/vox/lss/common/voxel/ColumnTimestampCache.java
+++ b/common/src/main/java/dev/vox/lss/common/voxel/ColumnTimestampCache.java
@@ -210,7 +210,10 @@ public class ColumnTimestampCache {
                 // JsonConfig.save): a torn file on crash is tolerable, the loader discards it.
                 Files.move(tmpFile, file, StandardCopyOption.REPLACE_EXISTING);
             }
-            LSSLogger.info("Saved " + size() + " timestamp cache entries to " + file);
+            // debug, not info: besides the ~5-min periodic save, the invalidation debounce
+            // saves within ~2s of any dirty-broadcast — on a busy server that is a console
+            // line every few seconds (#32). Failures below still WARN.
+            LSSLogger.debug("Saved " + size() + " timestamp cache entries to " + file);
         } catch (IOException e) {
             LSSLogger.warn("Failed to save timestamp cache to " + file, e);
             try { Files.deleteIfExists(tmpFile); } catch (IOException e2) {

--- a/fabric/src/test/java/dev/vox/lss/common/LogThrottleTest.java
+++ b/fabric/src/test/java/dev/vox/lss/common/LogThrottleTest.java
@@ -1,0 +1,82 @@
+package dev.vox.lss.common;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Pins the aggregate-warning window behind the disk reader's saturation log (#32): the
+ * first event releases immediately, the interval suppresses the flood, the next release
+ * carries the full suppressed count, and every event is counted exactly once.
+ */
+class LogThrottleTest {
+
+    private static final long INTERVAL = 60_000;
+
+    @Test
+    void firstEventReleasesImmediatelyWithCountOne() {
+        var throttle = new LogThrottle(INTERVAL);
+        assertEquals(1, throttle.recordAndTryAcquire(0),
+                "the condition must surface as soon as it starts, not one interval later");
+    }
+
+    @Test
+    void eventsInsideTheIntervalStaySilent() {
+        var throttle = new LogThrottle(INTERVAL);
+        throttle.recordAndTryAcquire(0);
+        for (long t = 1; t < INTERVAL; t += 10_000) {
+            assertEquals(0, throttle.recordAndTryAcquire(t), "silent at t=" + t);
+        }
+    }
+
+    @Test
+    void nextReleaseCarriesEverySuppressedEvent() {
+        var throttle = new LogThrottle(INTERVAL);
+        throttle.recordAndTryAcquire(0);
+        for (int i = 0; i < 41; i++) {
+            throttle.recordAndTryAcquire(1_000 + i);
+        }
+        assertEquals(42, throttle.recordAndTryAcquire(INTERVAL),
+                "41 suppressed + the releasing event itself — no event may vanish from the count");
+    }
+
+    @Test
+    void countResetsAfterEachRelease() {
+        var throttle = new LogThrottle(INTERVAL);
+        throttle.recordAndTryAcquire(0);
+        throttle.recordAndTryAcquire(5);
+        assertEquals(2, throttle.recordAndTryAcquire(INTERVAL));
+        assertEquals(1, throttle.recordAndTryAcquire(INTERVAL * 2),
+                "a release must not re-report events already reported");
+    }
+
+    @Test
+    void exactlyOneReleasePerWindowAcrossManyWindows() {
+        var throttle = new LogThrottle(INTERVAL);
+        long released = 0;
+        long releases = 0;
+        long events = 0;
+        for (long t = 0; t < INTERVAL * 5; t += 7_000) {
+            events++;
+            long got = throttle.recordAndTryAcquire(t);
+            if (got > 0) {
+                releases++;
+                released += got;
+            }
+        }
+        assertEquals(5, releases, "one release per elapsed interval");
+        long tail = throttle.recordAndTryAcquire(INTERVAL * 10);
+        assertEquals(events + 1, released + tail, "conservation: every event reported exactly once");
+    }
+
+    @Test
+    void aQuietStretchDoesNotBankExtraReleases() {
+        var throttle = new LogThrottle(INTERVAL);
+        throttle.recordAndTryAcquire(0);
+        // Ten intervals of silence, then a burst: only ONE release is due, not ten.
+        long t = INTERVAL * 10;
+        assertEquals(1, throttle.recordAndTryAcquire(t));
+        assertEquals(0, throttle.recordAndTryAcquire(t + 1), "the burst is inside the new window");
+        assertEquals(0, throttle.recordAndTryAcquire(t + 2));
+    }
+}


### PR DESCRIPTION
Fixes #32.

Two per-event log lines flooded busy server consoles, both reporting normal self-healing mechanisms:

### Disk-reader saturation WARN (one line per rejected chunk)
When the reader pool's queue is full, each rejected request is bounced to the client as rate-limited and the client retries on a later scan — the designed protocol path. But the WARN fired per position, so one player scanning a large LOD radius on a slow disk produced dozens of lines per second.

Now aggregated through a new `LogThrottle` (`common/`): the **first** saturation still warns immediately, then at most **one WARN per minute** carrying the count of reads rejected since the last warning, plus an actionable hint (`raise diskReaderThreads in lss-server-config.json if this persists`). `/lsslod diag` saturation counters are unchanged — every event is still counted — and per-delivery detail remains on the existing debug path in `OffThreadProcessor`.

### Timestamp-cache "Saved N entries" INFO (every few seconds)
Periodic saves run ~5 min apart, but the durable-invalidation debounce saves ~2 s after any dirty-broadcast invalidation — on a busy server that's an INFO line every few seconds. Demoted to debug. `Loaded N entries` stays INFO (once per startup) and save failures still WARN.

### Cosmetic: `./world/./data/` path
Both platforms derive the cache dir from `getWorldPath(LevelResource.ROOT)`, which ends in `/.`. Normalized once in the shared `OffThreadProcessor` constructor, so remaining log lines print `world/data/...`.

All changes are in `common/`, so Fabric and Paper are fixed together.

### Tests
- New Tier 1 `LogThrottleTest` pins the window semantics: immediate first release, in-window suppression, suppressed-count conservation (every event reported exactly once), no banked releases after quiet stretches.
- Existing saturation-envelope tests (`AbstractChunkDiskReaderTest`, `PaperDiskReaderEnvelopeTest`) pass unchanged — behavior and diagnostics are untouched, only logging.
- Verified locally: Fabric Tier 1 + Tier 2, Paper Tier 1 — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)