### PR TITLE
docs: README — drop now-inaccurate "config paths" identity claim

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ All builds are on [Modrinth](https://modrinth.com/plugin/lod-server-support) —
 
 Since v0.7.0, every release is additionally published to the
 [Voxy Server Side](https://modrinth.com/plugin/voxy-server-side) Modrinth page. Both listings
-ship the **same mod** identical internals, networking protocol, and
-config paths; only the display name, description, and icon differ. Compatibility is total, you
-can join LSS servers with a VSS client and vice versa. 
+ship the **same mod** — identical internals and networking protocol; only the display name,
+description, and icon differ. Compatibility is total, you can join LSS servers with a VSS
+client and vice versa.
 
 ### Redistribution
 


### PR DESCRIPTION
The VSS/LSS compatibility note said the two builds have "identical … config paths". Since v0.7.1 the client config filename differs by brand (fresh VSS install → `vss-client-config.json`; server config path still shared), so this trims it to "identical internals and networking protocol" and tidies the sentence. Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)