### PR TITLE
Coordinate disk admission with pool capacity (issue #32 root cause)

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Server config is generated on first run:
 | `bytesPerSecondLimitGlobal` | `104857600` | Total pre-compression bandwidth cap (100 MB/s) |
 | `diskReaderThreads` | `5` | Thread pool size for async disk reads |
 | `sendQueueLimitPerPlayer` | `4000` | Max queued column payloads per player (each carries a full chunk column of sections) |
-| `syncOnLoadConcurrencyLimitPerPlayer` | `200` | Max in-flight sync requests per player |
+| `syncOnLoadConcurrencyLimitPerPlayer` | `128` | Max in-flight sync requests per player (kept at/below the disk-reader pool capacity — `diskReaderThreads` × 32 — so requests aren't routinely rate-limited) |
 | `generationConcurrencyLimitPerPlayer` | `16` | Max in-flight generation requests per player |
 | `enableChunkGeneration` | `true` | Generate missing chunks on demand for LOD data |
 | `generationConcurrencyLimitGlobal` | `32` | Max chunks generating server-wide at once |

--- a/common/src/main/java/dev/vox/lss/common/config/ServerConfigBase.java
+++ b/common/src/main/java/dev/vox/lss/common/config/ServerConfigBase.java
@@ -20,7 +20,12 @@ public abstract class ServerConfigBase extends JsonConfig {
     public int generationConcurrencyLimitGlobal = 32;
     public int generationTimeoutSeconds = 60;
     public int dirtyBroadcastIntervalSeconds = 10;
-    public int syncOnLoadConcurrencyLimitPerPlayer = 200;
+    // 128 sits below the default disk-reader capacity (diskReaderThreads 5 × 32 + 5 = 165), so
+    // a single player's in-flight reads never overflow the pool and trigger routine rate-limits
+    // (issue #32). Not a throughput change: 5 reader threads are the bottleneck and 128 in-flight
+    // already keeps them saturated; the old 200 could never all sit in the pool at once. Admission
+    // gates on real pool headroom, so any custom cap-vs-threads mismatch still degrades gracefully.
+    public int syncOnLoadConcurrencyLimitPerPlayer = 128;
     public int generationConcurrencyLimitPerPlayer = 16;
     public int perDimensionTimestampCacheSizeMB = 32;
 

--- a/common/src/main/java/dev/vox/lss/common/processing/AbstractChunkDiskReader.java
+++ b/common/src/main/java/dev/vox/lss/common/processing/AbstractChunkDiskReader.java
@@ -6,6 +6,7 @@ import dev.vox.lss.common.LogThrottle;
 
 import java.util.UUID;
 import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ExecutorService;
@@ -42,6 +43,11 @@ public abstract class AbstractChunkDiskReader {
     private final LogThrottle saturationWarn = new LogThrottle(SATURATION_WARN_INTERVAL_MS);
 
     private final ExecutorService executor;
+    // Direct handle on the executor's work queue so admission can gate on real headroom
+    // (hasReadCapacity) before submitting — the router is the sole submitter and reader
+    // threads only dequeue, so remainingCapacity()>0 guarantees the next submit won't reject.
+    private final BlockingQueue<Runnable> workQueue;
+    private final int maxReadCapacity;
     private final ConcurrentHashMap<UUID, ConcurrentLinkedQueue<ChunkReadResult>> playerResults = new ConcurrentHashMap<>();
     private final AtomicBoolean isShutdown = new AtomicBoolean(false);
 
@@ -49,13 +55,47 @@ public abstract class AbstractChunkDiskReader {
 
     protected AbstractChunkDiskReader(int threadCount) {
         int queueCapacity = threadCount * QUEUE_CAPACITY_PER_THREAD;
+        this.workQueue = new ArrayBlockingQueue<>(queueCapacity);
+        // Reads outstanding before the pool would reject: queueCapacity queued + threadCount
+        // running (once all core threads are busy, submits queue; a full queue rejects).
+        this.maxReadCapacity = queueCapacity + threadCount;
         this.executor = new ThreadPoolExecutor(threadCount, threadCount, 0L, TimeUnit.MILLISECONDS,
-                new ArrayBlockingQueue<>(queueCapacity), r -> {
+                this.workQueue, r -> {
             var thread = new Thread(r, "LSS Disk Reader #" + THREAD_COUNTER.incrementAndGet());
             thread.setDaemon(true);
             thread.setPriority(Thread.MIN_PRIORITY);
             return thread;
         });
+    }
+
+    /**
+     * True when a {@link #submitRead} would NOT be rejected. The executor's only producer is
+     * the single processing thread and its consumers (reader threads) only remove work, so a
+     * non-full queue here means the immediately-following submit is guaranteed a seat. Admission
+     * gates on this so the pool never throws {@link RejectedExecutionException} in normal
+     * operation (issue #32 root cause: the per-player slot cap could exceed pool capacity).
+     */
+    public boolean hasReadCapacity() {
+        return this.workQueue.remainingCapacity() > 0;
+    }
+
+    /** Reads that can be outstanding (queued + running) before the pool would reject. */
+    public int maxReadCapacity() {
+        return this.maxReadCapacity;
+    }
+
+    /**
+     * Startup advisory: returns a warning when the per-player in-flight ceiling exceeds the
+     * whole pool's capacity (a single player can then be routinely rate-limited), or null when
+     * they are consistent. Admission degrades gracefully either way — this only tells the admin
+     * how to align the two knobs.
+     */
+    public String capacityAdvisory(int syncOnLoadConcurrencyLimitPerPlayer) {
+        if (syncOnLoadConcurrencyLimitPerPlayer <= this.maxReadCapacity) return null;
+        return "syncOnLoadConcurrencyLimitPerPlayer (" + syncOnLoadConcurrencyLimitPerPlayer
+                + ") exceeds disk reader capacity (" + this.maxReadCapacity + "): requests above "
+                + this.maxReadCapacity + " are rate-limited until reads drain (clients retry). "
+                + "Raise diskReaderThreads or lower the cap to align them.";
     }
 
     protected boolean isShutdown() {

--- a/common/src/main/java/dev/vox/lss/common/processing/IncomingRequestRouter.java
+++ b/common/src/main/java/dev/vox/lss/common/processing/IncomingRequestRouter.java
@@ -194,6 +194,15 @@ class IncomingRequestRouter<PS extends AbstractPlayerRequestState<?>> {
         if (type == RequestType.SYNC || this.diskReadingAvailable) {
             // Route through disk reader (with cross-player dedup)
             boolean claimsData = req.clientTimestamp() > 0;
+            // Gate on real pool headroom BEFORE admitting, but only when this request would
+            // actually submit a read — a request that will attach to an in-flight dedup group
+            // adds no pool load and must not be bounced. Checking before tryAdmit avoids taking
+            // (and unwinding) a slot on the bounce. The router is the sole submitter, so a
+            // non-full queue here guarantees the later submit won't reject (issue #32).
+            if (!this.dedupTracker.hasGroup(packed, dimension) && !this.processor.hasDiskReadCapacity()) {
+                rateLimit(state, playerUuid, req, packed, type, dimension);
+                return;
+            }
             if (!state.tryAdmit(new PendingRequest(req.cx(), req.cz(), type, SlotType.SYNC_ON_LOAD, claimsData))) {
                 rateLimit(state, playerUuid, req, packed, type, dimension);
                 return;

--- a/common/src/main/java/dev/vox/lss/common/processing/OffThreadProcessor.java
+++ b/common/src/main/java/dev/vox/lss/common/processing/OffThreadProcessor.java
@@ -253,6 +253,15 @@ public abstract class OffThreadProcessor<PlayerState extends AbstractPlayerReque
                                             long submissionOrder);
 
     /**
+     * True when the disk reader can accept another read without rejecting. The router gates
+     * new (non-deduped) disk submits on this so the pool never saturates into a rejection
+     * (issue #32). Overridable so tests can drive the pool-full path directly.
+     */
+    protected boolean hasDiskReadCapacity() {
+        return this.diskReader == null || this.diskReader.hasReadCapacity();
+    }
+
+    /**
      * Store timestamp and enqueue pre-serialized column data as a payload.
      */
     protected boolean enqueueLoadedColumn(PlayerState state, LoadedColumnData column,

--- a/fabric/src/main/java/dev/vox/lss/networking/server/RequestProcessingService.java
+++ b/fabric/src/main/java/dev/vox/lss/networking/server/RequestProcessingService.java
@@ -74,6 +74,8 @@ public class RequestProcessingService {
         this.dirtyTracker = new DirtyColumnTracker();
 
         this.diskReader = new ChunkDiskReader(config.diskReaderThreads);
+        var advisory = this.diskReader.capacityAdvisory(config.syncOnLoadConcurrencyLimitPerPlayer);
+        if (advisory != null) LSSLogger.warn(advisory);
         if (config.enableChunkGeneration) {
             this.generationService = new ChunkGenerationService(config);
             this.generationService.setDirtyContentFilter(this.dirtyContentFilter);

--- a/fabric/src/test/java/dev/vox/lss/common/processing/AbstractChunkDiskReaderTest.java
+++ b/fabric/src/test/java/dev/vox/lss/common/processing/AbstractChunkDiskReaderTest.java
@@ -234,6 +234,52 @@ class AbstractChunkDiskReaderTest {
                         + d.getErrorCount() + d.getSaturationCount());
     }
 
+    // ---- Capacity gate (B): admission checks headroom before submitting ----
+
+    @Test
+    void maxReadCapacityIsQueuePlusRunning() {
+        // threadCount 1 → queue 32 + 1 running = 33 outstanding before rejection.
+        assertEquals(33, reader.maxReadCapacity());
+    }
+
+    @Test
+    void hasReadCapacityFlipsFalseWhenQueueFullAndTrueAfterDrain() throws Exception {
+        // Pin the single worker on a gated read and fill the 32-slot queue behind it, exactly
+        // as the saturation test does — the 33rd task in flight leaves the queue full.
+        var started = new CountDownLatch(1);
+        var gate = new CountDownLatch(1);
+        reader.submit(player, 0, 0, 1L, () -> {
+            started.countDown();
+            if (!gate.await(10, TimeUnit.SECONDS)) throw new IllegalStateException("gate never opened");
+            return new byte[0];
+        });
+        assertTrue(started.await(5, TimeUnit.SECONDS), "worker occupied");
+        assertTrue(reader.hasReadCapacity(), "queue empty behind the running task — capacity available");
+
+        for (int i = 1; i <= 32; i++) {
+            reader.submit(player, i, 0, 1L + i, () -> {
+                if (!gate.await(10, TimeUnit.SECONDS)) throw new IllegalStateException("gate never opened");
+                return new byte[0];
+            });
+        }
+        assertFalse(reader.hasReadCapacity(), "queue full (32 queued behind 1 running) — no capacity");
+        assertEquals(0, reader.getDiag().getSaturationCount(), "still exactly at capacity, nothing rejected yet");
+
+        gate.countDown();
+        awaitResults(33);
+        assertTrue(reader.hasReadCapacity(), "capacity restored once the queue drains");
+    }
+
+    @Test
+    void capacityAdvisoryFiresOnlyWhenCapExceedsPool() {
+        // maxReadCapacity == 33 here.
+        assertNull(reader.capacityAdvisory(33), "cap equal to pool capacity is consistent — no advisory");
+        assertNull(reader.capacityAdvisory(1), "cap below pool capacity — no advisory");
+        String msg = reader.capacityAdvisory(200);
+        assertNotNull(msg, "cap above pool capacity must advise");
+        assertTrue(msg.contains("200") && msg.contains("33"), "advisory names both the cap and the pool capacity");
+    }
+
     @Test
     void shutDownReaderIsSilent() throws Exception {
         reader.submit(player, 1, 1, 1L, () -> new byte[0]);

--- a/fabric/src/test/java/dev/vox/lss/common/processing/IncomingRequestRouterTest.java
+++ b/fabric/src/test/java/dev/vox/lss/common/processing/IncomingRequestRouterTest.java
@@ -54,10 +54,16 @@ class IncomingRequestRouterTest {
         final ConcurrentLinkedQueue<CapturedPayload> payloads = new ConcurrentLinkedQueue<>();
         volatile boolean failSubmits;
         volatile boolean dropPayloads; // models the platform oversized-payload drop (payloads still records the attempt)
+        volatile boolean diskFull;     // drives the pool-full capacity gate (B) without a real full queue
 
         TestProcessor(Map<UUID, TestState> players, AbstractChunkDiskReader diskReader,
                       boolean generationAvailable, Path dataDir) {
             super(players, diskReader, generationAvailable, dataDir, 1);
+        }
+
+        @Override
+        protected boolean hasDiskReadCapacity() {
+            return !this.diskFull;
         }
 
         @Override
@@ -172,6 +178,70 @@ class IncomingRequestRouterTest {
     }
 
     // ---- Tests ----
+
+    @Test
+    void diskFullBouncesNewSyncRequestBeforeAdmissionAndRecovers(@TempDir Path tempDir) throws Exception {
+        // B: when the pool has no headroom, a fresh (non-deduped) sync request is bounced
+        // rate-limited BEFORE it takes a slot or submits — so the executor never rejects.
+        var players = new ConcurrentHashMap<UUID, TestState>();
+        var p1 = addPlayer(players, 2, 1);
+        var proc = new TestProcessor(players, null, true, tempDir);
+        try {
+            proc.diskFull = true;
+            proc.start();
+            p1.enqueue(new IncomingRequest(1, 0, -1));
+            proc.postSnapshot(snapshot(p1), List.of());
+
+            var delivered = drainUntil(proc, contains(LSSConstants.RESPONSE_RATE_LIMITED, packed(1, 0)));
+            assertEquals(1, delivered.size(), "the only disposition is the rate-limit bounce: " + delivered);
+            assertEquals(1, count(delivered, LSSConstants.RESPONSE_RATE_LIMITED, packed(1, 0)));
+            assertTrue(proc.submits.isEmpty(), "a full pool must NOT submit — that is the rejection we prevent");
+            assertEquals(0, p1.getHeldSyncSlots(), "the bounce takes no slot (gate is before tryAdmit)");
+            assertFalse(p1.hasPendingRequest(1, 0));
+            assertEquals(1, proc.getDiagnostics().getTotalSyncRateLimited());
+
+            // Recovery: with headroom, the same position now submits — proving the bounce left
+            // no phantom dedup group and no held slot behind.
+            proc.diskFull = false;
+            p1.enqueue(new IncomingRequest(1, 0, -1));
+            proc.postSnapshot(snapshot(p1), List.of());
+            waitFor(() -> !proc.submits.isEmpty(), "submit after capacity returns");
+            assertEquals(List.of(packed(1, 0)), submitPositions(proc));
+            assertEquals(1, p1.getHeldSyncSlots(), "the recovered request holds exactly one slot");
+        } finally {
+            proc.shutdown();
+        }
+    }
+
+    @Test
+    void attachedDedupRequestProceedsEvenWhenDiskFull(@TempDir Path tempDir) throws Exception {
+        // B: a request that will ATTACH to an in-flight dedup group adds no pool load, so the
+        // capacity gate must let it through even when the pool is full.
+        var players = new ConcurrentHashMap<UUID, TestState>();
+        var p1 = addPlayer(players, 2, 1);
+        var p2 = addPlayer(players, 2, 1);
+        var proc = new TestProcessor(players, null, true, tempDir);
+        try {
+            proc.start();
+            // p1 creates the group and submits the one disk read (capacity available).
+            p1.enqueue(new IncomingRequest(5, 5, -1));
+            proc.postSnapshot(snapshot(p1, p2), List.of());
+            waitFor(() -> !proc.submits.isEmpty(), "primary submit");
+            assertEquals(List.of(packed(5, 5)), submitPositions(proc));
+
+            // Now the pool is full, but p2 requesting the SAME position attaches to p1's group.
+            proc.diskFull = true;
+            p2.enqueue(new IncomingRequest(5, 5, -1));
+            proc.postSnapshot(snapshot(p1, p2), List.of());
+            waitFor(() -> p2.hasPendingRequest(5, 5), "p2 attaches despite the full pool");
+
+            assertEquals(1, proc.submits.size(), "attach adds no second disk read");
+            assertEquals(1, p2.getHeldSyncSlots(), "p2 holds its own slot for the shared read");
+            assertEquals(0, proc.getDiagnostics().getTotalSyncRateLimited(), "no bounce for the attached read");
+        } finally {
+            proc.shutdown();
+        }
+    }
 
     @Test
     void mixedBatchEveryRequestGetsExactlyOneDisposition(@TempDir Path tempDir) throws Exception {

--- a/fabric/src/test/java/dev/vox/lss/config/JsonConfigLoadTest.java
+++ b/fabric/src/test/java/dev/vox/lss/config/JsonConfigLoadTest.java
@@ -149,7 +149,7 @@ class JsonConfigLoadTest {
         assertEquals(32, c.generationConcurrencyLimitGlobal);
         assertEquals(60, c.generationTimeoutSeconds);
         assertEquals(10, c.dirtyBroadcastIntervalSeconds);
-        assertEquals(200, c.syncOnLoadConcurrencyLimitPerPlayer);
+        assertEquals(128, c.syncOnLoadConcurrencyLimitPerPlayer);
         assertEquals(16, c.generationConcurrencyLimitPerPlayer);
         assertEquals(32, c.perDimensionTimestampCacheSizeMB);
     }

--- a/paper/src/main/java/dev/vox/lss/paper/PaperRequestProcessingService.java
+++ b/paper/src/main/java/dev/vox/lss/paper/PaperRequestProcessingService.java
@@ -205,6 +205,8 @@ public class PaperRequestProcessingService {
     private static Wiring productionWiring(MinecraftServer server, Plugin plugin, PaperConfig config) {
         Map<UUID, PaperPlayerRequestState> players = new ConcurrentHashMap<>();
         var diskReader = new PaperChunkDiskReader(config.diskReaderThreads);
+        var advisory = diskReader.capacityAdvisory(config.syncOnLoadConcurrencyLimitPerPlayer);
+        if (advisory != null) LSSLogger.warn(advisory);
         PaperChunkGenerationService generationService = config.enableChunkGeneration
                 ? new PaperChunkGenerationService(config, plugin) : null;
 

--- a/paper/src/test/java/dev/vox/lss/paper/PaperConfigLoadTest.java
+++ b/paper/src/test/java/dev/vox/lss/paper/PaperConfigLoadTest.java
@@ -113,7 +113,7 @@ class PaperConfigLoadTest {
         assertEquals(32, c.generationConcurrencyLimitGlobal);
         assertEquals(60, c.generationTimeoutSeconds);
         assertEquals(10, c.dirtyBroadcastIntervalSeconds);
-        assertEquals(200, c.syncOnLoadConcurrencyLimitPerPlayer);
+        assertEquals(128, c.syncOnLoadConcurrencyLimitPerPlayer);
         assertEquals(16, c.generationConcurrencyLimitPerPlayer);
         assertEquals(32, c.perDimensionTimestampCacheSizeMB);
     }


### PR DESCRIPTION
Follow-up to the #32 console-spam fix (#33): that quieted the *symptom*; this addresses the *root cause* the log spam was reporting.

## Root cause

Disk-reader saturation was a sizing inconsistency between three independently-configured bounds:

| Bound | Default | |
|---|---|---|
| Client offers (in-flight ceiling) | 200 | = server's advertised sync cap |
| Server admits (per-player slots) | **200** | `syncOnLoadConcurrencyLimitPerPlayer` |
| Disk pool absorbs (queue + running) | **165** | `diskReaderThreads` 5 × 32 + 5 |

The disk pool — the actual bottleneck — is the *smallest* number, so a single player's contiguous scan was admitted for up to 200 concurrent reads while the pool rejected everything past ~165. The per-player slot limiter, whose whole job is to protect the pool, was set 21% above it. (Analysis surfaced no leak — the bounce self-heals — but the saturation path was structurally routine, not an edge case.)

## Changes

**B — gate disk submission on real pool headroom.** `AbstractChunkDiskReader` exposes `hasReadCapacity()` / `maxReadCapacity()`. `IncomingRequestRouter` checks headroom *before* admitting a new (non-deduped) read and bounces `rate-limited` cleanly when the pool is full, instead of admit → submit → executor-reject → round-trip a saturated result. The router is the **sole** submitter and reader threads only dequeue, so a non-full queue guarantees the next submit can't reject — `RejectedExecutionException` becomes unreachable in normal operation. Dedup-attached reads (no new pool load) and in-memory probe hits bypass the gate.

**A — align the default ceiling with the pool.** `syncOnLoadConcurrencyLimitPerPlayer` default **200 → 128** (< 165). The client reads this from `SessionConfig` as its drain ceiling, so a single player never reaches the gate. **Not a throughput change** — 5 reader threads are the bottleneck and 128 in-flight already keeps them saturated; the old 200 could never all sit in the pool at once. Each service logs a one-time advisory when a custom cap exceeds pool capacity.

Together: single-player saturation is eliminated by A; multi-player / custom-config mismatches degrade as clean rate-limits (no executor rejection, no wasted round-trip) by B. The robust idempotent-position protocol is untouched.

Deliberately **not** in scope (considered, deferred): dropping the client's ×4 scan-budget multiplier (affects per-scan queuing only, not the in-flight ceiling — zero saturation benefit, high test churn); server-side deferred queue and distance-priority scheduling (larger, don't address the sizing gap).

## Tests
- `AbstractChunkDiskReaderTest`: `hasReadCapacity()` flips false at queue-full and true after drain; `maxReadCapacity() == threads + threads×32`; `capacityAdvisory` fires only when cap > pool.
- `IncomingRequestRouterTest`: a full pool bounces a fresh sync request **before** admission (no submit, no slot taken, no dedup leak) and recovers when headroom returns; an attached dedup read still proceeds under a full pool.
- Updated the two default-assert config tests + README.
- Verified locally: Fabric Tier 1 + Tier 2, Paper Tier 1 — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)