### PR TITLE
fix: release.yml tag filter — '*+' is an invalid GitHub pattern

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,11 +2,12 @@ name: Release
 
 on:
   push:
-    # The +mc* exclusion keeps this MAIN-line workflow off support-line tags (v0.8.0+mc26.1
-    # etc.): a support tag mistakenly pushed onto a main commit would otherwise publish 26.2
-    # jars under a support-line name, with the +mc suffix corrupting -Pmod_version below.
-    # (The support branches' release.yml carry the mirror-image scoped triggers.)
-    tags: ['v*', '!v*+mc*']
+    # Deliberately the broad v* glob: GitHub's filter-pattern language treats '+' as a
+    # quantifier, so any pattern containing '*+' (e.g. '!v*+mc*') is INVALID and turns
+    # every push into a phantom failed run — worse, a real tag push would trigger NOTHING.
+    # The wrong-line protection lives in the guard step below instead, where '+' is
+    # literal shell text. (The support branches' release.yml scope the same way.)
+    tags: ['v*']
 
 jobs:
   release:
@@ -14,6 +15,16 @@ jobs:
     permissions:
       contents: write
     steps:
+      # A support-line tag (v0.8.0+mc26.1 etc.) mistakenly pushed onto a main commit must
+      # not publish: it would ship 26.2 jars under a support-line name, and the +mc suffix
+      # would corrupt -Pmod_version below. This cannot live in the on.push.tags filter —
+      # see the comment there.
+      - name: Refuse support-line tags
+        run: |
+          case "${GITHUB_REF_NAME}" in
+            *+mc*) echo "::error::${GITHUB_REF_NAME} is a support-line tag — the mainline release.yml must not publish it"; exit 1 ;;
+          esac
+
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0

--- a/paper/src/test/java/dev/vox/lss/paper/ReleaseWorkflowContractTest.java
+++ b/paper/src/test/java/dev/vox/lss/paper/ReleaseWorkflowContractTest.java
@@ -30,7 +30,11 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class ReleaseWorkflowContractTest {
 
     // ---- the line's expected values (the support branches carry their own flavors) ----
-    private static final String TRIGGER_LINE = "tags: ['v*', '!v*+mc*']";
+    // NOTE: GitHub's filter-pattern language treats '+' as a quantifier, so a pattern
+    // containing '*+' is INVALID — it phantom-fails every push and a real tag triggers
+    // NOTHING. The literal-'+' scoping must stay in shell (the guard step), never the glob.
+    private static final String TRIGGER_LINE = "tags: ['v*']";
+    private static final String GUARD_CASE_LINE = "*+mc*)";
     private static final String PREV_TAG_PIPELINE =
             "git tag -l 'v*' --sort=-v:refname | grep -v \"^${TAG}$\" | grep -v '+mc' | head -1 || true";
     private static final String LSS_MODRINTH_ID = "lKiXKLvv";
@@ -75,12 +79,26 @@ class ReleaseWorkflowContractTest {
     }
 
     @Test
-    void triggerExcludesSupportLineTags() {
-        // A support-line tag (v0.8.0+mc26.1 etc.) mistakenly pushed onto a main commit must
-        // not run this workflow: it would publish 26.2 jars under a support-line name, and
-        // ${GITHUB_REF_NAME#v} would feed the +mc suffix into -Pmod_version.
+    void triggerIsTheBroadGlobWithNoQuantifierConstruct() {
         assertTrue(releaseYml.contains(TRIGGER_LINE),
-                "release.yml must trigger on v* while excluding v*+mc* (" + TRIGGER_LINE + ")");
+                "release.yml must trigger on the plain v* glob (" + TRIGGER_LINE + ")");
+        assertFalse(Pattern.compile("tags:.*\\*\\+").matcher(releaseYml).find(),
+                "no tag filter may contain '*+' — GitHub treats '+' as a quantifier, the "
+                        + "pattern is invalid, and a real tag push would trigger NOTHING");
+    }
+
+    @Test
+    void guardStepRefusesSupportLineTags() {
+        // A support-line tag (v0.8.0+mc26.1 etc.) mistakenly pushed onto a main commit must
+        // not publish: it would ship 26.2 jars under a support-line name, and
+        // ${GITHUB_REF_NAME#v} would feed the +mc suffix into -Pmod_version. This lives in
+        // a shell guard because the on.push.tags filter cannot express a literal '+'.
+        String guard = stepBlock("- name: Refuse support-line tags");
+        assertTrue(guard.contains(GUARD_CASE_LINE) && guard.contains("exit 1"),
+                "the guard step must fail the run on any *+mc* tag");
+        assertTrue(releaseYml.indexOf("- name: Refuse support-line tags")
+                        < releaseYml.indexOf("- uses: actions/checkout"),
+                "the guard must be the FIRST step — before checkout, builds, or any publish");
     }
 
     @Test


### PR DESCRIPTION
GitHub's filter-pattern language treats `+` as a quantifier, so the `'!v*+mc*'` exclusion (added with the tri-line scoping in #51) made release.yml unparseable: every push to main created a phantom failed run, and **a real v0.8.0 tag would have triggered nothing** — the release would silently not publish. The support branches' `v*+mc26.1*`-style triggers carry the same bug (fixed on those branches directly).

- Trigger returns to the plain `v*` glob; the wrong-line protection becomes a first-step shell guard (`case "*+mc*" → exit 1`), where `+` is literal text.
- `ReleaseWorkflowContractTest` pins the plain glob, bans `*+` in any tag filter, and requires the guard step to precede checkout.

Verification: pushes of the broken file phantom-fail release.yml with zero jobs (runs 30236473350 on main, 30237087891 on support/mc26.1); the push of this fixed branch produced no release.yml run at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)