### PR TITLE
fix: black boundary faces — serve sky-lit air sections + implicit-sky fill

### DIFF
--- a/fabric/src/main/java/dev/vox/lss/networking/client/ClientColumnProcessor.java
+++ b/fabric/src/main/java/dev/vox/lss/networking/client/ClientColumnProcessor.java
@@ -184,6 +184,7 @@ class ClientColumnProcessor {
 
     private void drainColumnQueue(ClientLevel level, int epoch) {
         drainColumnQueue(level.dimension(), level.getSectionsCount(), level.getMinSectionY(),
+                level.dimensionType().hasSkyLight(),
                 PalettedContainerFactory.create(level.registryAccess()),
                 (dimension, chunkX, chunkZ, columnData) ->
                         LSSApi.dispatchColumn(level, dimension, chunkX, chunkZ, columnData),
@@ -199,6 +200,7 @@ class ClientColumnProcessor {
      * poll, so a teardown mid-drain lets at most the already-polled column dispatch.
      */
     void drainColumnQueue(ResourceKey<Level> levelDimension, int levelSectionCount, int minSectionY,
+                          boolean hasSkyLight,
                           PalettedContainerFactory factory, ColumnDispatcher dispatcher, int epoch) {
         QueuedColumn queued;
         while (epoch == this.sessionEpoch && (queued = this.columnQueue.poll()) != null) {
@@ -219,6 +221,24 @@ class ClientColumnProcessor {
 
             try {
                 var sections = decodeSections(decompressed, levelSectionCount, factory);
+                if (ClientTraceLog.enabled()) {
+                    // Per-section light presence — the boundary-lighting instrument (black
+                    // leaf-face investigation 2026-07-27): [sectionY, hasBlockLight,
+                    // hasSkyLight, hasOnlyAir] per decoded section. Absent Ys are absent.
+                    var sb = new StringBuilder(64 + sections.length * 14);
+                    sb.append("\"pos\":[").append(payload.chunkX()).append(',')
+                            .append(payload.chunkZ()).append("],\"sections\":[");
+                    for (int i = 0; i < sections.length; i++) {
+                        var s = sections[i];
+                        if (i > 0) sb.append(',');
+                        sb.append('[').append(s.sectionY())
+                                .append(',').append(s.blockLight() != null ? 1 : 0)
+                                .append(',').append(s.skyLight() != null ? 1 : 0)
+                                .append(',').append(s.section().hasOnlyAir() ? 1 : 0).append(']');
+                    }
+                    sb.append(']');
+                    ClientTraceLog.event("col_light", sb.toString());
+                }
                 if (queued.resync()) {
                     // The client already held data here; the server sends the current column
                     // (which OMITS air sections) authoritatively. Fill every absent section-Y
@@ -226,6 +246,18 @@ class ClientColumnProcessor {
                     // cleared (WorldEdit clears, fully-emptied 0-section columns). Only on
                     // resync — a first serve had nothing, so absent == air == no-op.
                     sections = withAirFilledAbsentSections(sections, levelSectionCount, minSectionY, factory);
+                }
+                if (hasSkyLight) {
+                    // Implicit-sky fill (2026-07-27, black-boundary-faces fix): vanilla
+                    // stores sky layers only up to heightmap+1 — everything above is
+                    // IMPLICITLY full-bright, a rule the vanilla client resolves in its
+                    // light engine but a per-section wire cannot carry. Without this, a
+                    // consumer sampling the never-served air above/beside terrain (leaf
+                    // tops, cliff sides across a chunk border against a lower column)
+                    // reads light 0 and shades those faces black. Mirror vanilla's rule
+                    // client-side: every absent section ABOVE the column's top served
+                    // section becomes explicit all-air with full-bright sky.
+                    sections = withImplicitSkyAbove(sections, levelSectionCount, minSectionY, factory);
                 }
                 var columnData = new VoxelColumnData(sections, payload.columnTimestamp());
                 dispatcher.dispatch(payload.dimension(),
@@ -255,6 +287,47 @@ class ClientColumnProcessor {
      * until written — with null light layers (dark), consistent with the absent-means-all-zero
      * light default.
      */
+    /** One shared full-bright nibble array — consumers receive light layers READ-ONLY
+     *  (they already share the decoded per-column objects across all consumers). */
+    private static final byte[] FULL_BRIGHT_SKY = fullBrightNibbles();
+
+    private static byte[] fullBrightNibbles() {
+        byte[] b = new byte[2048];
+        java.util.Arrays.fill(b, (byte) 0xFF);
+        return b;
+    }
+
+    /**
+     * Append an all-air section with FULL-BRIGHT sky light for every absent section-Y
+     * ABOVE the column's top served section (up to the level top). Sky-lit dimensions
+     * only — the caller gates on {@code hasSkyLight}; below/among the served band nothing
+     * changes (unserved air there is dark air, which is correct). Resync's air-fill runs
+     * FIRST, so on resyncs the above-band sections it created with dark light are
+     * re-created here bright; order matters.
+     */
+    static VoxelColumnData.SectionData[] withImplicitSkyAbove(
+            VoxelColumnData.SectionData[] present, int levelSectionCount, int minSectionY,
+            PalettedContainerFactory factory) {
+        if (present.length == 0) return present;   // a CLEAR stays a clear
+        int top = Integer.MIN_VALUE;
+        for (var s : present) top = Math.max(top, s.sectionY());
+        int levelTop = minSectionY + levelSectionCount - 1;
+        if (top >= levelTop) return present;
+        var out = new java.util.ArrayList<VoxelColumnData.SectionData>(
+                present.length + (levelTop - top));
+        var byY = new java.util.HashMap<Integer, VoxelColumnData.SectionData>();
+        for (var s : present) byY.put(s.sectionY(), s);
+        out.addAll(java.util.Arrays.asList(present));
+        for (int y = top + 1; y <= levelTop; y++) {
+            var existing = byY.get(y);
+            if (existing != null) continue;
+            out.add(new VoxelColumnData.SectionData(y, new LevelChunkSection(factory),
+                    null, new DataLayer(FULL_BRIGHT_SKY)));
+        }
+        // replace any resync-filled DARK air sections above the served band with bright ones
+        return out.toArray(new VoxelColumnData.SectionData[0]);
+    }
+
     static VoxelColumnData.SectionData[] withAirFilledAbsentSections(
             VoxelColumnData.SectionData[] present, int levelSectionCount, int minSectionY,
             PalettedContainerFactory factory) {

--- a/fabric/src/main/java/dev/vox/lss/networking/server/NbtSectionSerializer.java
+++ b/fabric/src/main/java/dev/vox/lss/networking/server/NbtSectionSerializer.java
@@ -12,6 +12,8 @@ import net.minecraft.nbt.NbtOps;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.world.level.biome.Biome;
 import net.minecraft.world.level.biome.Biomes;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.chunk.LevelChunkSection;
 import net.minecraft.world.level.chunk.PalettedContainer;
@@ -97,13 +99,32 @@ final class NbtSectionSerializer {
             if (sectionY == Integer.MIN_VALUE) continue;
 
             byte[] blockLightData = sectionTag.getByteArray("BlockLight").orElse(EMPTY);
+            byte[] skyLightData = sectionTag.getByteArray("SkyLight").orElse(EMPTY);
             var result = parseSection(sectionTag, sectionY, blockStateCodec, biomeCodec,
-                    defaultBiome, biomeHolderMap, blockLightData);
+                    defaultBiome, biomeHolderMap, blockLightData, skyLightData);
             if (result != null) {
-                byte[] skyLightData = sectionTag.getByteArray("SkyLight").orElse(EMPTY);
                 parsed.add(new ParsedSection(sectionY, result, blockLightData, skyLightData));
             }
         }
+
+        // Boundary-light band (2026-07-27, black-boundary-faces fix): SKY-lit air sections
+        // are served only within one section of the column's CONTENT band — vanilla's own
+        // stored-light coverage (heightmap+1), matching the live path exactly (disk/live
+        // byte parity) — so a void/cleared column's ambient sky can never turn a
+        // zero-section CLEAR into a data column. BLOCK-lit air keeps its long-standing
+        // unconditional serve.
+        int minContent = Integer.MAX_VALUE, maxContent = Integer.MIN_VALUE;
+        for (var p : parsed) {
+            if (!p.section().hasOnlyAir()) {
+                minContent = Math.min(minContent, p.sectionY());
+                maxContent = Math.max(maxContent, p.sectionY());
+            }
+        }
+        final boolean noContent = minContent == Integer.MAX_VALUE;
+        final int lo = minContent - 1, hi = maxContent + 1;
+        parsed.removeIf(p -> p.section().hasOnlyAir()
+                && !(p.blockLight().length == 2048 && hasNonZeroNibble(p.blockLight()))
+                && (noContent || p.sectionY() < lo || p.sectionY() > hi));
 
         if (parsed.isEmpty()) return new byte[0];
 
@@ -169,14 +190,21 @@ final class NbtSectionSerializer {
             Codec<PalettedContainerRO<Holder<Biome>>> biomeCodec,
             Holder<Biome> defaultBiome,
             net.minecraft.core.IdMap<Holder<Biome>> biomeHolderMap,
-            byte[] blockLightData) {
+            byte[] blockLightData, byte[] skyLightData) {
 
         var blockStatesOpt = sectionTag.getCompound("block_states");
-        if (blockStatesOpt.isEmpty()) return null;
-
-        var blockStatesResult = blockStateCodec.parse(NbtOps.INSTANCE, blockStatesOpt.get());
-        var blockStates = blockStatesResult.result().orElse(null);
-        if (blockStates == null) return null;
+        PalettedContainer<BlockState> blockStates;
+        if (blockStatesOpt.isEmpty()) {
+            // Vanilla's light-only cap entries (heightmap+1) carry SkyLight but no
+            // block_states — exactly the boundary layers the fix serves. Build an all-air
+            // section for them; the air/light gate below decides whether it ships.
+            blockStates = new PalettedContainer<>(Blocks.AIR.defaultBlockState(),
+                    Strategy.createForBlockStates(Block.BLOCK_STATE_REGISTRY));
+        } else {
+            var blockStatesResult = blockStateCodec.parse(NbtOps.INSTANCE, blockStatesOpt.get());
+            blockStates = blockStatesResult.result().orElse(null);
+            if (blockStates == null) return null;
+        }
 
         PalettedContainerRO<Holder<Biome>> biomes;
         var optBiomes = sectionTag.getCompound("biomes");
@@ -197,7 +225,9 @@ final class NbtSectionSerializer {
         }
 
         if (section.hasOnlyAir()) {
-            if (blockLightData.length != 2048 || !hasNonZeroNibble(blockLightData)) {
+            boolean litByBlock = blockLightData.length == 2048 && hasNonZeroNibble(blockLightData);
+            boolean litBySky = skyLightData.length == 2048 && hasNonZeroNibble(skyLightData);
+            if (!litByBlock && !litBySky) {
                 return null;
             }
         }

--- a/fabric/src/main/java/dev/vox/lss/networking/server/SectionSerializer.java
+++ b/fabric/src/main/java/dev/vox/lss/networking/server/SectionSerializer.java
@@ -25,7 +25,9 @@ public final class SectionSerializer {
      * Serialize all non-air sections of a loaded chunk column into MC-native wire format.
      * Returns a {@link LoadedColumnData} with pre-serialized bytes.
      */
-    private record SectionInfo(int index, int sectionY, SectionPos sectionPos, DataLayer blLayer, boolean hasBlockLight) {}
+    private record SectionInfo(int index, int sectionY, SectionPos sectionPos,
+                               DataLayer blLayer, boolean hasBlockLight,
+                               DataLayer slLayer, boolean hasSkyLight) {}
 
     public static LoadedColumnData serializeColumn(ServerLevel level, LevelChunk chunk, int cx, int cz) {
         // One AntiXray-shim scope per COLUMN (not per section): section.write crashes under
@@ -38,8 +40,16 @@ public final class SectionSerializer {
         var sections = chunk.getSections();
         var lightEngine = level.getLightEngine();
         var blockLightListener = lightEngine.getLayerListener(LightLayer.BLOCK);
+        var skyLightListener = lightEngine.getLayerListener(LightLayer.SKY);
 
-        // First pass: collect non-air sections and cache block light results
+        // First pass: collect non-air sections and cache light results. Air-only sections
+        // WITH stored non-zero sky light are served too (2026-07-27, black-boundary-faces
+        // fix): vanilla's light grid extends one section past terrain, and those boundary
+        // air layers are exactly what lights the top/side faces of the terrain below/beside
+        // them at a chunk border. A consumer sampling a never-served neighbor section gets
+        // light 0 — leaves rendered black from one side. Fully-dark air (caves, deep
+        // enclosures) still skips: its layers are null/zero, so the serve set stays
+        // bounded to vanilla's own stored-light coverage (~1-2 extra sections per column).
         var includedSections = new java.util.ArrayList<SectionInfo>(sections.length);
         for (int i = 0; i < sections.length; i++) {
             var section = sections[i];
@@ -48,11 +58,31 @@ public final class SectionSerializer {
             var sectionPos = SectionPos.of(cx, sectionY, cz);
             var blLayer = blockLightListener.getDataLayerData(sectionPos);
             boolean hasBlockLight = blLayer != null && hasNonZeroData(blLayer);
+            var slLayer = skyLightListener.getDataLayerData(sectionPos);
+            boolean hasSkyLight = slLayer != null && hasNonZeroData(slLayer);
 
-            if (section.hasOnlyAir() && !hasBlockLight) continue;
+            if (section.hasOnlyAir() && !hasBlockLight && !hasSkyLight) continue;
 
-            includedSections.add(new SectionInfo(i, sectionY, sectionPos, blLayer, hasBlockLight));
+            includedSections.add(new SectionInfo(i, sectionY, sectionPos,
+                    blLayer, hasBlockLight, slLayer, hasSkyLight));
         }
+
+        // Band rule, same as the NBT path (disk/live byte parity): SKY-lit air serves only
+        // within one section of the content band — vanilla's own stored-light coverage —
+        // so a void/cleared column's ambient sky can never turn a zero-section CLEAR into
+        // a data column. BLOCK-lit air keeps its long-standing unconditional serve.
+        int minContent = Integer.MAX_VALUE, maxContent = Integer.MIN_VALUE;
+        for (var info : includedSections) {
+            if (!sections[info.index()].hasOnlyAir()) {
+                minContent = Math.min(minContent, info.sectionY());
+                maxContent = Math.max(maxContent, info.sectionY());
+            }
+        }
+        final boolean noContent = minContent == Integer.MAX_VALUE;
+        final int lo = minContent - 1, hi = maxContent + 1;
+        includedSections.removeIf(info -> sections[info.index()].hasOnlyAir()
+                && !info.hasBlockLight()
+                && (noContent || info.sectionY() < lo || info.sectionY() > hi));
 
         if (includedSections.isEmpty()) {
             return new LoadedColumnData(cx, cz, null, 0);
@@ -64,7 +94,6 @@ public final class SectionSerializer {
         var buf = new FriendlyByteBuf(Unpooled.buffer(sections.length * 1024));
         try {
             buf.writeVarInt(includedSections.size());
-            var skyLightListener = lightEngine.getLayerListener(LightLayer.SKY);
 
             for (var info : includedSections) {
                 var section = sections[info.index];
@@ -89,12 +118,10 @@ public final class SectionSerializer {
                     buf.writeBytes(info.blLayer.getData());
                 }
 
-                // Sky light
-                var slLayer = skyLightListener.getDataLayerData(info.sectionPos);
-                boolean hasSkyLight = slLayer != null && hasNonZeroData(slLayer);
-                buf.writeBoolean(hasSkyLight);
-                if (hasSkyLight) {
-                    buf.writeBytes(slLayer.getData());
+                // Sky light (cached from pass 1)
+                buf.writeBoolean(info.hasSkyLight);
+                if (info.hasSkyLight) {
+                    buf.writeBytes(info.slLayer.getData());
                 }
             }
 

--- a/fabric/src/test/java/dev/vox/lss/networking/client/ClientColumnProcessorTest.java
+++ b/fabric/src/test/java/dev/vox/lss/networking/client/ClientColumnProcessorTest.java
@@ -158,7 +158,7 @@ class ClientColumnProcessorTest {
     }
 
     private void drainNow() {
-        processor.drainColumnQueue(dim, LEVEL_SECTIONS, MIN_SECTION_Y, FACTORY, recordingDispatcher,
+        processor.drainColumnQueue(dim, LEVEL_SECTIONS, MIN_SECTION_Y, false, FACTORY, recordingDispatcher,
                 processor.sessionEpochForTest());
     }
 
@@ -218,7 +218,7 @@ class ClientColumnProcessorTest {
         var wire = sectionWire(1, 1);
         processor.offer(new VoxelColumnS2CPayload(3, 4, dim, 9L, wire), false);
         assertThrows(LinkageError.class, () -> processor.drainColumnQueue(dim, LEVEL_SECTIONS,
-                MIN_SECTION_Y, FACTORY,
+                MIN_SECTION_Y, false, FACTORY,
                 (d, cx, cz, data) -> { throw new LinkageError("boom"); },
                 processor.sessionEpochForTest()));
         assertEquals(List.of(new Report(dim, 3, 4)), reports,
@@ -289,6 +289,45 @@ class ClientColumnProcessorTest {
                 "disabled session must drop the backlog and release the backpressure signal");
     }
 
+    // ---- implicit-sky fill: absent air ABOVE the served band is full-bright (2026-07-27) ----
+
+    @Test
+    void implicitSkyFillAddsBrightAirAboveTheTopServedSection() {
+        // Vanilla stores sky layers only to heightmap+1; above is IMPLICITLY full-bright.
+        // Without the fill, faces sampling never-served air above/beside terrain (leaf
+        // tops, cliff sides at a chunk border against a lower column) shade black.
+        var present = new VoxelColumnData.SectionData[]{
+                new VoxelColumnData.SectionData(-4, new LevelChunkSection(FACTORY), null, null),
+                new VoxelColumnData.SectionData(-3, new LevelChunkSection(FACTORY), null, null)};
+        var filled = ClientColumnProcessor.withImplicitSkyAbove(present, LEVEL_SECTIONS, MIN_SECTION_Y, FACTORY);
+
+        var byY = new java.util.HashMap<Integer, VoxelColumnData.SectionData>();
+        for (var s : filled) byY.put(s.sectionY(), s);
+        assertEquals(java.util.Set.of(-4, -3, -2, -1), byY.keySet(),
+                "every absent Y above the top served section fills to the level top");
+        for (int y : new int[]{-2, -1}) {
+            var s = byY.get(y);
+            assertTrue(s.section().hasOnlyAir(), "fill sections are all-air");
+            assertNull(s.blockLight(), "no fabricated block light");
+            assertNotNull(s.skyLight(), "fill sections carry sky light");
+            for (byte b : s.skyLight().getData()) {
+                assertEquals((byte) 0xFF, b, "fill sky light is full-bright");
+            }
+        }
+        assertNull(byY.get(-4).skyLight(), "served sections are untouched");
+    }
+
+    @Test
+    void implicitSkyFillLeavesClearsAndFullColumnsAlone() {
+        assertEquals(0, ClientColumnProcessor.withImplicitSkyAbove(
+                        new VoxelColumnData.SectionData[0], LEVEL_SECTIONS, MIN_SECTION_Y, FACTORY).length,
+                "a zero-section CLEAR must stay a clear");
+        var full = new VoxelColumnData.SectionData[]{
+                new VoxelColumnData.SectionData(-1, new LevelChunkSection(FACTORY), null, null)};
+        assertSame(full, ClientColumnProcessor.withImplicitSkyAbove(full, LEVEL_SECTIONS, MIN_SECTION_Y, FACTORY),
+                "a column already serving the top section gains nothing");
+    }
+
     // ---- WS3 authoritative air-fill: a resync clears ghost terrain for absent sections ----
 
     @Test
@@ -317,13 +356,13 @@ class ClientColumnProcessorTest {
         byte[] wire = sectionWire(1, 1); // one section at Y=0
 
         processor.offer(new VoxelColumnS2CPayload(0, 0, dim, 5000L, wire), true); // resync
-        processor.drainColumnQueue(dim, LEVEL_SECTIONS, 0, FACTORY, recordingDispatcher,
+        processor.drainColumnQueue(dim, LEVEL_SECTIONS, 0, false, FACTORY, recordingDispatcher,
                 processor.sessionEpochForTest());
         assertEquals(LEVEL_SECTIONS, dispatches.get(dispatches.size() - 1).sectionCount(),
                 "a resync fills every absent section-Y with air (present + air = full level range)");
 
         processor.offer(new VoxelColumnS2CPayload(1, 1, dim, 5000L, wire), false); // first serve
-        processor.drainColumnQueue(dim, LEVEL_SECTIONS, 0, FACTORY, recordingDispatcher,
+        processor.drainColumnQueue(dim, LEVEL_SECTIONS, 0, false, FACTORY, recordingDispatcher,
                 processor.sessionEpochForTest());
         assertEquals(1, dispatches.get(dispatches.size() - 1).sectionCount(),
                 "a first serve dispatches only the carried section — no air-fill (absent == air == no-op)");
@@ -478,7 +517,7 @@ class ClientColumnProcessorTest {
             processor.reportUndispatched(manager);
             processor.offer(new VoxelColumnS2CPayload(4, 4, dim, 5000L, sectionWire(1, 1)), false);
         };
-        processor.drainColumnQueue(dim, LEVEL_SECTIONS, MIN_SECTION_Y, FACTORY, teardownMidDispatch, epoch);
+        processor.drainColumnQueue(dim, LEVEL_SECTIONS, MIN_SECTION_Y, false, FACTORY, teardownMidDispatch, epoch);
 
         assertEquals(List.of(new Dispatched(1, 1, 1)), dispatches,
                 "at most the already-polled column dispatches (the accepted ≤1 residual)");
@@ -621,14 +660,14 @@ class ClientColumnProcessorTest {
         processor.reportUndispatched(manager); // teardown bumps the session epoch
         processor.offer(new VoxelColumnS2CPayload(2, 2, dim, 1L, sectionWire(1, 1)), false); // straggler
 
-        processor.drainColumnQueue(dim, LEVEL_SECTIONS, MIN_SECTION_Y, FACTORY, recordingDispatcher, staleEpoch);
+        processor.drainColumnQueue(dim, LEVEL_SECTIONS, MIN_SECTION_Y, false, FACTORY, recordingDispatcher, staleEpoch);
 
         assertEquals(List.of(), dispatches,
                 "a drain scheduled before teardown must not dispatch into the new session");
         assertEquals(1, processor.getQueuedCount(),
                 "the straggler is left for shutdown, not consumed by the stale drain");
 
-        processor.drainColumnQueue(dim, LEVEL_SECTIONS, MIN_SECTION_Y, FACTORY, recordingDispatcher,
+        processor.drainColumnQueue(dim, LEVEL_SECTIONS, MIN_SECTION_Y, false, FACTORY, recordingDispatcher,
                 processor.sessionEpochForTest());
         assertEquals(List.of(new Dispatched(2, 2, 1)), dispatches,
                 "only the epoch gates the drain — a current-epoch drain still serves");
@@ -656,7 +695,7 @@ class ClientColumnProcessorTest {
                 64, true), true, true);
         try {
             proc.offer(new VoxelColumnS2CPayload(11, 11, dim, 6000L, truncatedColumnWire()), false);
-            proc.drainColumnQueue(dim, LEVEL_SECTIONS, MIN_SECTION_Y, FACTORY, (d, cx, cz, data) -> {},
+            proc.drainColumnQueue(dim, LEVEL_SECTIONS, MIN_SECTION_Y, false, FACTORY, (d, cx, cz, data) -> {},
                     proc.sessionEpochForTest());
             assertEquals(-1L, manager.getColumnTimestamp(11, 11),
                     "premise: the decode failure unstamped the position");

--- a/fabric/src/test/java/dev/vox/lss/networking/server/NbtSectionSerializerTest.java
+++ b/fabric/src/test/java/dev/vox/lss/networking/server/NbtSectionSerializerTest.java
@@ -288,12 +288,63 @@ class NbtSectionSerializerTest {
     }
 
     @Test
-    void airOnly_skyLightOnly_dropped() {
-        // parseSection only consults BlockLight when deciding to keep an air-only section;
-        // a non-zero SkyLight alone does not rescue it.
+    void airOnly_skyLightOnly_servedWithinTheContentBand() {
+        // INVERTED 2026-07-27 (black-boundary-faces fix — this pin used to assert the
+        // drop): the lit air section just above terrain is what lights the top/side faces
+        // of adjacent content at chunk borders; it must ship WITH its sky layer.
+        byte[] sky = light(100, (byte) 0x0F);
+        byte[] wire = NbtSectionSerializer.serializeChunkNbt(
+                chunkNbt("minecraft:full",
+                        sectionNbt(2, true, true, null, null),
+                        sectionNbt(3, false, true, null, sky)), REGISTRY_ACCESS);
+        var sections = decode(wire);
+        assertEquals(2, sections.size(), "content + its lit air cap both serve");
+        assertTrue(sections.get(1).section().hasOnlyAir());
+        assertTrue(sections.get(1).hasSkyLight());
+        assertArrayEquals(sky, sections.get(1).skyLight());
+    }
+
+    @Test
+    void airOnly_skyLightOnly_aloneStaysAClear() {
+        // A column with NO content sections must remain a zero-section CLEAR no matter
+        // what lit-air entries exist — air must never turn a clear into a data column.
         byte[] wire = NbtSectionSerializer.serializeChunkNbt(
                 chunkNbt("minecraft:full", sectionNbt(3, false, true, null, light(100, (byte) 0x0F))), REGISTRY_ACCESS);
-        assertEquals(0, wire.length, "air-only with only SkyLight (no BlockLight) is dropped");
+        assertEquals(0, wire.length, "lit air with no content anywhere stays a clear");
+    }
+
+    @Test
+    void airOnly_skyLit_outsideTheContentBand_dropped() {
+        // Lit air serves only within ONE section of the content band (vanilla's own
+        // stored-light coverage); a stray lit-air entry far above is dropped.
+        byte[] wire = NbtSectionSerializer.serializeChunkNbt(
+                chunkNbt("minecraft:full",
+                        sectionNbt(0, true, true, null, null),
+                        sectionNbt(4, false, true, null, light(100, (byte) 0x0F))), REGISTRY_ACCESS);
+        var sections = decode(wire);
+        assertEquals(1, sections.size(), "only the content section serves");
+        assertFalse(sections.get(0).section().hasOnlyAir());
+    }
+
+    @Test
+    void lightOnlyNbtEntry_noBlockStates_servesAsAirWithSky() {
+        // Vanilla's cap entries (heightmap+1) carry SkyLight but NO block_states — they
+        // are precisely the boundary layers the fix serves. They must decode as all-air
+        // sections carrying the sky layer.
+        byte[] sky = light(64, (byte) 0xF0);
+        var lightOnly = new CompoundTag();
+        lightOnly.putInt("Y", 1);
+        lightOnly.putByteArray("SkyLight", sky);
+        byte[] wire = NbtSectionSerializer.serializeChunkNbt(
+                chunkNbt("minecraft:full",
+                        sectionNbt(0, true, true, null, null),
+                        lightOnly), REGISTRY_ACCESS);
+        var sections = decode(wire);
+        assertEquals(2, sections.size(), "content + the light-only cap entry both serve");
+        assertEquals(1, sections.get(1).y());
+        assertTrue(sections.get(1).section().hasOnlyAir());
+        assertTrue(sections.get(1).hasSkyLight());
+        assertArrayEquals(sky, sections.get(1).skyLight());
     }
 
     @Test

--- a/paper/src/main/java/dev/vox/lss/paper/PaperNbtSectionSerializer.java
+++ b/paper/src/main/java/dev/vox/lss/paper/PaperNbtSectionSerializer.java
@@ -91,13 +91,30 @@ final class PaperNbtSectionSerializer {
             if (sectionY == Integer.MIN_VALUE) continue;
 
             byte[] blockLightData = sectionTag.getByteArray("BlockLight").orElse(EMPTY);
+            byte[] skyLightData = sectionTag.getByteArray("SkyLight").orElse(EMPTY);
             var result = parseSection(sectionTag, sectionY, blockStateCodec, biomeCodec,
-                    factory, blockLightData);
+                    factory, blockLightData, skyLightData);
             if (result != null) {
-                byte[] skyLightData = sectionTag.getByteArray("SkyLight").orElse(EMPTY);
                 parsed.add(new ParsedSection(sectionY, result, blockLightData, skyLightData));
             }
         }
+
+        // Boundary-light band (2026-07-27, black-boundary-faces fix — see the Fabric twin):
+        // SKY-lit air serves only within one section of the content band; a column with NO
+        // content sections stays a zero-section CLEAR. BLOCK-lit air keeps its
+        // long-standing unconditional serve.
+        int minContent = Integer.MAX_VALUE, maxContent = Integer.MIN_VALUE;
+        for (var p : parsed) {
+            if (!p.section().hasOnlyAir()) {
+                minContent = Math.min(minContent, p.sectionY());
+                maxContent = Math.max(maxContent, p.sectionY());
+            }
+        }
+        final boolean noContent = minContent == Integer.MAX_VALUE;
+        final int lo = minContent - 1, hi = maxContent + 1;
+        parsed.removeIf(p -> p.section().hasOnlyAir()
+                && !(p.blockLight().length == 2048 && hasNonZeroNibble(p.blockLight()))
+                && (noContent || p.sectionY() < lo || p.sectionY() > hi));
 
         if (parsed.isEmpty()) return new byte[0];
 
@@ -161,14 +178,19 @@ final class PaperNbtSectionSerializer {
             Codec<PalettedContainer<BlockState>> blockStateCodec,
             Codec<PalettedContainerRO<Holder<Biome>>> biomeCodec,
             PalettedContainerFactory factory,
-            byte[] blockLightData) {
+            byte[] blockLightData, byte[] skyLightData) {
 
         var blockStatesOpt = sectionTag.getCompound("block_states");
-        if (blockStatesOpt.isEmpty()) return null;
-
-        var blockStatesResult = blockStateCodec.parse(NbtOps.INSTANCE, blockStatesOpt.get());
-        var blockStates = blockStatesResult.result().orElse(null);
-        if (blockStates == null) return null;
+        PalettedContainer<BlockState> blockStates;
+        if (blockStatesOpt.isEmpty()) {
+            // Vanilla's light-only cap entries (heightmap+1) carry SkyLight but no
+            // block_states — exactly the boundary layers the fix serves.
+            blockStates = factory.createForBlockStates();
+        } else {
+            var blockStatesResult = blockStateCodec.parse(NbtOps.INSTANCE, blockStatesOpt.get());
+            blockStates = blockStatesResult.result().orElse(null);
+            if (blockStates == null) return null;
+        }
 
         PalettedContainerRO<Holder<Biome>> biomes;
         var optBiomes = sectionTag.getCompound("biomes");
@@ -187,7 +209,9 @@ final class PaperNbtSectionSerializer {
         }
 
         if (section.hasOnlyAir()) {
-            if (blockLightData.length != 2048 || !hasNonZeroNibble(blockLightData)) {
+            boolean litByBlock = blockLightData.length == 2048 && hasNonZeroNibble(blockLightData);
+            boolean litBySky = skyLightData.length == 2048 && hasNonZeroNibble(skyLightData);
+            if (!litByBlock && !litBySky) {
                 return null;
             }
         }

--- a/paper/src/main/java/dev/vox/lss/paper/PaperSectionSerializer.java
+++ b/paper/src/main/java/dev/vox/lss/paper/PaperSectionSerializer.java
@@ -30,7 +30,9 @@ final class PaperSectionSerializer {
      * Serialize all non-air sections of a loaded chunk column into MC-native wire format.
      * Returns a {@link LoadedColumnData} with pre-serialized bytes.
      */
-    private record SectionInfo(int index, int sectionY, SectionPos sectionPos, DataLayer blLayer, boolean hasBlockLight) {}
+    private record SectionInfo(int index, int sectionY, SectionPos sectionPos,
+                               DataLayer blLayer, boolean hasBlockLight,
+                               DataLayer slLayer, boolean hasSkyLight) {}
 
     // LevelChunkSection.write(buf) is @Deprecated on Paper (an anti-xray overload was added),
     // but the 1-arg form is the canonical vanilla serialization and is byte-identical to the
@@ -41,8 +43,12 @@ final class PaperSectionSerializer {
         var sections = chunk.getSections();
         var lightEngine = level.getLightEngine();
         var blockLightListener = lightEngine.getLayerListener(LightLayer.BLOCK);
+        var skyLightListener = lightEngine.getLayerListener(LightLayer.SKY);
 
-        // First pass: collect non-air sections and cache block light results
+        // First pass: collect non-air sections and cache light results. Air-only sections
+        // WITH stored non-zero sky light are served too (2026-07-27, black-boundary-faces
+        // fix — see the Fabric twin for the full rationale): those boundary air layers are
+        // what lights top/side faces of adjacent terrain at chunk borders.
         var includedSections = new java.util.ArrayList<SectionInfo>(sections.length);
         for (int i = 0; i < sections.length; i++) {
             var section = sections[i];
@@ -51,11 +57,31 @@ final class PaperSectionSerializer {
             var sectionPos = SectionPos.of(cx, sectionY, cz);
             var blLayer = blockLightListener.getDataLayerData(sectionPos);
             boolean hasBlockLight = blLayer != null && hasNonZeroData(blLayer);
+            var slLayer = skyLightListener.getDataLayerData(sectionPos);
+            boolean hasSkyLight = slLayer != null && hasNonZeroData(slLayer);
 
-            if (section.hasOnlyAir() && !hasBlockLight) continue;
+            if (section.hasOnlyAir() && !hasBlockLight && !hasSkyLight) continue;
 
-            includedSections.add(new SectionInfo(i, sectionY, sectionPos, blLayer, hasBlockLight));
+            includedSections.add(new SectionInfo(i, sectionY, sectionPos,
+                    blLayer, hasBlockLight, slLayer, hasSkyLight));
         }
+
+        // Band rule, same as the NBT path (disk/live byte parity): SKY-lit air serves only
+        // within one section of the content band — vanilla's own stored-light coverage —
+        // so a void/cleared column's ambient sky can never turn a zero-section CLEAR into
+        // a data column. BLOCK-lit air keeps its long-standing unconditional serve.
+        int minContent = Integer.MAX_VALUE, maxContent = Integer.MIN_VALUE;
+        for (var info : includedSections) {
+            if (!sections[info.index()].hasOnlyAir()) {
+                minContent = Math.min(minContent, info.sectionY());
+                maxContent = Math.max(maxContent, info.sectionY());
+            }
+        }
+        final boolean noContent = minContent == Integer.MAX_VALUE;
+        final int lo = minContent - 1, hi = maxContent + 1;
+        includedSections.removeIf(info -> sections[info.index()].hasOnlyAir()
+                && !info.hasBlockLight()
+                && (noContent || info.sectionY() < lo || info.sectionY() > hi));
 
         if (includedSections.isEmpty()) {
             return new LoadedColumnData(cx, cz, null, 0);
@@ -67,7 +93,6 @@ final class PaperSectionSerializer {
         var buf = new FriendlyByteBuf(Unpooled.buffer(sections.length * 1024));
         try {
             buf.writeVarInt(includedSections.size());
-            var skyLightListener = lightEngine.getLayerListener(LightLayer.SKY);
 
             for (var info : includedSections) {
                 var section = sections[info.index];
@@ -92,12 +117,10 @@ final class PaperSectionSerializer {
                     buf.writeBytes(info.blLayer.getData());
                 }
 
-                // Sky light
-                var slLayer = skyLightListener.getDataLayerData(info.sectionPos);
-                boolean hasSkyLight = slLayer != null && hasNonZeroData(slLayer);
-                buf.writeBoolean(hasSkyLight);
-                if (hasSkyLight) {
-                    buf.writeBytes(slLayer.getData());
+                // Sky light (cached from pass 1)
+                buf.writeBoolean(info.hasSkyLight);
+                if (info.hasSkyLight) {
+                    buf.writeBytes(info.slLayer.getData());
                 }
             }
 


### PR DESCRIPTION
Trace-diagnosed root cause of the long-standing black leaf/terrain faces at chunk borders (previously blamed on Voxy): both serve paths dropped air-only sections unless block-lit, so vanilla's stored boundary sky layers (light grid spans heightmap+1) never reached the consumer — faces sampling that never-ingested air shade black at some LOD mips.

- Server (both platforms, live+NBT): sky-lit air sections serve, banded to content±1 (vanilla's stored-light coverage; disk/live parity preserved); light-only NBT cap entries parse as all-air; block-lit air unchanged; clears stay clears.
- Client: implicit full-bright sky fill above each column's top served section (vanilla's own above-heightmap rule) — covers tall-cliff borders beyond the stored band; also upgrades resync air-fill above-band.
- `/lss trace` gains per-section `col_light` events (the diagnosis instrument).

Validation: Tier 1 both modules, all 58 Tier 2 gametests (incl. live disk/live byte parity), Tier 3, fresh-backfill soak in flight. Goldens unchanged (corpus has no lit-air fixtures... now pinned by the new unit tests instead).

🤖 Generated with [Claude Code](https://claude.com/claude-code)