### PR TITLE
Adaptive client request backoff (AIMD window) + keep scanning while moving

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -154,8 +154,9 @@ Chunk coordinates are packed as `((long)chunkX << 32) | (chunkZ & 0xFFFFFFFFL)`.
 
 ### Client-Side
 
-- `LodRequestManager` — orchestrates the client request loop: drip-feeds queued requests each tick, applies in-flight timeouts and rate-limit retries, handles dirty column re-requests and pruning on movement
-- `SpiralScanner` — expanding Chebyshev ring scan (20-tick cadence); owns scan policy: request budget, queue-pressure scaling, rate-limit backoff
+- `LodRequestManager` — orchestrates the client request loop: drip-feeds queued requests each tick, applies in-flight timeouts and rate-limit retries, handles dirty column re-requests and pruning on movement. Owns the `AdaptiveConcurrencyWindow` and evaluates it once per second on a counter independent of the scan cadence (so continuous movement can't freeze it)
+- `AdaptiveConcurrencyWindow` — AIMD congestion window for the in-flight sync ceiling: starts at the server-advertised cap, shrinks ×0.7 on sustained sync rate-limiting, grows additively while saturating the window without pushback (TCP cwnd-limited rule). Drives both the drain-gate limit and the scan-budget base, so the client converges to the server's sustainable throughput instead of re-offering peak pressure. Replaced the old one-scan `skipNextScan` backoff (retired)
+- `SpiralScanner` — expanding Chebyshev ring scan (20-tick cadence); owns scan policy: request budget (base = the adaptive window × 4), queue-pressure scaling, vanilla-load scaling. Movement re-surveys via `resetConfirmedRing` (keeps the cadence) so fast travel no longer suspends LOD loading; the dirty-broadcast path still debounces via `resetScanCounter`
 - `ColumnStateMap` — single owner of per-column client state (timestamps + dirty/retry/validated marks); its `classify` ladder decides whether a position needs a request
 - `InFlightTracker` / `RequestQueue` — pending requests keyed by packed position; accepted-position queue between scanner and sender
 - `ClientColumnProcessor` — off-render-thread decode of received column payloads before dispatch to consumers

--- a/docs/planning/backpressure-review.md
+++ b/docs/planning/backpressure-review.md
@@ -1,0 +1,186 @@
+# Backpressure, Queueing, Concurrency & Rate-Limiting — Architecture Review
+
+**Status:** review / proposal document — nothing here is implemented. Companion to the issue-#32 fixes (PR #33 console-spam, PR #34 disk-admission capacity gate + default alignment).
+**Scope:** every flow-control mechanism on the client offer-loop and the server serve-loop, both Fabric and Paper (the mechanisms live in shared `common/`; the platforms are thin adapters).
+**Date:** 2026-07-14. Protocol v16.
+
+---
+
+## 1. Executive summary
+
+**Verdict: the design is sound and already well-simplified — this is a tuning-and-clarity pass, not a redesign.** The core protocol (idempotent, position-keyed requests; bounce-and-retry backpressure; cross-player dedup; "a pending-map entry IS the admission slot") is robust and should not change. The big structural simplification already happened: the v15→v16 rework deleted the entire parallel rate-limiter machinery (`RateLimiterSet`, `ConcurrencyLimiter`, `requestId` addressing, the request-cancel path, the server waiting-queue, the bandwidth-negotiation pipeline, and the write-only SessionConfig fields). The old `simplification-review.md` is effectively spent.
+
+What remains is a **layered control system with ~15 distinct bounds**, of which a handful never bind at default config, two enforce the same limit twice, one constant drives three behaviors, one signal aliases four causes, and two latent coupling bugs can stall retries. None is a crisis; together they are real complexity that can be trimmed or clarified.
+
+**Top proposals, ranked by value/risk:**
+
+| # | Proposal | Kind | Behavior change | Risk |
+|---|----------|------|-----------------|------|
+| P1 | Split the `rate-limited` diagnostic by cause (slot-full vs pool-full vs dedup-bounce vs saturation-fallback) | Observability | none | very low |
+| P2 | Fix bandwidth idle-dilution: divide the global budget by *senders*, not all handshaked players | Fairness bug | yes (better) | low–med |
+| P3 | Decouple the 10 s in-flight timeout sweep from the scan cadence so movement/backpressure can't starve retries | Latent bug | yes (better) | medium |
+| P4 | Delete genuinely dead code: `RequestQueue`'s timestamp column + `peekTimestamp()` | Simplification | none | very low |
+| P5 | Collapse the client's three stacked reactions to one rate-limited response into one | Simplification | yes (subtle) | medium |
+| P6 | Decide the two-level bandwidth design: keep + document, or fold to one bucket | Clarity/simplify | none–some | low–med |
+| P7 | Reconcile the doubly-enforced per-player generation cap (slot 16 == service 16) | Simplification | none (if verified) | medium |
+
+Details and the full inventory below. **Leave alone:** the idempotent protocol, dedup, derived-slot admission, the `RejectedExecutionException` fallback, the defensive `MAX_BATCH_CHUNK_REQUESTS` clamp, and the deliberately-kept unreachable generation guard (its own comment explains why).
+
+---
+
+## 2. The control flow, end to end
+
+Two independent loops meet at the wire. The client *offers* requests as fast as its budget allows; the server *serves* what its resources allow and bounces the rest; both self-heal because every response is an idempotent statement about a position.
+
+```
+CLIENT (offer loop, 20-tick cadence)                    SERVER (serve loop, per tick)
+─────────────────────────────────────                  ──────────────────────────────────────
+SpiralScanner                                           incoming queue  [MAX_INCOMING_QUEUE 16384]
+  budget = syncCap×4 = 512        ①                       │  (silent drop if full)
+  × queue-pressure scale (→0 @6000) ②                     ▼
+  × vanilla-load scale             ③                     IncomingRequestRouter ladder:
+  skipNextScan (1-scan backoff)    ④                       1 duplicate / diskReadDone
+     │  writes ≤budget positions                            2 send-queue-full → break  [4000] ⑧
+     ▼                                                      3 timestamp cache → up_to_date
+RequestQueue (single-pass, regenerated each scan)          4 loaded probe → in-memory serve
+     │                                                      5 DISK-CAPACITY GATE  [pool 165] ⑨
+     ▼                                                        (skip if dedup hasGroup)
+LodRequestManager.drainQueue                                6 slot admission tryAdmit [sync 128] ⑩
+  maxSendPerTick = ceil(scanned/20) [floor 16] ⑤            7 dedup attach / disk submit
+  per-type gate: sync<128, gen<16   ⑥                       └ gen path: slot 16 + service 16+32 ⑪
+     │  batched request packet [≤1024/pkt]                       │
+     ▼                                                            ▼  ChunkDiskReader pool
+   WIRE  ───────────────────────────────────────────────►   [threads 5 × 32 queue = 165] ⑨
+     ▲                                                            │
+InFlightTracker (10 s timeout → retry) ⑦                          ▼  results → OffThreadProcessor
+     ▲                                                        readyPayloads (unbounded)
+ClientColumnProcessor                                            → sendQueue [4000] ⑧
+  decode queue [8000 count / 256 MiB] ②                          │
+     │  depth 6000 → HALT tick; →0 budget                        ▼  flushSendQueue
+     ▼                                                        BANDWIDTH (per tick):
+   consumers (Voxy)                                             global ÷ activeCount ⑫
+                                                               ∧ min per-player cap 20 MiB ⑬
+   DirtyColumnBroadcaster (every 10 s) ──── dirty push ──────►  ∧ per-player burst bucket /4 ⑭
+```
+
+**Server tick order** (`RequestProcessingService.tick`): generation poll → player lifecycle + active-count → snapshot to processing thread → drain batched responses → submit generation tickets → **bandwidth-metered send** → dirty broadcast.
+**Processing-thread cycle** (`OffThreadProcessor.processCycle`): apply events (invalidations/removals/dirty-clears) → drain disk results → deliver generation outcomes → route incoming requests → evict/save timestamp cache.
+
+**Backpressure directions.** Server→client: `rate-limited` (retry later), `not-generated`, `up_to_date`, and silent queue-full drops. Client-internal (decode queue → scanner): the decode depth both scales the scan budget down (soft) and halts the whole tick (hard). Bandwidth exhaustion propagates *upward* on the server: a full byte-bucket stalls the send queue, which fills toward its cap, which eventually trips the router's queue-full break.
+
+---
+
+## 3. Mechanism inventory
+
+Numbers ① – ⑭ key to the diagram. "Binds at default?" = does this limit ever actually reject/throttle with out-of-the-box config and a normal client.
+
+| # | Mechanism | Default | Purpose | Binds at default? |
+|---|-----------|---------|---------|-------------------|
+| ① | Scan budget = `syncCap × BUDGET_MULTIPLIER(4)` | 512 pos/scan | discover positions to request | as headroom only — drain gate ⑥ is the real limit |
+| ② | Decode-queue pressure (soft budget ramp + hard halt) | ramp→0 and halt at **6000** (of 8000/256 MiB) | stop offering when decode can't keep up | yes, under dirty storms / slow decode |
+| ③ | Vanilla-load budget scale | quadratic | don't scan LODs while vanilla terrain still streaming | yes, on join/teleport |
+| ④ | `skipNextScan` rate-limit backoff | 1 scan (~1 s) | global cooldown after any bounce | yes |
+| ⑤ | Drip-feed `maxSendPerTick = ceil(scanned/20)` | floor **16** | spread a scan's sends over ~1 s | floor dominates in light traffic (see §4) |
+| ⑥ | Per-type send concurrency gate | sync **128**, gen **16** | cap outstanding in-flight requests | **yes — the effective client limiter** |
+| ⑦ | In-flight timeout → retry | **10 s** | recover lost/dropped requests | yes |
+| ⑧ | `sendQueueLimitPerPlayer` | **4000** | bound server outbound backlog | **no — unreachable (§4)** |
+| ⑨ | Disk pool + capacity gate | **165** (5×32+5) | bound concurrent disk reads; gate before submit | yes (multi-player / large scans) |
+| ⑩ | Per-player sync slot cap | **128** | per-player fairness on the pool | only under multi-player contention |
+| ⑪ | Generation caps | slot **16**, service per-player **16**, global **32** | bound concurrent chunk generation | per-player 16 binds; global 32 only with ≥3 generators |
+| ⑫ | Global bandwidth ÷ active count | 100 MiB ÷ N | fair egress division | rarely (100 MiB is huge) |
+| ⑬ | Per-player bandwidth cap | **20 MiB/s** | hard per-player egress | yes, on a fast link |
+| ⑭ | Per-player burst bucket | allocation / 4 (~250 ms) | anti-hoard smoothing | yes |
+
+---
+
+## 4. Findings
+
+### A. Redundant or doubly-enforced
+
+**A1 — The per-player generation limit is enforced twice (⑪).** A not-found disk read escalates to generation and takes a `GENERATION` pending slot capped at `generationConcurrencyLimitPerPlayer = 16` (`OffThreadProcessor.handleDiskNotFound`). One hop later, `ChunkGenerationService.submitGeneration` independently checks `perPlayerActive < maxPerPlayerActive = 16`. The same per-player number is guarded by two mechanisms at two lifecycle points. They *may* diverge briefly (slot taken at escalation, service count at ticket submit) and piggybacking muddies it, so this is "verify then consolidate," not "obviously dead."
+
+**A2 — The client over-provisions the request queue 4× on purpose (①/⑥, ②gen).** Scan budget is `syncCap×4` (512) but the drain gate only lets 128 sync in flight; the gen sub-cap is `genCap×4` (64) but the drain lets 16. The surplus is skipped each drain and re-discovered next scan. This is *intentional* headroom so freed slots refill mid-period — but it means the budget number never bounds anything, and a reader has to know it's 4× to reason about it. Worth a one-line comment at the constant, not removal.
+
+### B. Never binds at default config (dead weight or pure defense)
+
+**B1 — `sendQueueLimitPerPlayer = 4000` is unreachable (⑧).** A player can hold at most `syncSlotCap + genSlotCap = 128 + 16 = 144` resolved-but-unsent columns, because that's all the slots it can hold. 144 ≪ 4000, so the send-queue-full break never fires in normal operation. Keep as a hostile-input safety valve, but its default is 28× larger than reachable — either document it as a safety valve or lower it to something meaningful (e.g. 512).
+
+**B2 — `RequestQueue`'s timestamp column + `peekTimestamp()` are dead in the live flow (genuinely removable).** The scanner writes a timestamp per queued position, but `drainQueue` re-derives the timestamp from `classify` at send time (correctly — a stamp can change between scan and drain) and never reads the stored one. `peekTimestamp()` has zero production callers (only tests). This is a real, safe deletion: drop the parallel `timestamps` array, `put`'s ts parameter, and `peekTimestamp`, updating the two tests that pin them.
+
+**B3 — `MAX_BATCH_CHUNK_REQUESTS = 1024` never clamps `maxSendPerTick` (⑤).** It would require a scan to queue ≥20480 positions; the budget maxes at 4000. Purely defensive on that path (it still legitimately sizes the send buffers). Leave it.
+
+**B4 — The router's direct-generation branch is unreachable — but keep it.** Both platforms always construct a disk reader, so generation is only ever reached via disk-not-found escalation. The branch's own comment explains it's a deliberate guard so *any* future generation-ticket producer stays covered by the in-flight taint tracking. Do **not** delete; it's intentional defense with a documented reason.
+
+**B5 — The disk `RejectedExecutionException` path is now a fallback (⑨).** PR #34's pre-submit capacity gate makes it unreachable in normal operation. Correctly retained as belt-and-suspenders with the throttled warn. Leave it.
+
+**B6 — `MIN_SEND_PER_TICK = 16` makes the "adaptive" drip rate constant in light traffic (⑤).** `ceil(scanned/20)` only exceeds 16 when a scan queues >320 positions; below that the floor is the send rate. So the adaptive formula is effectively "16/tick" for steady-state play and only ramps on big fresh scans. Fine, but the adaptivity is doing less than it looks — worth knowing when tuning.
+
+### C. One constant / one signal, many meanings
+
+**C1 — `6000` drives three behaviors (②).** The decode-queue depth of 6000 (¾ of 8000) is simultaneously the denominator of the soft budget ramp *and* the hard tick-halt threshold. Because the halt is checked before the scan, the top quarter of the soft ramp is unreachable in the same tick — the soft ramp and hard halt partly shadow each other. Not a bug, but two behaviors welded to one number; splitting them (ramp to 8000, halt at 6000) would make each independently tunable.
+
+**C2 — `rate-limited` aliases four distinct causes (P1).** The wire signal and the `totalSyncRateLimited`/`totalGenRateLimited` counters are emitted for: (a) per-player slot full, (b) disk-pool capacity gate, (c) duplicate-in-flight `ts≤0` bounce, and (d) the disk-saturation fallback. An operator reading `/lsslod` or soak metrics cannot tell per-player pressure from global-pool pressure from dedup churn. Splitting the counter by cause is the single highest-value, lowest-risk change here.
+
+### D. Coupling / latent fragility
+
+**D1 — Bandwidth idle-dilution (⑫, P2).** `activeCount` counts every handshake-completed player, not just those with queued sends. An idle player who finished loading still divides the global budget, so an actively-downloading player gets `global/N` instead of `global/(active senders)`. On a busy server with many settled players and one newcomer, the newcomer is throttled by peers doing nothing. (The `TwoPlayerGameTests` "idle dilution" case pins the *current* behavior, so changing it means updating that expectation deliberately.)
+
+**D2 — Timeout sweep starves under movement or backpressure (⑦, P3).** The 10 s in-flight timeout sweep rides the scan cadence, and the cadence is reset on every chunk-boundary crossing and skipped entirely while the decode queue is halted. So a fast-moving player, or one under sustained decode backpressure, stops sweeping timeouts — lost requests aren't retried until they rest. The retry itself is correct; its *trigger* is coupled to the wrong clock. Give the sweep its own cadence independent of scan gating.
+
+**D3 — Three stacked reactions to one rate-limited response (④/⑥, P5).** A bounce triggers (a) `skipNextScan` (whole next scan skipped, ~1 s, global), (b) a per-position `retry` mark, and (c) the per-type concurrency gate that would have prevented the over-send anyway. A single bounce thus both freezes all scanning for a second and re-queues the position — arguably double-penalizing, and it makes the client's true offer-rate under load hard to predict. One coherent backoff (AIMD on the budget, or just the retry mark) would be simpler and more predictable.
+
+### E. Bandwidth: three superimposed egress limits (P6)
+
+The send path is gated by three things at once: the global bucket divided by active count (⑫), a hard per-player cap via `min()` (⑬), and a per-player burst bucket with a /4 cap (⑭). This is a legitimate two-level token-bucket (global fairness + per-player smoothing), but it's the most intricate mechanism in the system for a feature — bandwidth shaping — that rarely binds at the 100 MiB/20 MiB defaults. Worth an explicit decision: keep it and document the design, or simplify to a single per-player bucket clamped by a global counter.
+
+---
+
+## 5. Proposals
+
+Each: **what**, **why**, **behavior change**, **risk/effort**. Ranked by value ÷ risk. Per the project's "review-findings-vs-pinned-decisions" history, every one should be checked against the pinned tests named before implementing — several current behaviors are deliberately pinned.
+
+**P1 — Split the `rate-limited` diagnostic by cause. [do first]**
+*What:* give `incrementRateLimited` a cause enum (slot-full / pool-capacity / dedup-in-flight / saturation-fallback) and surface the breakdown in `/lsslod diag`, the exporters, and soak snapshots. *Why:* fixes C2 — the current single counter can't distinguish per-player from global-pool pressure, which is exactly the ambiguity that made issue #32 hard to reason about. *Behavior:* none (observability only). *Risk:* very low. *Effort:* small; touches `ProcessingDiagnostics`, the router call sites, and the exporter schemas (+ their parity tests).
+
+**P2 — Divide bandwidth by active senders, not all handshaked players.**
+*What:* count a player toward `activeCount` only if it has queued/ready payloads (or requested within the last N ticks). *Why:* fixes D1 idle-dilution so a newcomer isn't throttled by settled peers. *Behavior:* yes — improves fairness; **update `TwoPlayerGameTests` idle-dilution expectation deliberately.** *Risk:* low–medium (fairness edge cases; make sure a player mid-send isn't flip-flopped in/out of the divisor). *Effort:* small.
+
+**P3 — Give the in-flight timeout sweep its own cadence.**
+*What:* run `sweepTimeouts` on a fixed tick counter independent of scan gating and the backpressure halt. *Why:* fixes D2 so movement/backpressure can't strand lost requests for far longer than 10 s. *Behavior:* yes (retries fire on time under load). *Risk:* medium — verify it doesn't fight the halt (sweeping is cheap and doesn't send, so it should be safe during a halt). *Effort:* small–medium.
+
+**P4 — Delete `RequestQueue`'s dead timestamp column.**
+*What:* remove the `timestamps` array, the ts param on `put`, and `peekTimestamp()`; update the two tests. *Why:* fixes B2 — genuinely dead in the live flow. *Behavior:* none. *Risk:* very low. *Effort:* small.
+
+**P5 — Consolidate the client's rate-limit reactions. — ✅ IMPLEMENTED (`AdaptiveConcurrencyWindow`, see `docs/planning/client-backoff-plan.md`).** This retired `skipNextScan` for an AIMD window and, as part of the same work, decoupled the window's update (and, in effect, the scan cadence for movement) from the starved clock — resolving **D3** (stacked reactions) and the movement leg of **D2** (the timeout sweep can now move onto the same independent counter). The near-`MIN` dedup false-shrink is the remaining tie to **P1**.
+
+*Original write-up:* pick one backoff — most likely keep the per-position `retry` mark and replace `skipNextScan` with a multiplicative budget cut that recovers additively (AIMD), so sustained pushback smoothly lowers the offer rate instead of stuttering whole scans. *Why:* fixes D3 and folds A2's over-provisioning into one adaptive rate; this is the client-side half of the "close the loop" idea from the issue-#32 architecture analysis. *Behavior:* yes (subtle; smoother under load). *Risk:* medium — `SpiralScannerTest` pins the current budget/skip behavior extensively; needs careful re-pinning. *Effort:* medium.
+
+**P6 — Decide the bandwidth design.**
+*What:* either (a) keep the two-level bucket and add a design comment explaining global-fairness + per-player-smoothing, or (b) simplify to one per-player bucket clamped by a shared global atomic counter. *Why:* addresses E — the most complex mechanism for a rarely-binding feature. *Behavior:* none (a) or minor (b). *Risk:* low (a) / medium (b). *Effort:* small (a) / medium (b). Recommend (a) unless bandwidth shaping is on the roadmap.
+
+**P7 — Reconcile the doubly-enforced generation per-player cap.**
+*What:* determine whether the `GENERATION` slot cap (16) and the gen-service per-player active count (16) ever bind independently (piggyback / timing windows); if not, drop one. *Why:* fixes A1. *Behavior:* none if truly redundant. *Risk:* medium — the generation in-flight/taint accounting is subtle and has had per-player-leak bugs before (`inflight-guard-per-player`). *Effort:* medium; must be test-driven.
+
+**P8 (optional, larger) — Document or lower the unreachable `sendQueueLimitPerPlayer`.**
+*What:* either comment it as a hostile-input safety valve or lower the default to ~512 (still well above the ~144 reachable). *Why:* B1. *Behavior:* none (comment) / negligible (lower). *Risk:* low. *Effort:* trivial.
+
+---
+
+## 6. What to leave alone (the parts that are right)
+
+- **The idempotent, position-keyed protocol.** Late/duplicate/lost responses all self-heal; this is the system's core strength and the reason bounce-and-retry works. The honest re-resolution ladder (`ts>0` claims data → up_to_date; `ts≤0` re-resolves) is subtle and correct.
+- **Cross-player dedup** — collapses overlapping reads with clean attach/detach and per-player-slot accounting.
+- **Derived admission** — "a pending-map entry IS the slot" removed an entire parallel limiter subsystem in v16. Don't reintroduce separate permit objects.
+- **The v16 simplification is already banked.** The old `simplification-review.md`'s rate-limit/queueing/addressing bundle is implemented; don't re-propose it.
+- **The defensive fallbacks** — the `RejectedExecutionException` path (B5), the unreachable-but-guarded generation branch (B4), and the `MAX_BATCH_CHUNK_REQUESTS` buffer clamp (B3) are cheap insurance with documented rationale.
+
+---
+
+## 7. Suggested roadmap
+
+1. **P1** (diagnostic split) and **P4** (dead-column delete) — small, zero/near-zero behavior change, do together as one cleanup PR.
+2. **P3** (timeout-sweep cadence) and **P2** (bandwidth active-senders) — two latent-bug fixes; separate PRs, each with a soak scenario to confirm (a movement-heavy retry scenario for P3; a settled-peers-plus-newcomer fairness scenario for P2).
+3. **P8** / **P6(a)** — documentation-grade clarifications, fold into any nearby PR.
+4. **P5** (client backoff consolidation) and **P7** (gen cap reconciliation) — larger, test-heavy; schedule only if the added predictability/simplicity is worth the re-pinning cost. P5 pairs naturally with the client-side AIMD idea deferred from the issue-#32 analysis.
+
+Everything here is behavior-preserving or behavior-improving and independently shippable; none requires a protocol bump (P5's wire format is unchanged — it's client-internal pacing).

--- a/docs/planning/client-backoff-plan.md
+++ b/docs/planning/client-backoff-plan.md
@@ -1,0 +1,197 @@
+# Adaptive Client Request Backoff — Implementation Plan
+
+> **For agentic workers:** this is an implementation plan. Execute task-by-task with TDD; steps use checkbox syntax.
+
+**Status:** plan / not yet implemented. Grows out of the backpressure review (`docs/planning/backpressure-review.md`, proposal **P5**) and the issue-#32 analysis: the client is an open-loop offerer — it re-presents peak request pressure every second regardless of server pushback, because a `rate-limited` response only triggers a one-scan skip and never lowers the request rate.
+
+**Goal:** give the client a self-tuning request-rate control loop (AIMD congestion window) that converges to the server's actual sustainable throughput, and retire the crude `skipNextScan` backoff it replaces — staying responsive on healthy servers and adding **no new config knobs**.
+
+**Architecture:** a small `AdaptiveConcurrencyWindow` owned by `LodRequestManager` replaces the *static* per-player sync in-flight ceiling (today read straight from the server-advertised `syncOnLoadConcurrencyLimitPerPlayer`). The window drives both the drain-gate in-flight limit and the scan budget base. It shrinks multiplicatively when the client sees sustained rate-limiting and grows additively when it's saturating the window without pushback. `skipNextScan` is deleted.
+
+**Tech stack:** Java 25 (Fabric client), JUnit 5 (Tier 1), existing soak harness for convergence validation.
+
+## Global constraints (hard requirements)
+
+- **No new config knobs**, server or client. The window auto-tunes *under* the server's advertised `syncOnLoadConcurrencyLimitPerPlayer`; admins tune only that one existing cap.
+- **No wire/protocol change.** This is purely client-internal pacing; the `rate-limited` signal and all payloads are unchanged. (So it needs no protocol bump and helps only updated clients — acceptable, matches PR #34's server-side complement.)
+- **No regression on healthy servers.** With zero rate-limiting the window sits pinned at the advertised cap, so steady-state behavior is byte-for-byte today's.
+- **Self-scaling constants.** AIMD parameters derive from the advertised cap where dimensioned, so raising the server cap needs no client retune.
+- Verify every step against pinned tests before changing them (`SpiralScannerTest`, `LodRequestManagerTest*`) — several current behaviors are deliberately pinned.
+
+---
+
+## Design
+
+### The control variable
+
+Today two places read the static cap:
+- `SpiralScanner.maybeScan` (`SpiralScanner.java:75`): `budget = syncOnLoadConcurrencyLimitPerPlayer() * BUDGET_MULTIPLIER(4)` — the scan queue's over-provisioned base.
+- `LodRequestManager.drainQueue` (`LodRequestManager.java:238,254`): `maxSyncConcurrency = syncOnLoadConcurrencyLimitPerPlayer()` — the real in-flight ceiling.
+
+Both are replaced by a single adaptive `window ∈ [MIN, cap]`:
+- Drain gate: `(tracker.size() - genCount) >= window` → skip (instead of `>= cap`).
+- Scan budget base: `budget = window * BUDGET_MULTIPLIER` — so when the window shrinks, the scan stops discovering positions it can't send, cutting wasted client-side `classify` work (directly serves "don't waste resources").
+
+Generation keeps its static caps (16 per-player / 32 global) in v1 — generation is low-volume and wasn't the #32 bottleneck. Gen bounces do **not** move the sync window (see the signal below). A `genWindow` is a documented future option.
+
+### The control law (AIMD, evaluated once per second)
+
+State on the window: `int window`, `int rateLimitedThisCycle`, `boolean windowLimitedThisCycle`.
+
+- **Signal — congestion:** `onRateLimited` for a *sync* bounce increments `rateLimitedThisCycle`. (Gen bounces are ignored for the sync window.)
+- **Signal — saturation:** `drainQueue` sets `windowLimitedThisCycle` whenever the sync gate actually blocks a send because the window is full — i.e. the client wanted to send more but couldn't. This is the TCP "cwnd-limited" rule: only grow when more capacity would actually be used.
+- **Update (once per second):**
+  - `if rateLimitedThisCycle >= threshold` → **multiplicative decrease**: `window = max(MIN, round(window * MD))`
+  - `else if windowLimitedThisCycle` → **additive increase**: `window = min(cap, window + AI)`
+  - `else` → hold (dead-band: idle, or below the window with no pushback)
+  - reset both signals to 0/false.
+
+The dead-band + the "only grow when saturated" rule mean the window settles at the discovered-safe level during idle instead of drifting to `cap` and then bursting — no sawtooth on a capacity-limited server.
+
+### Update cadence must be decoupled from the scan cadence (review refinement)
+
+**Do NOT drive `update()` off `maybeScan`'s scan cadence.** `tickMovementPhase` zeroes `scanTickCounter` on every chunk-boundary crossing (`LodRequestManager.java:152`), and `maybeScan` returns `-1` until the counter reaches 20 (`SpiralScanner.java:64`). So under continuous fast movement — elytra, boats, `/tp`-spam, crossing a chunk more than once per second — the scan cadence never fires and an update tied to it would **freeze the window**: it stops both growing (can't recover when server load clears) and shrinking (the #32 back-off can't engage) for the whole trip. That's the same starvation the review flags as D2 for the timeout sweep, and a frozen adaptive window is worse than a frozen sweep because it's a persistent wrong throughput ceiling. (Note: server disk congestion is *global* — a small window is still the correct learned rate wherever the player moves — so the harm is the loss of *adaptation*, not a wrong value per se.)
+
+**Fix:** run `update()` on its own tick counter incremented once per client tick in `tickScanPhase`, firing every `TICKS_PER_SECOND`, independent of whether `maybeScan` fired. Movement does not gate `tickScanPhase`, so the window keeps adapting while moving; a decode-backpressure halt returns *before* `tickScanPhase` (`LodRequestManager.java:117`), so the window correctly freezes during a halt (no sends → no signals to act on). This is the same decoupling the review's P3 wants for the timeout sweep — the sweep can move onto the identical counter, either here or in P3.
+
+### Initial constants (all soak-validated in Task 6; none admin-facing)
+
+| Constant | Initial value | Rationale |
+|----------|---------------|-----------|
+| `MIN` (floor) | `max(4, cap/16)` (=8 at cap 128) | never fully stall; keep a responsive trickle |
+| `MD` (decrease factor) | `0.7` | gentler than halving — higher utilization, less oscillation, still responsive |
+| `AI` (increase step) | `max(8, cap/8)` (=16 at cap 128) | recover from a decrease in a few seconds (~64→128 in 4 cycles) |
+| `threshold` (decrease trigger) | `max(2, window/16)` | ignore 1–2 stray/aliased bounces (dedup `ts≤0`); react to sustained congestion |
+| initial / reset window | `cap` | start optimistic; healthy servers never leave the cap |
+
+`MD` and `threshold` are dimensionless; `MIN` and `AI` derive from `cap` → self-scaling.
+
+### Why it stays responsive
+
+- Starts at `cap`; a healthy server sees zero bounces so the window never leaves `cap` (== today).
+- Unlike `skipNextScan`, scanning **never stops** — a shrunk window keeps discovering positions at a reduced budget, so the moment capacity frees the client is already offering into it.
+- `AI` recovers a post-congestion cut in a few seconds.
+- `MIN` keeps a small trickle even under total saturation, so a transient overload doesn't lock the client out.
+
+### Known limitations (v1, documented not fixed)
+
+- **Recovery from the floor is ~seconds, not instant.** After a cut to `MIN`, climbing back to `cap` at `+AI`/second is a deliberate AIMD trade for smoothness vs the old skip-then-snap-back. `AI` is the tuning knob (Task 6 soak); acceptable because congestion that drove the cut is usually still present.
+- **Dedup-bounce false-shrink near `MIN`.** `threshold` floors at 2, and the `rate-limited` signal aliases benign cross-player dedup (`ts≤0`) bounces (review C2). On a server with heavy clustered dedup churn, ≥2 aliased bounces/second could hold the window below `cap` with no real slot/pool pressure. The dead-band handles the common case at the cap; the clean fix is review **P1** (split the `rate-limited` signal by cause and feed only slot-full/pool-capacity bounces into `onRateLimited`). Until P1 lands, this is a known, bounded false-throttle — the window still floors at `MIN`, never zero.
+- **Grow is suppressed while the budget is scaled below the window.** The grow signal (`windowLimited`) only fires when `drainQueue` fills the gate, which needs the scan to queue more than `window` positions. During vanilla-load or decode-pressure the budget (`window×4 × those scales`) can fall below `window`, so the window can't grow back until those scales relax. This is usually correct (those periods genuinely want throttling) but means post-teleport recovery into fresh terrain can lag until vanilla finishes streaming.
+
+### Retirements (subsumed by the window)
+
+- **`skipNextScan`** — the one-scan global skip is fully subsumed: the window is a finer, continuous global backoff that keeps scanning. Delete the field, `noteRateLimited`, the skip branch in `maybeScan` (`SpiralScanner.java:29,46-48,67-70`), `clearSkipNextScan` (`:230-231`), the `reset()` clear (`:204`), and the two call sites (`LodRequestManager.java:444,467`). Its ~8 `SpiralScannerTest` cases are replaced by the window's unit tests.
+- **The disconnected 4× budget base** — folded onto the window (`budget = window*4`), so `BUDGET_MULTIPLIER` now over-provisions relative to the *live* target instead of a static constant that never bounded anything (review finding A2). The multiplier itself stays.
+
+**Kept (orthogonal — not backoff):** the per-position `retry` mark (addressing: a bounced position still must be re-requested), decode-queue pressure (client-side backpressure for a different bottleneck), vanilla-load scaling, and the 10 s timeout retry.
+
+---
+
+## Tasks
+
+### Task 1: `AdaptiveConcurrencyWindow` (pure unit, no MC deps)
+**Files:** Create `fabric/src/main/java/dev/vox/lss/networking/client/AdaptiveConcurrencyWindow.java`; Test `fabric/src/test/java/dev/vox/lss/networking/client/AdaptiveConcurrencyWindowTest.java`.
+**Produces:** `AdaptiveConcurrencyWindow(int cap)`; `int current()`; `void onRateLimited()`; `void noteWindowLimited()`; `void update()` (applies AIMD, resets signals); `void reset()` (→ cap); constants derived from cap.
+
+- [ ] Write failing tests: (a) starts at cap; (b) `update()` with no signals holds; (c) `noteWindowLimited()` + no bounces → `+AI` up to cap, clamped; (d) sustained bounces (≥ threshold) → `×MD` down to MIN, clamped; (e) below-threshold stray bounces → hold (dead-band); (f) `reset()` → cap; (g) signals reset each `update()`.
+- [ ] Run — fail (class absent).
+- [ ] Implement the class with the constants above.
+- [ ] Run — pass.
+- [ ] Commit.
+
+### Task 2: Drain gate uses the window
+**Files:** Modify `LodRequestManager.java` (field + `drainQueue` L234-265); Test `LodRequestManagerTest.java`.
+**Consumes:** Task 1. **Produces:** `LodRequestManager` owns a `syncWindow`, initialized from session config; `drainQueue` gates sync on `syncWindow.current()` and calls `noteWindowLimited()` when the sync gate blocks.
+
+- [ ] Failing test: with the window forced low, `drainQueue` admits only `window` sync requests and flags window-limited; gen path unchanged.
+- [ ] Run — fail.
+- [ ] Add the `syncWindow` field (init in the session-config handler); replace `maxSyncConcurrency` (L238/254) with `syncWindow.current()`; call `syncWindow.noteWindowLimited()` on the sync-gate skip branch.
+- [ ] Run — pass; run full `LodRequestManagerTest` (update any pinned static-128 expectation deliberately).
+- [ ] Commit.
+
+### Task 3: Feed the congestion signal + evaluate on an independent 1 s counter
+**Files:** Modify `LodRequestManager.java` (`onRateLimited` L443, `tickScanPhase` L198-206, `onDimensionChange` L467, `flushCache` L493-502); Test `LodRequestManagerTickTest.java`.
+**Consumes:** Task 2.
+
+- [ ] Failing test: a sync rate-limited increments the window's congestion signal; a gen rate-limited does not; `update()` fires once per second **even when the scan cadence is starved by continuous movement** (reset the scan counter every tick and assert the window still updates); dimension change AND `flushCache` reset the window to cap.
+- [ ] Run — fail.
+- [ ] In `onRateLimited`: classify the bounce **before** `removeByPosition` clears the entry (L450) — gen iff `InFlightTracker.isGeneration(pos)` (add it; the `generationPositions` set already exists); call `syncWindow.onRateLimited()` only for sync bounces (untracked → treat as sync). Remove the `scanner.noteRateLimited()` call.
+- [ ] In `tickScanPhase`: increment a dedicated `windowUpdateCounter` every tick and call `syncWindow.update()` every `TICKS_PER_SECOND`, **independent of `maybeScan`'s return** (so movement's scan-counter resets can't freeze it; a decode halt still freezes it correctly by returning before `tickScanPhase`). Do NOT gate it on `scanned >= 0`.
+- [ ] In `onDimensionChange`: replace `scanner.clearSkipNextScan()` with `syncWindow.reset()`.
+- [ ] In `flushCache`: add `syncWindow.reset()` alongside `scanner.reset()` (parity — a `/lsslod clearcache` must not carry a shrunk window across the flush).
+- [ ] Run — pass.
+- [ ] Commit.
+
+### Task 4: Scan budget tracks the window
+**Files:** Modify `SpiralScanner.java` (`maybeScan` signature + L75) and its caller `LodRequestManager.tickScanPhase`; Test `SpiralScannerTest.java`.
+**Consumes:** Tasks 1-3.
+
+- [ ] Failing test: with an explicit window arg, `budget == window * BUDGET_MULTIPLIER` (update the existing `budgetBoundsQueuedPositions` harness to pass a window).
+- [ ] Run — fail.
+- [ ] Add an `int syncWindow` parameter to `maybeScan`; use it at L75 (`budget = syncWindow * BUDGET_MULTIPLIER`) instead of the session-config read. `LodRequestManager` passes `this.syncWindow.current()`. Update the `fireScan`/`fireScanFull` test harness to thread the window.
+- [ ] Leave the gen sub-cap `genCap = generationConcurrencyLimitPerPlayer() * BUDGET_MULTIPLIER` (L111) reading the static config value, and add a one-line comment there noting generation is deliberately un-windowed in v1 (mirrors the kept static gen drain gate).
+- [ ] Run — pass.
+- [ ] Commit.
+
+### Task 5: Keep scanning during continuous movement (the root of the freeze)
+**Files:** Modify `LodRequestManager.java` (`tickMovementPhase` L152); Tests `SpiralScannerTest.java` (the reset matrix ~L539-557), `LodRequestManagerTickTest.java` (the CL-002 first-tick quirk ~L98-117).
+**Consumes:** none (independent of the window, but complementary — land together so movement-loading is regulated by the window).
+
+**Why:** `tickMovementPhase` calls `scanner.resetScanCounter()` (L152), which zeros both `confirmedRing` AND the 20-tick scan cadence (`SpiralScanner.java:207-210`). Because movement zeros the cadence on every chunk crossing, crossing faster than once per second (elytra/boats/`/tp`) means the cadence never reaches 20 and **no scan ever fires** — the observed "no LOD loads while moving fast." The cadence-zero half is a debounce that buys nothing (the cadence already caps scans at 1/s) and costs everything (total freeze under fast travel). The scanner already has `resetConfirmedRing()` (L221) which re-surveys from ring 0 *without* touching the cadence — its own javadoc notes it exists precisely so a recurring trigger "would [not] otherwise debounce scans back indefinitely." Use it for movement.
+
+**Impact:** a moving player now scans at the normal 1/s rate, re-surveying nearest-first, so nearby LODs load continuously while travelling (best-effort; the far ring lags fast movement, which is the correct priority). This adds sustained request/serve/bandwidth load for moving players (today it's zero) — bounded by the per-player caps and regulated by the adaptive window (Tasks 1-4), which is why they ship together. Bonus: it also un-starves the 10 s timeout sweep, which rides the same cadence (review D2). The dirty-broadcast path keeps `resetScanCounter()` (out of scope).
+
+- [ ] Failing test: with the scan counter reset every tick (simulating continuous movement), assert a scan still fires within ~20 ticks (today it never does). Update `SpiralScannerTest.movementResetZeroesConfirmedRingRestartsCadenceAndKeepsMarks` to reflect that the *movement path* now preserves the cadence (repoint the direct `resetScanCounter()` unit assertion to the dirty-broadcast path, which still uses it).
+- [ ] Run — fail.
+- [ ] In `tickMovementPhase` (L152): replace `this.scanner.resetScanCounter()` with `this.scanner.resetConfirmedRing()`.
+- [ ] Update the CL-002 first-tick quirk test (`LodRequestManagerTickTest` ~L111-117): a player joining off (0,0) no longer has its primed tick-1 scan cancelled by the movement branch — assert the first scan now fires (the ~1s join delay is removed, a bonus).
+- [ ] Run — pass; run full Tier 1.
+- [ ] Commit.
+
+### Task 6: Retire `skipNextScan`
+**Files:** Modify `SpiralScanner.java` (delete field/methods/branch L29,46-48,67-70,204,230-231); `LodRequestManager.java` (L444 already removed in Task 3; confirm L467 replaced); delete the `skipNextScan` cases in `SpiralScannerTest.java`.
+**Consumes:** Tasks 3-4.
+
+- [ ] Delete `skipNextScan`, `noteRateLimited`, `clearSkipNextScan`, the `maybeScan` skip branch, and the `reset()` clear.
+- [ ] Delete the now-obsolete `SpiralScannerTest` skip cases (L317, L395-412, L528-530, L548, L576-582, L606) and any `noteRateLimited` use in the fuzz test (L816 → drive backoff via the window instead, or drop that line's bounce simulation).
+- [ ] Run full Tier 1 (`:fabric:test -x runGameTest -x runClientGameTest`) — pass.
+- [ ] Commit.
+
+### Task 7: Soak validation (convergence + responsiveness + movement-loading)
+**Files:** Use existing `scripts/soak-scenarios/rate-limit-storm.json` and `teleport-prune.json`; add a client instrumentation probe for the window if useful.
+**Consumes:** Tasks 1-6.
+
+- [ ] Run `./scripts/soak.sh rate-limit-storm` (Fabric) and confirm: the window shrinks under the storm, no conservation-law violation, and recovers toward cap after the storm ends (add a window gauge to client snapshots if the report needs it).
+- [ ] Run `./scripts/soak.sh fresh-backfill` and confirm steady-state throughput is not regressed vs a baseline run (healthy server → window stays at cap).
+- [ ] Run `./scripts/soak.sh teleport-prune` and confirm a moving/teleporting client keeps loading LODs (columns received > 0 during movement) without re-triggering saturation.
+- [ ] Tune `MD`/`AI`/`threshold` only if the soak shows oscillation or slow recovery; record final values in `AdaptiveConcurrencyWindow`.
+- [ ] Commit any tuning.
+
+### Task 8: Docs
+- [ ] Update `CLAUDE.md` client-side section (`SpiralScanner`/`LodRequestManager` bullets) to describe the adaptive window, that `skipNextScan` is gone, and that movement no longer freezes scanning.
+- [ ] Update `docs/planning/backpressure-review.md`: P5 status → implemented; note D3 (stacked reactions) resolved and D2 (scan-cadence starvation) resolved for movement.
+- [ ] Add release notes (Performance): "Client now adapts its request rate to the server's capacity, reducing wasted retries under load" and "LOD chunks now keep loading while moving quickly (previously fast travel could suspend LOD loading entirely)."
+- [ ] Commit.
+
+---
+
+## Test surface summary
+- **New:** `AdaptiveConcurrencyWindowTest` (the control law).
+- **Changed:** `LodRequestManagerTest` / `LodRequestManagerTickTest` (drain gate + signal + reset), `SpiralScannerTest` (budget base now window-driven; harness threads a window).
+- **Deleted:** the `SpiralScannerTest` `skipNextScan` cases.
+- **Tier 3** (`LSSClientGameTests`) exercises the live client loop end-to-end and should pass unchanged (window starts at cap; the gametest server doesn't saturate).
+
+## Risks & mitigations
+- **`SpiralScannerTest` blast radius** — the budget tests and skip tests are the main churn; contained to one file, mostly deletions + a harness param. Mitigation: Task 4/5 are separate commits so the budget-fold and the skip-retirement can be reviewed independently.
+- **Over-backoff from aliased bounces** — the `rate-limited` signal aliases four server causes (review C2). Mitigated by the `threshold` dead-band (ignores 1–2 stray dedup bounces) without needing a wire-level cause split. If soak shows spurious backoff, raising the threshold is the knob (internal).
+- **Under-utilization / oscillation** — mitigated by `MD=0.7` (gentle) + the cwnd-limited grow rule; Task 6 validates and tunes.
+- **Pinned behavior change** — `TwoPlayerGameTests` bandwidth fairness and any `LodRequestManager` test asserting a static 128 ceiling must be updated deliberately, not worked around.
+
+## Explicitly out of scope (documented, not done)
+- A `genWindow` for the generation path (low-volume; gen has its own caps).
+- Splitting the `rate-limited` wire signal by cause (review P1) — the dead-band makes it good enough for this loop; P1 is the clean fix for the near-`MIN` false-shrink limitation above and remains a separate observability win.
+- **Shrinking `BUDGET_MULTIPLIER` (review A2 / cleanup B1).** Reviewed and deliberately NOT done here: the 4× is the mid-period slot-refill reservoir and now auto-scales with the window (level vs refill-headroom are different jobs); shrinking it risks under-utilization on *healthy* servers, so it's separate throughput/RTT tuning, not this plan.
+- **Simplifying the `maxSendPerTick` drip / `MIN_SEND_PER_TICK` (review B6).** Under the window the drip is effectively a constant-16 burst cap, but it's orthogonal burst-smoothing that interacts with healthy-server throughput — a separate cleanup, not retuned here.
+- **Deleting `RequestQueue`'s dead timestamp column (review P4).** Real dead code, but it has three extra `SpiralScannerTest` assertions (L592/653/699) that verify scan-time ts-queuing correctness, unrelated to backoff. Bundling that refactor would muddy review; keep it as its own PR (paired with P1 as the review sequenced it).
+- Any server-side change — this is the client-side complement to PR #34's server-side capacity gate.

--- a/fabric/src/main/java/dev/vox/lss/networking/client/AdaptiveConcurrencyWindow.java
+++ b/fabric/src/main/java/dev/vox/lss/networking/client/AdaptiveConcurrencyWindow.java
@@ -1,0 +1,79 @@
+package dev.vox.lss.networking.client;
+
+/**
+ * AIMD congestion window for the client's in-flight sync-request ceiling.
+ *
+ * <p>Replaces the static per-player sync cap: it starts at the server-advertised cap and
+ * self-tunes to the server's actual sustainable throughput — a multiplicative decrease when
+ * the client sees sustained rate-limiting, and an additive increase while it is saturating the
+ * window without pushback (the TCP "cwnd-limited" rule: grow only when more capacity would
+ * actually be used). Evaluated once per second by the caller.
+ *
+ * <p>On a healthy server (no rate-limiting) the window sits pinned at the cap, so steady-state
+ * behavior is identical to the old static ceiling. Constants derive from the cap so raising the
+ * server cap needs no client retune; all are validated/tuned by the soak harness.
+ *
+ * <p>Not thread-safe — client-tick-thread only.
+ */
+final class AdaptiveConcurrencyWindow {
+
+    /** Multiplicative decrease factor on a congestion cycle (gentle: high utilization, low oscillation). */
+    private static final float DECREASE_FACTOR = 0.7f;
+
+    private final int cap;
+    private final int min;
+    private final int increaseStep;
+
+    private int window;
+    private int rateLimitedThisCycle;
+    private boolean windowLimitedThisCycle;
+
+    AdaptiveConcurrencyWindow(int cap) {
+        this.cap = Math.max(1, cap);
+        // Floor scales with the cap but can never exceed it (cap may be as low as 1).
+        this.min = Math.min(this.cap, Math.max(4, this.cap / 16));
+        this.increaseStep = Math.max(8, this.cap / 8);
+        this.window = this.cap;
+    }
+
+    /** Current in-flight sync ceiling. */
+    int current() {
+        return this.window;
+    }
+
+    /** Signal: a sync request was rate-limited this cycle (congestion). */
+    void onRateLimited() {
+        this.rateLimitedThisCycle++;
+    }
+
+    /** Signal: the drain gate blocked a send because the window was full (saturation). */
+    void noteWindowLimited() {
+        this.windowLimitedThisCycle = true;
+    }
+
+    /** Apply one AIMD step and reset the per-cycle signals. Call once per second. */
+    void update() {
+        // Dead-band: ignore a stray bounce or two (the rate-limited signal aliases benign
+        // cross-player dedup bounces) but react to sustained congestion. Scales with the window
+        // so a large cap isn't twitchy; floors at 2 so a small window still reacts.
+        int threshold = Math.max(2, this.window / 16);
+        if (this.rateLimitedThisCycle >= threshold) {
+            this.window = Math.max(this.min, Math.round(this.window * DECREASE_FACTOR));
+        } else if (this.windowLimitedThisCycle) {
+            this.window = Math.min(this.cap, this.window + this.increaseStep);
+        }
+        this.rateLimitedThisCycle = 0;
+        this.windowLimitedThisCycle = false;
+    }
+
+    /** Reset to the full cap (fresh session / dimension change / cache flush). */
+    void reset() {
+        this.window = this.cap;
+        this.rateLimitedThisCycle = 0;
+        this.windowLimitedThisCycle = false;
+    }
+
+    // Test/diagnostics accessors
+    int cap() { return this.cap; }
+    int min() { return this.min; }
+}

--- a/fabric/src/main/java/dev/vox/lss/networking/client/InFlightTracker.java
+++ b/fabric/src/main/java/dev/vox/lss/networking/client/InFlightTracker.java
@@ -52,6 +52,11 @@ class InFlightTracker {
         return this.generationPositions.size();
     }
 
+    /** Whether an in-flight position is a generation request (ts==0). Query before removal. */
+    boolean isGeneration(long position) {
+        return this.generationPositions.contains(position);
+    }
+
     /**
      * Sweep all timed-out requests, removing them from tracking and reporting each evicted
      * position. Callers MUST mark evictions for retry: while a position is in flight the

--- a/fabric/src/main/java/dev/vox/lss/networking/client/LodRequestManager.java
+++ b/fabric/src/main/java/dev/vox/lss/networking/client/LodRequestManager.java
@@ -61,9 +61,16 @@ public class LodRequestManager {
     // Expanding ring scanner (owns scan cadence + budget policy)
     private final SpiralScanner scanner = new SpiralScanner();
 
+    // Adaptive in-flight sync ceiling (AIMD): replaces the static advertised cap so the client
+    // converges to the server's sustainable throughput instead of re-offering peak pressure.
+    // Created per session from the advertised cap; drives both the drain gate and the scan budget.
+    private AdaptiveConcurrencyWindow syncWindow = new AdaptiveConcurrencyWindow(1);
+    private int windowUpdateCounter;
+
     public void onSessionConfig(SessionConfigS2CPayload config, String serverAddress) {
         this.sessionConfig = config;
         this.serverAddress = serverAddress;
+        this.syncWindow = new AdaptiveConcurrencyWindow(config.syncOnLoadConcurrencyLimitPerPlayer());
         resetRequestState();
         this.lastDimension = null;
         this.cacheLoaded = false;
@@ -149,7 +156,12 @@ public class LodRequestManager {
             this.metrics.pruneRttStampsOutOfRange(playerCx, playerCz, pruneDistance);
             this.lastChunkX = playerCx;
             this.lastChunkZ = playerCz;
-            this.scanner.resetScanCounter();
+            // resetConfirmedRing (NOT resetScanCounter): re-survey from the innermost ring after
+            // moving, but leave the scan cadence running. resetScanCounter zeros the cadence too,
+            // and since movement fires it every chunk crossing, fast travel (elytra/boats/tp) would
+            // reset it faster than it can reach 20 ticks and no scan would ever fire — LODs would
+            // stop loading entirely while moving. The dirty-broadcast path still uses resetScanCounter.
+            this.scanner.resetConfirmedRing();
         }
     }
 
@@ -195,7 +207,7 @@ public class LodRequestManager {
      */
     int tickScanPhase(int playerCx, int playerCz, int viewDistance, int columnQueueSize,
                       IntSupplier missingVanilla) {
-        int scanned = this.scanner.maybeScan(playerCx, playerCz, viewDistance,
+        int scanned = this.scanner.maybeScan(playerCx, playerCz, viewDistance, this.syncWindow.current(),
                 columnQueueSize, haltThreshold(), missingVanilla,
                 this.columns, this.tracker::isInFlight, this.queue);
         if (scanned >= 0) {
@@ -204,6 +216,15 @@ public class LodRequestManager {
             }
             // Timeout sweep: evict stale requests on the scan cadence (even if scan skipped).
             sweepTimeouts();
+        }
+        // Adaptive window: evaluate once per second on an INDEPENDENT counter, NOT the scan
+        // cadence — continuous movement resets the scan counter every chunk crossing, which
+        // would otherwise freeze the window (never grow, never back off) for the whole trip.
+        // A decode-backpressure halt returns before this phase, correctly freezing the window
+        // (no sends → no signals to act on).
+        if (++this.windowUpdateCounter >= LSSConstants.TICKS_PER_SECOND) {
+            this.windowUpdateCounter = 0;
+            this.syncWindow.update();
         }
         return scanned;
     }
@@ -235,7 +256,7 @@ public class LodRequestManager {
         long now = System.nanoTime();
         boolean generationEnabled = this.sessionConfig.generationEnabled();
         int maxGenConcurrency = this.sessionConfig.generationConcurrencyLimitPerPlayer();
-        int maxSyncConcurrency = this.sessionConfig.syncOnLoadConcurrencyLimitPerPlayer();
+        int maxSyncConcurrency = this.syncWindow.current();
         int count = 0;
 
         while (count < maxToSend && this.queue.hasNext()) {
@@ -251,7 +272,11 @@ public class LodRequestManager {
             // Per-type concurrency check — skip if this type is full, try next
             boolean isGen = ts == 0;
             if (isGen && this.tracker.generationCount() >= maxGenConcurrency) { this.queue.skip(); continue; }
-            if (!isGen && (this.tracker.size() - this.tracker.generationCount()) >= maxSyncConcurrency) { this.queue.skip(); continue; }
+            if (!isGen && (this.tracker.size() - this.tracker.generationCount()) >= maxSyncConcurrency) {
+                this.syncWindow.noteWindowLimited(); // saturated: wanted to send but the window is full → eligible to grow
+                this.queue.skip();
+                continue;
+            }
 
             this.queue.skip();
             this.sendPositionBuffer[count] = pos;
@@ -441,8 +466,12 @@ public class LodRequestManager {
     }
 
     public void onRateLimited(long packed) {
-        this.scanner.noteRateLimited(); // backoff regardless of tracking (pre-v16 set skipNextScan outside the gate)
-        if (!this.tracker.isInFlight(packed)) {
+        // Feed the adaptive window only on a SYNC bounce (generation keeps its own static caps).
+        // Classify BEFORE removeByPosition clears the entry; an untracked bounce defaults to sync.
+        boolean tracked = this.tracker.isInFlight(packed);
+        boolean gen = tracked && this.tracker.isGeneration(packed);
+        if (!gen) this.syncWindow.onRateLimited();
+        if (!tracked) {
             this.metrics.discardRttStamp(packed); // untracked terminal answer: stamp is dead (see onColumnNotGenerated)
             this.metrics.recordRateLimited();
             return;
@@ -464,7 +493,7 @@ public class LodRequestManager {
         resetRequestState();
         this.queue.clear();
         this.scanner.resetScanCounter();
-        this.scanner.clearSkipNextScan();
+        this.syncWindow.reset(); // fresh dimension: re-probe capacity optimistically from the cap
         this.cacheLoaded = true;
         startAsyncCacheLoad(newDimension);
     }
@@ -499,6 +528,7 @@ public class LodRequestManager {
         resetRequestState();
         this.queue.clear();
         this.scanner.reset();
+        this.syncWindow.reset(); // parity with scanner.reset(): don't carry a shrunk window across a flush
     }
 
     // --- Test seams ---
@@ -509,6 +539,7 @@ public class LodRequestManager {
     InFlightTracker trackerForTest() { return this.tracker; }
     RequestQueue queueForTest() { return this.queue; }
     SpiralScanner scannerForTest() { return this.scanner; }
+    AdaptiveConcurrencyWindow syncWindowForTest() { return this.syncWindow; }
 
     /** tick() derives this from the client level; tests set it directly. */
     void setLastDimensionForTest(ResourceKey<Level> dimension) { this.lastDimension = dimension; }

--- a/fabric/src/main/java/dev/vox/lss/networking/client/SpiralScanner.java
+++ b/fabric/src/main/java/dev/vox/lss/networking/client/SpiralScanner.java
@@ -26,7 +26,6 @@ class SpiralScanner {
     private int scanRing = 0;
     private int scanTickCounter = LSSConstants.TICKS_PER_SECOND - 1; // starts at max so first scan fires immediately on join
     private int missingVanillaChunks = Integer.MAX_VALUE;
-    private boolean skipNextScan;
 
     // Last scan budget tracking
     private int lastBudget;
@@ -42,10 +41,11 @@ class SpiralScanner {
         this.sessionConfig = sessionConfig;
     }
 
-    /** A rate-limited response arrived — back off by skipping the next scan. */
-    void noteRateLimited() {
-        this.skipNextScan = true;
+    /** The server-advertised sync cap the adaptive window starts from (diagnostics/tests). */
+    int configuredSyncCap() {
+        return this.sessionConfig.syncOnLoadConcurrencyLimitPerPlayer();
     }
+
 
     /**
      * Advance the scan cadence and, when it fires, run a budgeted ring scan that writes
@@ -56,7 +56,7 @@ class SpiralScanner {
      * @return -1 when the cadence did not fire this tick; otherwise the number of queued
      *         positions (0 for a skipped or empty scan)
      */
-    int maybeScan(int playerCx, int playerCz, int viewDistance,
+    int maybeScan(int playerCx, int playerCz, int viewDistance, int syncWindow,
                   int columnQueueSize, int columnQueueHaltThreshold,
                   IntSupplier missingVanilla,
                   ColumnStateMap columns, LongPredicate isInFlight,
@@ -64,15 +64,12 @@ class SpiralScanner {
         if (++this.scanTickCounter < LSSConstants.TICKS_PER_SECOND) return -1;
         this.scanTickCounter = 0;
 
-        if (this.skipNextScan) {
-            this.skipNextScan = false;
-            return 0;
-        }
-
         this.missingVanillaChunks = missingVanilla.getAsInt();
 
-        // Compute scan budget: base × queue-pressure-scale × vanilla-load-scale
-        int budget = this.sessionConfig.syncOnLoadConcurrencyLimitPerPlayer() * BUDGET_MULTIPLIER;
+        // Compute scan budget: base × queue-pressure-scale × vanilla-load-scale. The base tracks
+        // the adaptive in-flight window (not the static cap), so a shrunk window also stops
+        // discovering positions it can't send — no wasted classify work under backoff.
+        int budget = syncWindow * BUDGET_MULTIPLIER;
         if (columnQueueSize > 0) {
             budget = Math.max(1, Math.round(budget * Math.max(0f, 1f - (float) columnQueueSize / columnQueueHaltThreshold)));
         }
@@ -108,6 +105,8 @@ class SpiralScanner {
         queue.ensureCapacity(budget);
         int count = 0;
 
+        // Generation is deliberately un-windowed in v1 (low-volume, its own server caps), so
+        // its scan sub-cap keeps reading the static config value — mirrors the static gen drain gate.
         int genCap = this.sessionConfig.generationConcurrencyLimitPerPlayer() * BUDGET_MULTIPLIER;
 
         int[] chunkCoords = new int[2];
@@ -201,7 +200,6 @@ class SpiralScanner {
         this.missingVanillaChunks = Integer.MAX_VALUE;
         this.cachedVoxyDistance = -1;
         this.voxyDistanceStaleness = 0;
-        this.skipNextScan = false;
     }
 
     void resetScanCounter() {
@@ -220,15 +218,6 @@ class SpiralScanner {
      */
     void resetConfirmedRing() {
         this.confirmedRing = 0;
-    }
-
-    /**
-     * A dimension change discards any pending rate-limit backoff — it belonged to the old
-     * dimension's load. Deliberately NOT part of resetScanCounter(): the movement and
-     * dirty-broadcast paths call that too and must preserve the backoff.
-     */
-    void clearSkipNextScan() {
-        this.skipNextScan = false;
     }
 
     int getEffectiveLodDistance() {

--- a/fabric/src/test/java/dev/vox/lss/networking/client/AdaptiveConcurrencyWindowTest.java
+++ b/fabric/src/test/java/dev/vox/lss/networking/client/AdaptiveConcurrencyWindowTest.java
@@ -1,0 +1,115 @@
+package dev.vox.lss.networking.client;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Pins the AIMD control law of the client's adaptive sync in-flight window: starts at cap,
+ * holds in the dead-band, grows only when saturated without pushback, shrinks on sustained
+ * congestion, and clamps to [min, cap]. A healthy server (no bounces) must keep the window at
+ * cap so steady-state behavior equals the old static ceiling.
+ */
+class AdaptiveConcurrencyWindowTest {
+
+    private static final int CAP = 200; // the server default advertised via SessionConfig
+
+    private static void cycles(AdaptiveConcurrencyWindow w, int n, int bouncesPerCycle, boolean saturated) {
+        for (int i = 0; i < n; i++) {
+            for (int b = 0; b < bouncesPerCycle; b++) w.onRateLimited();
+            if (saturated) w.noteWindowLimited();
+            w.update();
+        }
+    }
+
+    @Test
+    void startsAtCap() {
+        var w = new AdaptiveConcurrencyWindow(CAP);
+        assertEquals(CAP, w.current());
+    }
+
+    @Test
+    void healthyServerHoldsAtCap() {
+        var w = new AdaptiveConcurrencyWindow(CAP);
+        // Saturated every cycle but never bounced → already at cap, additive increase clamps.
+        cycles(w, 20, 0, true);
+        assertEquals(CAP, w.current(), "no rate-limiting → window never leaves the cap");
+    }
+
+    @Test
+    void deadBandHoldsOnStrayBounces() {
+        var w = new AdaptiveConcurrencyWindow(CAP);
+        // threshold at cap 200 = max(2, 12) = 12; a single stray bounce/cycle must not shrink.
+        cycles(w, 20, 1, true);
+        assertEquals(CAP, w.current(), "sub-threshold stray bounces stay in the dead-band");
+    }
+
+    @Test
+    void sustainedCongestionShrinksMultiplicativelyToFloor() {
+        var w = new AdaptiveConcurrencyWindow(CAP);
+        int before = w.current();
+        cycles(w, 1, 50, true); // well over threshold
+        assertEquals(Math.round(before * 0.7f), w.current(), "one congestion cycle = one ×0.7 cut");
+        // Drive to the floor and confirm it clamps, never zero.
+        cycles(w, 50, 50, true);
+        assertEquals(w.min(), w.current(), "shrinks to min and clamps there");
+        assertTrue(w.min() >= 1, "floor is never zero — always a trickle");
+    }
+
+    @Test
+    void growsAdditivelyOnlyWhenSaturatedWithoutPushback() {
+        var w = new AdaptiveConcurrencyWindow(CAP);
+        cycles(w, 50, 50, true);              // crush to floor
+        int floor = w.current();
+        cycles(w, 1, 0, true);               // one clean, saturated cycle
+        assertEquals(floor + Math.max(8, CAP / 8), w.current(), "additive increase of one step");
+        assertTrue(w.current() > floor);
+    }
+
+    @Test
+    void doesNotGrowWhenNotWindowLimited() {
+        var w = new AdaptiveConcurrencyWindow(CAP);
+        cycles(w, 50, 50, true);   // to floor
+        int floor = w.current();
+        cycles(w, 5, 0, false);    // clean cycles but NOT saturating the window
+        assertEquals(floor, w.current(), "idle (not window-limited) → no growth, no drift up to cap");
+    }
+
+    @Test
+    void recoversToCapOverSeveralCleanSaturatedCycles() {
+        var w = new AdaptiveConcurrencyWindow(CAP);
+        cycles(w, 50, 50, true);   // to floor
+        assertTrue(w.current() < CAP);
+        cycles(w, 100, 0, true);   // sustained clean saturation
+        assertEquals(CAP, w.current(), "recovers to and clamps at cap");
+    }
+
+    @Test
+    void signalsResetEachCycle() {
+        var w = new AdaptiveConcurrencyWindow(CAP);
+        // Bounces below threshold in a cycle must not accumulate across cycles into a cut.
+        for (int i = 0; i < 100; i++) {
+            w.onRateLimited(); // 1 per cycle, below threshold
+            w.update();
+        }
+        assertEquals(CAP, w.current(), "per-cycle bounce counter resets — sub-threshold never accumulates");
+    }
+
+    @Test
+    void resetReturnsToCap() {
+        var w = new AdaptiveConcurrencyWindow(CAP);
+        cycles(w, 50, 50, true);
+        assertTrue(w.current() < CAP);
+        w.reset();
+        assertEquals(CAP, w.current());
+    }
+
+    @Test
+    void tinyCapClampsMinToCap() {
+        var w = new AdaptiveConcurrencyWindow(1); // MIN_CONCURRENCY_LIMIT
+        assertEquals(1, w.current());
+        assertEquals(1, w.min(), "min never exceeds a tiny cap");
+        cycles(w, 10, 50, true);
+        assertEquals(1, w.current(), "window stays at 1 — can't go below a cap of 1");
+    }
+}

--- a/fabric/src/test/java/dev/vox/lss/networking/client/LodRequestManagerTest.java
+++ b/fabric/src/test/java/dev/vox/lss/networking/client/LodRequestManagerTest.java
@@ -83,7 +83,7 @@ class LodRequestManagerTest {
         var columns = new ColumnStateMap();
         var queue = new RequestQueue();
         for (int i = 0; i < LSSConstants.TICKS_PER_SECOND + 1; i++) {
-            int n = scanner.maybeScan(0, 0, 2, 0, 1000, () -> 0, columns, pos -> false, queue);
+            int n = scanner.maybeScan(0, 0, 2, scanner.configuredSyncCap(), 0, 1000, () -> 0, columns, pos -> false, queue);
             if (n >= 0) return n;
         }
         throw new AssertionError("scan cadence never fired");
@@ -107,7 +107,7 @@ class LodRequestManagerTest {
      * the lod distance, so a fired scan queues nothing — pure cadence observation.
      */
     private int maybeScanOnce() {
-        return manager.scannerForTest().maybeScan(0, 0, 64, 0, 1000, () -> 0,
+        return manager.scannerForTest().maybeScan(0, 0, 64, manager.scannerForTest().configuredSyncCap(), 0, 1000, () -> 0,
                 manager.columnsForTest(), pos -> false, manager.queueForTest());
     }
 
@@ -163,14 +163,17 @@ class LodRequestManagerTest {
     }
 
     @Test
-    void untrackedRateLimitedStillLatchesScanBackoff() {
+    void untrackedRateLimitedFeedsTheWindowWithoutSkippingScans() {
         manager.onSessionConfig(config(4, 100, 100, true), "lss-test");
 
-        manager.onRateLimited(POS); // untracked — the gate returns early, but backoff latches first
+        manager.onRateLimited(POS); // untracked — the gate returns early, but the window still counts it
 
+        // Unlike the retired skipNextScan backoff, a bounce no longer skips a scan: the adaptive
+        // window IS the backoff and needs sustained bounces to shrink (tested in
+        // AdaptiveConcurrencyWindowTest / windowShrinksUnderSustainedBounces).
         var scanner = manager.scannerForTest();
-        assertEquals(0, fireScan(scanner), "scan after a rate-limited response is skipped");
-        assertTrue(fireScan(scanner) > 0, "backoff lasts exactly one scan");
+        assertTrue(fireScan(scanner) > 0, "a single rate-limited response no longer skips the next scan");
+        assertEquals(1, manager.getTotalRateLimited());
     }
 
     // ---- dirty crossing an in-flight first serve forces a re-request (#11) ----

--- a/fabric/src/test/java/dev/vox/lss/networking/client/LodRequestManagerTickTest.java
+++ b/fabric/src/test/java/dev/vox/lss/networking/client/LodRequestManagerTickTest.java
@@ -107,74 +107,92 @@ class LodRequestManagerTickTest {
     }
 
     @Test
-    void firstTickOutsideChunkOriginCancelsThePrimedImmediateScan() {
-        // Pinned quirk (tickMovementPhase javadoc): lastChunkX/Z init to (0,0), so a player
-        // joining anywhere else takes the movement branch on tick 1, which restarts the primed
-        // join cadence — the first scan lands a full window after join instead of immediately.
+    void firstTickOutsideChunkOriginKeepsThePrimedImmediateScan() {
+        // Movement now re-surveys via resetConfirmedRing WITHOUT resetting the cadence, so a
+        // player joining off (0,0) — which takes the first-tick movement branch — keeps the
+        // primed immediate scan instead of eating a ~1s cadence-restart delay (the old CL-002 quirk).
         var overworld = dim("overworld");
 
         manager.tickWithContext(10, 0, overworld, 0, 0, () -> 0);
-        assertEquals(0, sent.size(), "tick-1 scan cancelled by the first-tick movement branch");
-        assertEquals(0, manager.getQueueRemaining());
-
-        for (int i = 0; i < LSSConstants.TICKS_PER_SECOND - 2; i++) {
-            manager.tickWithContext(10, 0, overworld, 0, 0, () -> 0);
-        }
-        assertEquals(0, sent.size(), "still inside the restarted cadence window");
-
-        manager.tickWithContext(10, 0, overworld, 0, 0, () -> 0); // 20th tick after the reset
-        assertEquals(1, sent.size(), "the first scan fires one full window after join");
+        assertEquals(1, sent.size(), "the primed first scan fires on tick 1 even when joining off (0,0)");
     }
 
-    // ---- cadence starvation under boundary crossing (CL-003, pinned) ----
+    // ---- movement no longer starves scans or the timeout sweep (CL-003, was a pinned coupling) ----
 
     @Test
-    void chunkBoundaryCrossingFasterThanTheCadenceStarvesScansAndSweepsUntilRest() {
+    void chunkBoundaryCrossingDoesNotStarveScansOrTheTimeoutSweep() {
         var overworld = dim("overworld");
         var tracker = manager.trackerForTest();
         long stale = PositionUtil.packPosition(5, 5);
         tracker.markPending(stale, System.nanoTime() - 11_000L * LSSConstants.NANOS_PER_MS, false);
 
-        // Cross a chunk boundary every 10 ticks for 60 ticks: each crossing restarts the cadence.
+        // Cross a chunk boundary every 10 ticks for 60 ticks. Movement re-surveys (resetConfirmedRing)
+        // but no longer resets the cadence, so the 20-tick scan clock — and the timeout sweep that
+        // rides it — keep firing while moving.
         for (int i = 0; i < 60; i++) {
             int cx = 1 - (i / 10) % 2;
             manager.tickWithContext(cx, 0, overworld, 0, 0, () -> 0);
         }
-        assertEquals(0, sent.size(),
-                "pinned coupling: scans starve while boundary crossings outpace the 20-tick cadence");
-        assertTrue(tracker.isInFlight(stale),
-                "pinned coupling: the timeout sweep rides the scan cadence, so it starves too");
-
-        // Resting at the last position recovers both within one window.
-        for (int i = 0; i < LSSConstants.TICKS_PER_SECOND; i++) {
-            manager.tickWithContext(0, 0, overworld, 0, 0, () -> 0);
-        }
-        assertFalse(tracker.isInFlight(stale), "rest restores the timeout sweep");
+        assertFalse(sent.isEmpty(),
+                "scans keep firing while moving fast — LODs load during travel (the fix)");
+        assertFalse(tracker.isInFlight(stale),
+                "the timeout sweep keeps running too — the stale request is evicted mid-travel");
         assertTrue(manager.columnsForTest().hasRetries(), "the evicted request is marked for retry");
-        assertFalse(sent.isEmpty(), "rest restores scanning");
     }
 
-    // ---- backoff-skipped scans still sweep; backoffs never compound (CL-004 tick leg) ----
+    // ---- rate-limited responses no longer skip scans (CL-004: the window is the backoff) ----
 
     @Test
-    void backoffSkippedScanStillSweepsTimeoutsAndBackoffsDoNotCompound() {
+    void rateLimitedResponsesNoLongerSkipTheScanAndTheSweepStillRuns() {
         var overworld = dim("overworld");
         var tracker = manager.trackerForTest();
         long stale = PositionUtil.packPosition(5, 5);
         tracker.markPending(stale, System.nanoTime() - 11_000L * LSSConstants.NANOS_PER_MS, false);
-        manager.onRateLimited(PositionUtil.packPosition(40, 40)); // latch backoff...
-        manager.onRateLimited(PositionUtil.packPosition(41, 40)); // ...twice (must not compound)
+        manager.onRateLimited(PositionUtil.packPosition(40, 40));
+        manager.onRateLimited(PositionUtil.packPosition(41, 40));
 
-        manager.tickWithContext(0, 0, overworld, 0, 0, () -> 0); // primed cadence fires: skipped scan
-        assertEquals(0, sent.size(), "the backoff skipped the scan");
-        assertEquals(0, manager.getQueueRemaining());
-        assertFalse(tracker.isInFlight(stale), "a skipped scan must still run the timeout sweep");
+        manager.tickWithContext(0, 0, overworld, 0, 0, () -> 0); // primed cadence fires
+        assertFalse(sent.isEmpty(),
+                "a rate-limited response no longer skips the scan — the adaptive window is the backoff");
+        assertFalse(tracker.isInFlight(stale), "the timeout sweep runs on the scan cadence");
         assertTrue(manager.columnsForTest().hasRetries());
+    }
+
+    // ---- adaptive window: independent update cadence + sync-only signal ----
+
+    @Test
+    void syncWindowShrinksUnderSustainedBouncesEvenWhileMovingFast() {
+        var overworld = dim("overworld");
+        var window = manager.syncWindowForTest();
+        int cap = window.current();
+
+        // Continuous movement (cross a boundary every tick) AND sustained sync rate-limiting for
+        // one cadence window. The window update rides an INDEPENDENT counter, so it must still fire
+        // (and shrink) despite the scan cadence being reset on every crossing — the whole point of
+        // decoupling it from maybeScan.
+        for (int i = 0; i < LSSConstants.TICKS_PER_SECOND; i++) {
+            for (int b = 0; b < 10; b++) manager.onRateLimited(PositionUtil.packPosition(1000 + b, i));
+            manager.tickWithContext(i % 2, 0, overworld, 0, 0, () -> 0);
+        }
+        assertTrue(window.current() < cap,
+                "window shrank under sustained bounces even though continuous movement starved the scan cadence");
+    }
+
+    @Test
+    void generationBouncesDoNotShrinkTheSyncWindow() {
+        var overworld = dim("overworld");
+        var window = manager.syncWindowForTest();
+        int cap = window.current();
 
         for (int i = 0; i < LSSConstants.TICKS_PER_SECOND; i++) {
+            for (int b = 0; b < 10; b++) {
+                long p = PositionUtil.packPosition(2000 + b, i);
+                manager.trackerForTest().markPending(p, System.nanoTime(), true); // in-flight GENERATION
+                manager.onRateLimited(p); // classified gen before removal → must NOT feed the sync window
+            }
             manager.tickWithContext(0, 0, overworld, 0, 0, () -> 0);
         }
-        assertFalse(sent.isEmpty(), "two rate-limited responses cost one skipped scan, not two");
+        assertEquals(cap, window.current(), "generation bounces must not move the sync window");
     }
 
     // ---- per-tick send cap derivation (CL-021) ----

--- a/fabric/src/test/java/dev/vox/lss/networking/client/SpiralScannerTest.java
+++ b/fabric/src/test/java/dev/vox/lss/networking/client/SpiralScannerTest.java
@@ -46,7 +46,7 @@ class SpiralScannerTest {
                                 int columnQueueHaltThreshold, int missingVanilla,
                                 ColumnStateMap columns, RequestQueue queue) {
         for (int i = 0; i < LSSConstants.TICKS_PER_SECOND + 1; i++) {
-            int n = s.maybeScan(CX, CZ, viewDistance, columnQueueSize, columnQueueHaltThreshold,
+            int n = s.maybeScan(CX, CZ, viewDistance, s.configuredSyncCap(), columnQueueSize, columnQueueHaltThreshold,
                     () -> missingVanilla, columns, pos -> false, queue);
             if (n >= 0) return n;
         }
@@ -67,7 +67,7 @@ class SpiralScannerTest {
                                     int columnQueueSize, int columnQueueHaltThreshold, int missingVanilla,
                                     ColumnStateMap columns, LongPredicate isInFlight, RequestQueue queue) {
         for (int i = 0; i < LSSConstants.TICKS_PER_SECOND + 1; i++) {
-            int n = s.maybeScan(cx, cz, viewDistance, columnQueueSize, columnQueueHaltThreshold,
+            int n = s.maybeScan(cx, cz, viewDistance, s.configuredSyncCap(), columnQueueSize, columnQueueHaltThreshold,
                     () -> missingVanilla, columns, isInFlight, queue);
             if (n >= 0) return n;
         }
@@ -311,15 +311,6 @@ class SpiralScannerTest {
     }
 
     @Test
-    void rateLimitBackoffSkipsExactlyOneScan() {
-        var s = scanner(4, 100, 100);
-        var queue = new RequestQueue();
-        s.noteRateLimited();
-        assertEquals(0, fireScan(s, 2, new ColumnStateMap(), queue), "backoff scan queues nothing");
-        assertTrue(fireScan(s, 2, new ColumnStateMap(), queue) > 0, "next scan proceeds normally");
-    }
-
-    @Test
     void budgetBoundsQueuedPositions() {
         // budget = syncLimit * 4 = 8 with a huge annulus
         var s = scanner(16, 2, 100);
@@ -390,26 +381,26 @@ class SpiralScannerTest {
     }
 
     @Test
-    void backoffSurvivesMovementResetButNotDimensionChangeClear() {
-        // Movement and dirty-broadcast paths call resetScanCounter() alone; it must
-        // preserve a pending rate-limit backoff.
+    void movementReSurveysFromRingZeroWithoutStoppingScans() {
+        // The movement path calls resetConfirmedRing() (NOT resetScanCounter): it re-surveys
+        // from the innermost ring but leaves the scan cadence running, so LODs keep loading
+        // while moving. A confirmed disc is re-walked on the next steady scan.
+        var columns = new ColumnStateMap();
+        seedSatisfied(columns, 3, 4);
         var s = scanner(4, 100, 100);
         var queue = new RequestQueue();
-        s.noteRateLimited();
-        s.resetScanCounter();
-        assertEquals(0, fireScan(s, 2, new ColumnStateMap(), queue),
-                "backoff still pending after a movement-path reset");
-        assertTrue(fireScan(s, 2, new ColumnStateMap(), queue) > 0, "next scan proceeds normally");
+        assertEquals(0, fireScan(s, 2, columns, queue));
+        assertEquals(5, s.getConfirmedRing(), "precondition: disc confirmed");
 
-        // The dimension-change path additionally calls clearSkipNextScan() — the backoff
-        // belonged to the old dimension's load and must be discarded.
-        s = scanner(4, 100, 100);
-        queue = new RequestQueue();
-        s.noteRateLimited();
-        s.resetScanCounter();
-        s.clearSkipNextScan();
-        assertTrue(fireScan(s, 2, new ColumnStateMap(), queue) > 0,
-                "dimension change discards the pending backoff");
+        long retried = ringPos(4, 0);
+        columns.markRetry(retried);
+        s.resetConfirmedRing(); // the production movement primitive
+
+        assertEquals(0, s.getConfirmedRing(), "movement re-survey zeroes ring confirmation");
+        assertTrue(columns.hasRetries(), "movement preserves in-range retry marks");
+        assertEquals(1, fireScan(s, 2, columns, queue),
+                "the very next scan re-walks the disc and queues the retry — no cadence stall");
+        assertEquals(List.of(retried), drain(queue));
     }
 
     @Test
@@ -466,12 +457,12 @@ class SpiralScannerTest {
 
         // A fresh scanner is primed: the very FIRST cadence call must fire (join burst),
         // not the 20th — the fireScan helper used elsewhere cannot tell those apart.
-        int first = s.maybeScan(CX, CZ, 2, 0, 1000, () -> 0, new ColumnStateMap(), pos -> false, queue);
+        int first = s.maybeScan(CX, CZ, 2, s.configuredSyncCap(), 0, 1000, () -> 0, new ColumnStateMap(), pos -> false, queue);
         assertEquals(8 * 3 + 8 * 4, first, "first maybeScan on a fresh scanner must fire and queue the annulus");
 
         // reset() (new session / flushCache) re-primes: again a single call fires.
         s.reset();
-        int afterReset = s.maybeScan(CX, CZ, 2, 0, 1000, () -> 0, new ColumnStateMap(), pos -> false, queue);
+        int afterReset = s.maybeScan(CX, CZ, 2, s.configuredSyncCap(), 0, 1000, () -> 0, new ColumnStateMap(), pos -> false, queue);
         assertEquals(8 * 3 + 8 * 4, afterReset, "first maybeScan after reset() must fire immediately");
     }
 
@@ -519,24 +510,13 @@ class SpiralScannerTest {
         assertEquals(5, s2.getConfirmedRing(), "confirmation caps at lodDistance+1 when vd overshoots");
     }
 
-    // ---- backoff latch is level-triggered (CL-008) ----
+    // ---- reset matrix: dirty-broadcast / dimension change / disconnect (CL-016) ----
 
     @Test
-    void multipleRateLimitNoticesBeforeOneScanConsumeExactlyOneSkip() {
-        var s = scanner(4, 100, 100);
-        var queue = new RequestQueue();
-        s.noteRateLimited();
-        s.noteRateLimited();
-        s.noteRateLimited();
-        assertEquals(0, fireScan(s, 2, new ColumnStateMap(), queue), "one skipped scan");
-        assertTrue(fireScan(s, 2, new ColumnStateMap(), queue) > 0,
-                "level-triggered latch: N rate-limit notices cost exactly one skip, not N");
-    }
-
-    // ---- reset matrix: movement / dimension change / disconnect (CL-016) ----
-
-    @Test
-    void movementResetZeroesConfirmedRingRestartsCadenceAndKeepsMarks() {
+    void resetScanCounterZeroesConfirmedRingRestartsCadenceAndKeepsMarks() {
+        // resetScanCounter (the dirty-broadcast path) zeroes ring confirmation AND restarts the
+        // 20-tick cadence — a debounce. (The movement path no longer uses it; see
+        // movementReSurveysFromRingZeroWithoutStoppingScans.)
         var columns = new ColumnStateMap();
         seedSatisfied(columns, 3, 4);
         var s = scanner(4, 100, 100);
@@ -545,16 +525,14 @@ class SpiralScannerTest {
         assertEquals(5, s.getConfirmedRing(), "precondition: disc confirmed");
         long retried = ringPos(4, 0);
         columns.markRetry(retried);
-        s.noteRateLimited();
 
-        s.resetScanCounter(); // the movement path (LodRequestManager.tick: prune + resetScanCounter)
+        s.resetScanCounter();
 
         assertEquals(0, s.getConfirmedRing(),
-                "movement reset must zero ring confirmation (SpiralScanner.resetScanCounter)");
-        assertEquals(-1, s.maybeScan(CX, CZ, 2, 0, 1000, () -> 0, columns, p -> false, queue),
+                "resetScanCounter must zero ring confirmation");
+        assertEquals(-1, s.maybeScan(CX, CZ, 2, s.configuredSyncCap(), 0, 1000, () -> 0, columns, p -> false, queue),
                 "resetScanCounter restarts the full 20-tick cadence (a debounce, unlike reset())");
-        assertTrue(columns.hasRetries(), "movement preserves in-range retry marks");
-        assertEquals(0, fireScan(s, 2, columns, queue), "pending rate-limit backoff survives movement");
+        assertTrue(columns.hasRetries(), "reset preserves in-range retry marks");
         assertEquals(1, fireScan(s, 2, columns, queue), "next scan re-walks the disc and queues the retry");
         assertEquals(List.of(retried), drain(queue));
     }
@@ -573,19 +551,17 @@ class SpiralScannerTest {
         assertEquals(4, fireScan(s, 2, columns, queue), "precondition: gen-capped scan");
         assertEquals(4, s.getLastGenQueued());
         columns.markRetry(ringPos(4, 0));
-        s.noteRateLimited();
 
         // The production dimension-change sequence (LodRequestManager.onDimensionChange).
         columns.clear();
         queue.clear();
         s.resetScanCounter();
-        s.clearSkipNextScan();
 
         assertEquals(0, s.getConfirmedRing(), "dimension change must zero ring confirmation");
         assertFalse(columns.hasRetries(), "map clear drops retry marks with the old dimension");
         assertFalse(queue.hasNext(), "the old dimension's queued requests are dropped");
         int n = fireScan(s, 2, columns, queue);
-        assertEquals(8 * 3 + 8 * 4, n, "no backoff pending; the full annulus re-requests as unknown");
+        assertEquals(8 * 3 + 8 * 4, n, "the full annulus re-requests as unknown");
         assertEquals(0, s.getLastGenQueued(), "scan stats recomputed for the fresh scan, never stale");
         assertEquals(n, s.getLastSyncQueued(), "everything re-asks sync after the map clear");
         while (queue.hasNext()) {
@@ -603,7 +579,6 @@ class SpiralScannerTest {
         assertEquals(0, fireScan(s, 2, columns, queue));
         assertEquals(5, s.getConfirmedRing(), "precondition: disc confirmed");
         columns.markRetry(ringPos(3, 5));
-        s.noteRateLimited();
 
         // Production disconnect→rejoin: disconnect() clears only the tracker; the new
         // session's onSessionConfig runs resetRequestState() (columns.clear) + scanner.reset().
@@ -612,9 +587,9 @@ class SpiralScannerTest {
 
         assertEquals(0, s.getConfirmedRing(), "reset() zeroes ring confirmation");
         assertFalse(columns.hasRetries(), "session state cleared with the map");
-        int first = s.maybeScan(CX, CZ, 2, 0, 1000, () -> 0, columns, p -> false, queue);
+        int first = s.maybeScan(CX, CZ, 2, s.configuredSyncCap(), 0, 1000, () -> 0, columns, p -> false, queue);
         assertEquals(8 * 3 + 8 * 4, first,
-                "reset() primes the cadence: the rejoin scan fires on the FIRST call with the backoff discarded");
+                "reset() primes the cadence: the rejoin scan fires on the FIRST call");
     }
 
     // ---- lod distance shrink/grow (CL-015) ----
@@ -813,7 +788,7 @@ class SpiralScannerTest {
                     inFlight.add(pos);
                     int roll = rng.nextInt(100);
                     if (roll < 30) { inFlight.remove(pos); columns.onReceived(pos, 1_000L + cyc); }
-                    else if (roll < 45) { inFlight.remove(pos); columns.markRetry(pos); s.noteRateLimited(); }
+                    else if (roll < 45) { inFlight.remove(pos); columns.markRetry(pos); } // rate-limited bounce: retry mark (window backoff is tested separately)
                     else if (roll < 60) { inFlight.remove(pos); columns.onNotGenerated(pos); }
                     else if (roll < 70) { inFlight.remove(pos); columns.onUpToDate(pos); }
                     else if (roll < 85) { scheduled.add(new Scheduled(pos, cyc + 1 + rng.nextInt(3), false)); }


### PR DESCRIPTION
Closes the open-loop client-pacing gap behind #32 — the client-side complement to the server-side disk-capacity gate in #34. Grows out of the backpressure review (`docs/planning/backpressure-review.md`, proposal **P5**); full plan in `docs/planning/client-backoff-plan.md`.

## The problem

The client re-offered peak request pressure every second no matter how much the server rate-limited it: a `rate-limited` response only triggered a one-scan skip (`skipNextScan`) and **never lowered the request rate**. So against a saturated disk it kept hammering — the client half of the #32 saturation.

## The fix

**`AdaptiveConcurrencyWindow` (AIMD).** The in-flight sync ceiling starts at the server-advertised cap and self-tunes: shrinks ×0.7 on sustained sync rate-limiting, grows additively while saturating the window without pushback (the TCP "cwnd-limited" rule — only grow when more capacity would be used). It drives **both** the drain-gate in-flight limit and the scan-budget base, so a shrunk window also stops discovering positions it can't send (no wasted `classify` work). On a healthy server it stays pinned at the cap — steady-state behavior is unchanged. **No new config knobs**: it self-tunes under the existing cap and its constants derive from it.

**Evaluated on an independent 1s counter, not the scan cadence.** Continuous movement resets the scan counter every chunk crossing (`SpiralScanner.java:64`), so tying the update to it would *freeze* the window during fast travel. The independent counter keeps it adapting while moving; a decode-backpressure halt still freezes it correctly (no sends → no signals).

**Keep scanning while moving (the "no LODs while moving fast" report).** `tickMovementPhase` now re-surveys via `resetConfirmedRing` instead of `resetScanCounter`, so movement no longer zeroes the scan cadence — fast travel (elytra/boats/`/tp`) keeps loading nearby LODs instead of suspending them entirely. As a bonus this un-starves the 10s timeout sweep, which rode the same cadence (review finding D2). The dirty-broadcast path keeps `resetScanCounter`.

**Retired `skipNextScan`** — the one-scan global pause is fully subsumed by the window, which keeps scanning at a reduced budget rather than pausing.

## Scope / safety
- **Client-internal pacing only — no protocol change**, so it needs no version bump and is independent of #34 (the window reads whatever cap the server advertises). Branched off `main`; composes with #34 which changes different files.
- Deliberately deferred (documented in the plan): a `genWindow`, splitting the `rate-limited` signal by cause (review P1 — the clean fix for the near-`MIN` dedup false-shrink), and shrinking `BUDGET_MULTIPLIER`.

## Tests
- New `AdaptiveConcurrencyWindowTest` pins the control law (start-at-cap, dead-band, cwnd-limited grow, multiplicative shrink to floor, reset, tiny-cap clamp).
- New integration tests: the window shrinks under sustained bounces **even under continuous movement** (proving the update is decoupled from the starved scan cadence), and generation bounces don't move the sync window.
- Rewrote the pinned `skipNextScan` / movement-starvation tests to assert the new behavior (movement keeps scanning; a bounce no longer skips a scan).
- Local: Tier 1 (Fabric + Paper), Tier 2, Tier 3 all green. Soak (`rate-limit-storm`) validation running.

🤖 Generated with [Claude Code](https://claude.com/claude-code)