### PR TITLE
docs: clearcache guidance on the boundary-light bullet

### DIFF
--- a/docs/release-notes-v0.8.0.md
+++ b/docs/release-notes-v0.8.0.md
@@ -1,6 +1,6 @@
 ### Bug Fixes
 
-- **Fixes black faces at chunk borders and treetops** — LOD data now carries the sky light for the air around terrain, so leaves and cliff sides no longer render black from one side at certain distances.
+- **Fixes black faces at chunk borders and treetops** — LOD data now carries the sky light for the air around terrain, so leaves and cliff sides no longer render black from one side at certain distances. Run `/lss clearcache` once after updating so already-cached LOD data picks up the fix.
 - **Anti-xray now fully covers LOD data** — On servers with anti-xray enabled, LOD chunk data could still be inspected to locate hidden ores. Masked LOD data now carries no trace of hidden blocks.
 - **LOD loading starts reliably on Paper** — The first batch of LOD requests could be lost at join (recovered a second later). Sessions now start cleanly.
 


### PR DESCRIPTION
Cached LOD data keeps its timestamps across the update, so the fix only reaches re-served columns — tell players to clear once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)