### PR TITLE
test: pin main's bounded MC range (FabricModJsonContractTest)

### DIFF
--- a/fabric/src/test/java/dev/vox/lss/FabricModJsonContractTest.java
+++ b/fabric/src/test/java/dev/vox/lss/FabricModJsonContractTest.java
@@ -1,0 +1,74 @@
+package dev.vox.lss;
+
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.io.StringReader;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Properties;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Main-line contract for {@code fabric.mod.json} + {@code gradle.properties}, read from
+ * the SOURCE tree (the fabric mirror of paper's
+ * {@code PluginYmlContractTest.apiVersionMatchesTheDevBundleMinecraftVersion} lockstep pin).
+ * The regression vector: the LOWER Minecraft bound is enforced by fabric-loader in every
+ * gametest launch, but the UPPER bound is caught by nothing at build time — and the mixins
+ * here are required:true over MC internals, so an unbounded range turns a future 26.3 into
+ * a hard mixin-apply crash instead of Loader's clean refusal (the v0.8.0 compat review's
+ * MAJOR). The support branches carry their own flavors of this test.
+ */
+class FabricModJsonContractTest {
+
+    // ---- the line's expected constants (each branch carries its own values) ----
+    // The trailing '-' makes the upper bound prerelease-EXCLUSIVE: Fabric semver sorts
+    // 26.3-rc below 26.3, so a bare '<26.3' would admit 26.3 prereleases — where the required
+    // mixins over MC internals hard-crash at apply (final compat review 2026-07-27).
+    private static final String EXPECTED_MINECRAFT_DEPENDS = ">=26.2 <26.3-";
+    private static final String EXPECTED_MINECRAFT_VERSION_PREFIX = "26.2";
+
+    private static JsonObject modJson;
+    private static Properties gradleProps;
+
+    @BeforeAll
+    static void load() throws Exception {
+        modJson = JsonParser.parseString(
+                Files.readString(locate("fabric/src/main/resources/fabric.mod.json"))).getAsJsonObject();
+        gradleProps = new Properties();
+        gradleProps.load(new StringReader(Files.readString(locate("gradle.properties"))));
+    }
+
+    /** Walks up from the working dir (fabric/ under Gradle, the repo root elsewhere). */
+    private static Path locate(String repoRelative) {
+        Path dir = Path.of("").toAbsolutePath();
+        for (int i = 0; i < 6 && dir != null; i++, dir = dir.getParent()) {
+            Path candidate = dir.resolve(repoRelative);
+            if (Files.exists(candidate)) return candidate;
+        }
+        throw new IllegalStateException("cannot locate " + repoRelative + " above " + Path.of("").toAbsolutePath());
+    }
+
+    @Test
+    void dependsMinecraftPinsThisLineBothWays() {
+        assertEquals(EXPECTED_MINECRAFT_DEPENDS,
+                modJson.getAsJsonObject("depends").get("minecraft").getAsString(),
+                "fabric.mod.json must pin the line's Minecraft range exactly — the upper "
+                        + "bound is what keeps this jar off incompatible newer lines");
+    }
+
+    @Test
+    void gradlePropertiesTargetsTheSameLine() {
+        String mc = gradleProps.getProperty("minecraft_version", "");
+        // equals-or-dot: a bare prefix match would also accept e.g. 26.10, which the
+        // depends range above would exclude — the two must move in lockstep.
+        assertTrue(mc.equals(EXPECTED_MINECRAFT_VERSION_PREFIX)
+                        || mc.startsWith(EXPECTED_MINECRAFT_VERSION_PREFIX + "."),
+                "gradle.properties minecraft_version (" + mc + ") must stay on the "
+                        + EXPECTED_MINECRAFT_VERSION_PREFIX + " line");
+    }
+}


### PR DESCRIPTION
Ports the support branches' fabric.mod.json contract test with main's values (`>=26.2 <26.3-` + gradle.properties lockstep) — closes the compat review's 'nothing pins the upper bound' gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)