### PR TITLE
docs: link XANTHA's Modrinth profile in the redistribution grant

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ All builds are on [Modrinth](https://modrinth.com/plugin/lod-server-support) —
 
 This mod is MIT-licensed — redistribution with attribution is welcome, and modpacks
 can reference the official Modrinth project directly. Per Modrinth's reupload policy:
-**XANTHA ([modrinth.com/mod/voxy-server-side](https://modrinth.com/mod/voxy-server-side))
+**[XANTHA](https://modrinth.com/user/XANTHA) on [Voxy Server Side](https://modrinth.com/plugin/voxy-server-side)
 has the copyright holder's explicit permission to distribute this mod, and derivatives
 of it, on Modrinth.**
 


### PR DESCRIPTION
Updates the redistribution-permission statement to link XANTHA's confirmed official Modrinth profile (https://modrinth.com/user/XANTHA) and the voxy-server-side project page, replacing the bare project URL. Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)