### PR TITLE
docs: v0.10.0 program plans + progress doc

### DIFF
--- a/docs/planning/cross-version-identity-encoding-plan.md
+++ b/docs/planning/cross-version-identity-encoding-plan.md
@@ -1,0 +1,686 @@
+# Cross-MC-version LOD serving — protocol 20 identity encoding (implementation plan)
+
+*2026-08-06. Trigger: issue #85 — players on 1.21.11 / 26.1.2 clients joining a 26.2
+server through ViaVersion/ViaBackwards get LOD data they cannot decode (Via translates
+vanilla packets; `lss:*` custom payloads pass through byte-for-byte). Worse, the
+mismatch is invisible today: the old-line clients speak LSS protocol 18/16, the
+server's compat rungs accept them as native same-MC sessions, and the client then
+decodes 26.2 registry ids against its own registry — silent garbage terrain, or a
+decode throw that loops forever through the ingest-failure re-serve path.*
+
+**Goal:** a version-neutral column encoding (protocol 20) so any v20 client works
+against any v20 server regardless of Minecraft version, plus (a) server-side
+translation to the native v19/v18/v16 formats for older LSS clients on the *same* MC
+version, (b) client-side translation so a v20 client works against older LSS servers
+on the same MC version, (c) an in-place store migration, and (d) a mismatch guard so
+legacy clients on a different MC version fail loud instead of half-working.
+
+**Non-goals:** serving *legacy-protocol* clients across MC versions (impossible — their
+formats are native-id by definition; the guard handles them); per-version numeric-id
+mapping tables à la ViaVersion (we side-step the whole chained-mapping apparatus by
+keying on identity); the 1.21.8 and 1.20.1 lines (OUT OF SCOPE — user decision
+2026-08-06: the supported MC set for cross-version serving is exactly 26.2, 26.1,
+1.21.11).
+
+---
+
+## 1. Why the current bytes are version-locked (verified facts)
+
+The column payload's `sectionBytes` (live path `SectionSerializer.java:99-136`, Paper
+twin identical) are:
+
+```
+VarInt sectionCount
+repeat:
+  byte  sectionY
+  short nonEmptyBlockCount; short fluidCount        // 26.2 shape
+  <blocks PalettedContainer>  <biomes PalettedContainer>
+  bool hasBlockLight [+2048 B]; bool hasSkyLight [+2048 B]
+```
+
+Each `PalettedContainer` = `byte bitsPerEntry; palette; packed long[]` (no length
+prefix; count implied). The **palette entries are global registry ids** — and in
+DIRECT mode (blocks >256 palette entries, biomes >8) the palette list is *absent* and
+the packed long array holds global ids directly, at a bit width derived from the
+**registry size** (`ceillog2`). Ids and registry sizes both shift every MC version
+(and with mods/datapacks) — three distinct version couplings in one layout.
+
+Everything else in the frame — packed index arrays, light nibbles, section Y, the two
+shorts — is already version-neutral.
+
+## 2. Wire format (protocol 20)
+
+Design rule (Via lesson): **rewrite palettes, never voxels.** Only the palette layer
+changes; packed arrays and light ship verbatim.
+
+### 2.1 Column layout
+
+Identical to v19 (coords, dimension, columnTimestamp, source byte, codec byte,
+zstd-1 framing, `MAX_SECTIONS_SIZE` guard) except inside the section bytes:
+
+```
+VarInt dictCount
+repeat dictCount: VarInt len + UTF-8 canonical identity string   // shared block+biome dictionary
+VarInt sectionCount
+repeat:
+  byte  sectionY
+  short nonEmptyBlockCount; short fluidCount
+  <blocks: byte bits; palette of VarInt DICT INDICES; packed long[]>
+  <biomes: byte bits; palette of VarInt DICT INDICES; packed long[]>
+  light as today
+```
+
+- **Dictionary**: first-seen order (deterministic given section order — pinned by
+  goldens), one entry per distinct identity in the column. Measured on real 26.2
+  terrain: ~38 entries/col. Blocks and biomes share one table; context (which palette
+  references it) disambiguates.
+- **Palette entries are dictionary indices**, VarInt (1 B in practice). `bits==0`
+  single-value = one index. The packed long arrays keep their existing
+  palette-relative semantics — shipped verbatim from the native form.
+- **DIRECT-mode sections are re-palettized** (the one repack case, exactly as
+  ViaVersion's `PaletteType1_18.readValues` synthesizes a palette from a global-mode
+  section): enumerate distinct ids in the longs, build an indexed palette, repack.
+  v20 has **no DIRECT mode** — removing the registry-size-dependent bit width from
+  the wire. **v20 palette widths are explicitly specified** (review MAJOR — a bare
+  `ceillog2(n)` emits width/shape combinations no vanilla strategy table accepts,
+  e.g. 1–3-bit block palettes from sparse sections stuck in global mode, since
+  vanilla never shrinks out of DIRECT): blocks `bits = clamp(ceillog2(n), 4, 12)`
+  (n ≤ 16 → 4 = vanilla-linear-shaped; 17–256 → 5–8 = vanilla-hashmap-shaped;
+  257+ → 9–12 = v20-custom), biomes `ceillog2(n)` in 0–6 (0–3 vanilla-shaped,
+  4–6 v20-custom). Natively-indexed sections ship their packed longs verbatim
+  (their widths are already vanilla-shaped); only re-palettized sections repack.
+  The v20-custom widths are decodable only via the §2.3 translation — never fed to
+  `section.read` directly. Worst case (a pathological 4096-state section, ~143 KB
+  dictionary raw) is bounded by `MAX_SECTIONS_SIZE` (2 MiB) — which is a
+  **column-level** cap enforced at client read (`LSSConstants.java:60`); the v20
+  emitter adds its own server-side size check rather than relying on the client's
+  read cap to reject an oversized own-encode.
+- **The v20 emitter replaces `section.write` wholesale** (it cannot call it — the
+  container write is where the ids are embedded) and recomputes both count shorts
+  itself, via the transcoder's existing histogram approach
+  (`NbtSectionSerializer.java:476-489,670`).
+- **A clear column (0 sections) always emits an EMPTY dictionary** — pinned:
+  `isClearColumn` (`ClientColumnProcessor.java:424-434`) reads the leading VarInt,
+  which v20 turns into `dictCount`, so ghost-clear semantics survive only via
+  dictCount==0 ⇔ sectionCount==0. No dictionary content may ever leak into a clear
+  frame.
+- **The two count shorts are pinned as version-neutral wire fields** (the 26.2
+  shape). `nonEmptyBlockCount`/`fluidCount` are what 26.2's `LevelChunkSection.write`
+  emits, but older MC versions' section shapes differ (1.21.11's count set diverges —
+  see `nbt-transcode-design.md:22-34` and the backport-gotchas notes). v20 always
+  carries both shorts; a client whose section object wants a different count set
+  recomputes locally from the decoded container (cheap — the recalc exists for the
+  mask path already). Without this pin the framing itself would be version-coupled.
+- **Canonical identity form**: `namespace:path[k1=v1,k2=v2]` — ALL properties, sorted
+  by property name, no spaces; bare `namespace:path` when the state has none. Biomes
+  are bare identifiers. MC's identifier charset (`[a-z0-9_./-]`) and property
+  names/values (alphanumeric) cannot contain `[ ] , =`, so no escaping is needed —
+  pinned by a validation test, not assumed. Note `BlockState.toString()` (used by
+  `RegistryFingerprint`, `RequestProcessingService.java:970-983`) is NOT this form —
+  the fingerprint keeps its stringifier untouched (it is persisted in store meta);
+  the wire gets a new strict `IdentityCodec` in `common/`.
+
+### 2.2 Handshake / session config
+
+- **The C2S handshake byte shape is FROZEN at `(VarInt version, VarInt caps)` — for
+  v20 and forever** (review CRITICAL, found independently by two lenses): every
+  legacy Fabric server's registered codec reads exactly two VarInts on
+  `lss:handshake_c2s`, and trailing bytes are a decoder kick — the repo documents
+  this exact hazard at `SessionConfigS2CPayload.java:97-101`. Legacy Paper ignores
+  trailing bytes (`PaperPayloadHandler.decodeHandshake:236-246`), which would have
+  made the failure Fabric-only and nastier to diagnose. An appended field would
+  hard-kick the v20 client from every shipped Fabric server, collapsing the §6
+  ladder at stage 1. C2S-shape stability joins the design rules; a Tier-1 pin
+  decodes the v20 announce under the v19 codec.
+- The client's MC data version therefore ships on a **new channel**
+  (`lss:client_info`, C2S, sent alongside the announce): legacy servers silently
+  discard unregistered channels; the v20 server treats absence as "legacy client"
+  and presence as diagnostics + guard input. The v20 server's handshake decode
+  branches version-first on the existing channel and still parses 2-field legacy
+  announces.
+- `SessionConfigS2CPayload` v20 appends the server's data version — the S2C append
+  IS safe (verified): the client codec branches per-frame on the leading version
+  VarInt and drains foreign layouts (`SessionConfigS2CPayload.java:67-103`).
+  Neither field is needed to decode v20 data (identity decode is version-blind).
+- Capability bits (`CAPABILITY_VOXEL_COLUMNS`, `CAPABILITY_ZSTD_COLUMNS`) unchanged.
+- `HandshakeGate.WireDialect` grows `V19`; `CURRENT` becomes protocol 20. Gate ladder
+  order unchanged (version rung first; mismatch = no reply).
+- **New config keys** (all following `ServerConfigBase` clamp/default conventions,
+  extending the `ConfigValidationTest` compat-defaults pin): server
+  `enableV19Compat` (default true — the v19 rung's kill switch, sibling of
+  `enableV16Compat`/`enableV18Compat`; the repo convention is that every rung
+  ships one) and `enableViaMismatchGuard` (default true — §7's operator override:
+  the guard denies registration off a third-party reflective API, and a Via API
+  drift that misreported protocols would otherwise lock out legitimate same-MC
+  legacy clients with no recourse); client `unknownBlockFallback` (default
+  `minecraft:stone`) and `crossVersionBlockFallbacks` (the curated-table extension,
+  §3).
+
+### 2.3 Client decode changes
+
+The client does NOT parse v20 containers through vanilla's `section.read` strategy
+tables — their width→shape mapping is version-fixed and rejects the v20-custom
+widths (§2.1). Instead the decode **reuses the §4.2 translator with the CLIENT's
+registry**: `ClientColumnProcessor` translates v20 → the client's OWN native layout
+in memory (identity → local id through the fallback ladder §3; vanilla-shaped
+sections pass their longs verbatim, only v20-custom-width sections repack), then
+feeds the existing `section.read` path (`ClientColumnProcessor.java:454-455`)
+unchanged. One translator component, exercised on both ends of the wire; the
+post-decode fills (`withImplicitSkyAbove`, `withAirFilledAbsentSections`) are
+format-agnostic and untouched.
+
+Decode-robustness changes riding along:
+- Sections whose `sectionY` is outside the client's world range are **parsed and
+  discarded** (today's count-clamp at `:448` assumes same-version heights; clamping
+  the count would desync the read cursor on a cross-version height mismatch).
+- **The hostile-allocation pin survives** (review MAJOR): today's clamp is
+  dual-purpose — `ClientColumnProcessor.java:437-441` pins that the claimed section
+  count never sizes an allocation. The v20 decode accumulates sections dynamically,
+  bounded by buffer exhaustion plus a sanity cap, never allocating from any
+  wire-claimed count (dictCount included). Pinned by a hostile-frame test.
+- Unknown-identity resolution uses the fallback ladder (§3), memoized per session.
+
+## 3. Unknown-identity fallback ladder (client)
+
+Via lessons applied: fail open with a bounded warn, never abort a section; curated
+fallbacks beat algorithmic; terminal default must not be air (air punches holes in
+distant terrain — ViaVersion's `checkValidity` returns air; wrong default for LOD).
+
+1. **Exact**: block registry has the name → `defaultBlockState()` → apply each
+   property via the state definition; unknown property names/values are skipped,
+   missing ones keep defaults (this IS the drop-unknown-props rung — it falls out of
+   the resolve algorithm for free).
+2. **Curated table** (name-level): a small JSON shipped in the client jar mapping
+   removed/renamed block names to visually-similar local ones, ViaBackwards-diff
+   style (`sulfur → sandstone`), user-extendable via a client config key. Ships
+   EMPTY at first release; populated as real gaps are reported.
+3. **Terminal default**: config `unknownBlockFallback`, default `minecraft:stone`.
+   Biomes: unknown → `minecraft:plains`.
+
+Per-identity resolution is memoized per session; each fallback logs once per identity
+per session (bounded), and a `fallbacks=` counter joins `/lss trace` + client diag.
+
+Two identities may resolve to the same local state (or the fallback) — the decoded
+palette then has duplicate entries. `PalettedContainer` tolerates duplicates, so no
+index remap is required client-side (Via needs the collapse pass because it re-EMITS
+wire bytes; we only materialize sections).
+
+## 4. Server side: encode direction and legacy egress
+
+### 4.1 v20 is the canonical internal form
+
+All three produce paths emit v20 directly; store rows hold v20; legacy sessions get
+a per-serve translation at egress. Rationale: single canonical form, self-contained
+registry-independent store rows, and the NBT transcode gets *simpler* (see below).
+The translation cost lands on legacy sessions during the transition window — palette
+layer only (~93 entries + ~38 strings/col, memoized lookups; packed arrays copy
+verbatim for natively-indexed sections, the re-palettized minority repacks — §2.1),
+negligible next to zstd + serialization.
+
+- **Live path** (`SectionSerializer.java:99-136` + Paper twin): serialize the
+  container as today but map palette ids → dictionary indices via a memoized
+  per-registry `id → canonical identity` table (built once from
+  `Block.BLOCK_STATE_REGISTRY` iteration order — the same enumeration
+  `RegistryFingerprint` already uses). DIRECT sections re-palettize here.
+- **NBT transcode path** (`NbtSectionSerializer.transcodeSection:408` + Paper twin):
+  the disk palette ALREADY stores name+properties NBT — canonicalize straight to
+  identity strings, **no registry resolution needed for the wire**. The
+  `MemoizedNbtCodec` id resolve survives only for what still needs ids: the two
+  shorts (air/fluid classification) and the x-ray mask pre-gate
+  (`mask.containsId`, `:497-508`). The >256-palette object-path fallback can be
+  RETIRED for encoding (v20 has no DIRECT limit; a >256 disk palette transcodes
+  fine) but stays for malformed shapes.
+- **X-ray masking** stays upstream of encoding, in the object/descriptor domain
+  (`XrayMaskFilter.mask` on `LevelChunkSection` before `write`; transcode pre-gate
+  unchanged) — every serve path and the `DirtyContentFilter` hash keep seeing
+  identical masked bytes. No mask changes required in phase 1; an identity-level
+  `MaskSet.containsIdentity` is a later cleanup, not a dependency.
+- **DirtyContentFilter**: hashes raw served bytes; v20 changes the bytes, the filter
+  is in-memory-only (re-seeds from serves after restart) — no migration concern.
+
+### 4.2 Legacy egress translators (same-MC v19/v18/v16 clients)
+
+New in `common/`: a `WireSectionCursor` (parse/skip/re-emit both the v20 and native
+section layouts — the transcoder's layout knowledge, factored out and shared with
+store migration) and a `V20ToNativeTranslator`:
+
+- identity → global id via a memoized `identity → id` map from the server's own
+  registry (exact and lossless on the same MC version — every identity a same-version
+  server serves exists in its registry; see §5.3 for the one post-migration edge).
+- **Palette collapse** (Via lesson): if two dictionary identities resolve to one id
+  (cannot happen same-version, CAN happen through the §5.3 edge), dedupe palette
+  entries and remap the packed indices — implemented and pinned from day one, not
+  deferred.
+- Emits native v19 layout (global-id palettes at vanilla widths, DIRECT at
+  registry-size bits when >256/>8 — exactly what a v19 client's `section.read`
+  expects; v20-custom-width sections repack here). Kill switch: `enableV19Compat`
+  (§2.2).
+
+Seam wiring (all four dialects flow through one choke point per platform):
+
+- Fabric `RequestProcessingService.sendColumnPayload` (`:602-664`): dialect switch
+  becomes V20-native / V19 (translate) / V18 (translate + `asV18()` splice) / V16
+  (translate + `asV16()` splice). The existing `WireShape` byte-splice machinery
+  (`VoxelColumnS2CPayload.write:164-178`) is unchanged — v18/v16 are "v19 minus
+  bytes", so translation composes with the existing splices.
+- Paper `PaperRequestProcessingService.columnPayloadSender` (`:130-174`) +
+  `PaperPayloadHandler.rewriteColumnToV16/V18` (`:152-203`): same composition.
+- **Store hits for legacy sessions**: today a store hit ships the zstd frame
+  verbatim. Post-v20 a legacy serve must decompress → translate → recompress (v19
+  with zstd capability) or serve raw (v18/v16, which require RAW anyway — their
+  splices throw on non-RAW, pinned today). This CPU lands only on
+  legacy-session store hits and shrinks to zero as clients update.
+- `V16CompatManager` (synthetic want-set, ingress shim) is untouched — it never
+  sees section bytes.
+
+### 4.3 Dialect tracking
+
+Replace the `V18CompatTracker` bare set + `V16CompatManager.isV16` egress checks with
+one `WireDialectTracker` (UUID → V16/V18/V19/CURRENT), preserving the pinned
+lifecycle semantics exactly: marked at network level BEFORE `registerPlayer` (Fabric
+inline main-thread; Paper only via the pump's dialectFlip), survives the
+dimension-change remove+register cycle, dropped at disconnect + Paper's
+quit-originated mailbox Remove. `V16CompatManager` keeps its session objects for the
+ingress shim and consults the tracker for membership — with ONE lifetime (review
+finding): today v16 membership has two (the manager's 75 s synthetic-want-set
+session TTL vs the egress `isV16` checks), and a tracker dropping only at
+disconnect would outlive an expired session. The tracker is the single source of
+truth; the manager's session prune is also its tracker-removal hook. `/lsslod diag`
+gains a `Dialects: v20=N v19=N v18=N v16=N` line replacing the `V18Compat:` slot —
+which touches FIVE pinned surfaces, all enumerated in §9: the `DiagData` record
+slot ordering (`DiagnosticsFormatter.java:38,82,102`), the formatter goldens,
+Tier-2 `CommandGameTests` exporter/formatter agreement, the Paper command-output
+tests, and the exporter schema-parity tests on both platforms. (The soak JSONL
+schema is unaffected — verified: no v18 field in `check_soak.py`.)
+
+## 5. Store migration (schema 3 → 4)
+
+Stored blob == wire frame by construction (`depositFrame` verbatim,
+`getFrame` serves without decompressing). A wire change is therefore a store change.
+The Modrinth server's live store is ~4 GB — a blocking full rewrite at open is not
+acceptable, so migration is **lazy + background**, with drop-and-rebuild as the
+fallback:
+
+1. **Schema bump with row-level format tag**: `SCHEMA_VERSION = 4`;
+   `ALTER TABLE lods_<id> ADD COLUMN wirefmt INTEGER NOT NULL DEFAULT 19` on
+   upgrade; new deposits write `wirefmt = 20`. **Meta is stamped
+   `wire_format_version = 20` and `schema_version = 4` INSIDE the upgrade
+   transaction, immediately** — review MAJOR: `metaMatches`
+   (`SqliteLodStore.java:353-364`) compares by EQUALITY, so any
+   "stamp 20 when migration completes" scheme fails the match on the first
+   post-upgrade restart and `openOrRecreateWriter` (`:288-308`) drops the whole
+   store — the 4 GB lazy design self-destructing. Migration COMPLETION is tracked
+   separately (a cheap `EXISTS wirefmt=19` probe / `min_wirefmt` meta key), never
+   via the version keys. The upgrade block sits between `openWriter()` and the
+   `metaMatches` check, probes `pragma table_info` before the ALTER (SQLite has no
+   `ADD COLUMN IF NOT EXISTS`; the catch path must never re-run a half-applied
+   upgrade — any upgrade failure falls through to drop-and-rebuild), and fires
+   ONLY from the exact state `schema_version=3 ∧ wire_format_version=19` — any
+   other from-state (dev-era metas, ≤18) drops as today, because the ALTER's
+   `DEFAULT 19` would mislabel those rows for the inverse translator.
+2. **Migratability gate**: upgrade-in-place ONLY when the stored
+   `registry_fingerprint` matches the running server (the stored bytes' ids are only
+   decodable against the registry that wrote them — same rule as today) AND the
+   §5.1 exact from-state holds AND `codec` matches. Any mismatch → the existing
+   drop-and-rebuild, which stays the universal fallback; the backfill re-warms a
+   dropped store (~23 min at the default 500 cps).
+3. **Read path**: a `getFrame` hit on a `wirefmt=19` row decompresses, translates
+   id → identity (the inverse translator — the same memoized registry table §4.1
+   builds), re-encodes; serving is correct from minute zero. A legacy-session serve
+   of a 19-row skips the double translation (it is already native). Contract
+   changes made explicit (review finding): `getFrame`'s hit record carries
+   `wirefmt` (today it selects only the blob — `SqliteLodStore.java:510-545`), the
+   translation runs on the reader-pool threads (`StoreCodec` is stateless —
+   verified safe), and a translated serve's recomputed `usize` is what feeds the
+   raw-denominated bandwidth charge (`AbstractChunkDiskReader.java:294`).
+4. **Background migration walk**: rides the backfill's restraint pattern (paced,
+   MSPT-gated at the same `LOD_STORE_BACKFILL_TICK_CEILING_MS`, resumable): batches
+   of `wirefmt=19` rows per dim (rowid watermark in meta `migrate_progress_<dim>` —
+   valid: `lods_*` are true ROWID tables, `pos INTEGER PRIMARY KEY` IS the rowid),
+   decompress → translate → re-encode → recompute `usize`/`chash`/`fhash` → UPDATE
+   with `wirefmt=20`, through the existing single-writer batcher **with the
+   watermark write riding the SAME batcher transaction as its batch** (an UPDATE
+   lost to rollback then retries because the watermark rolled back with it; a
+   watermark committed apart from its rows would silently skip them). Any per-row
+   parse anomaly deletes the row (derived data). Migration SQL failures count
+   toward the existing `WRITE_FAILURE_LATCH` (20) — accepted: a store that fails 20
+   consecutive writes should latch dead regardless of the writer. A `DropAll`
+   mid-walk also resets `migrate_progress_*`. One INFO line at start/end with row
+   counts; progress in `/lsslod store status` (`migrating=<n>/<total>`).
+5. **Interplay**: cap eviction and freshness sweeps operate on rows regardless of
+   `wirefmt` (verified: `evictOldestBatch` selects only `pos, length(blob), ts` and
+   the sweep never parses blobs; migration UPDATEs don't touch `ts`, so age order
+   survives); the backfill walk and the migration walk share the pacing budget (run
+   migration first — it converts existing value; backfill adds new value). One
+   acknowledged day-one pessimization: at release ~100 % of sessions are v19, and
+   every MIGRATED row served to them pays decompress→translate→recompress while
+   unmigrated 19-rows serve verbatim — bounded (tens of µs/col), shrinking as
+   clients update; the walk still starts promptly because a long mixed-format era
+   is worse to operate than a short recompress era.
+6. **Post-migration policy — the fingerprint stays.** Identity-keyed rows are
+   registry-drift-proof in principle, but relaxing the fingerprint drop creates a
+   real edge: a store row written under mod-set A can contain identities absent from
+   registry B, which a legacy-session egress translation cannot resolve (§4.2's
+   collapse/fallback would have to fabricate server-side content). Keep
+   drop-on-fingerprint-drift in this release; "store survives mod changes" is a
+   documented follow-up that needs the legacy-egress unknown-identity policy decided
+   (likely: delete row + fresh disk read).
+
+## 6. Client-side ladder for older same-MC LSS servers
+
+Generalize `ClientSessionGate` (`ClientSessionGate.java`) from the one-shot v16
+discovery boolean to an **attempt ladder**: announce 20 → 5 s silence → announce 19 →
+5 s silence → announce 16 (each stage reusing the existing
+`V16_DISCOVERY_DELAY_TICKS` machinery, arm/disarm/reset/downgrade-guard semantics
+preserved and re-pinned per stage). `V16ClientWire`'s netty-thread boolean becomes a
+per-attempt **decode dialect** enum consumed by `VoxelColumnS2CPayload.read`.
+
+- **The v19 rung is cheap**: a v19 server replies natively to a 19 announce with the
+  current 4-field SessionConfig; the v20 client's "v19 mode" is precisely today's
+  decode path (source + codec bytes, native-id palettes against its own registry —
+  same MC version by construction). It is retained code, not new code.
+- **Deliberately NO v18 rung**, consistent with the existing decision (a v0.9.1
+  client on a v0.8.x server degrades via v16): v0.7.x–v0.8.x servers all carry the
+  server-side v16 rung, so the ladder still lands every legacy server; adding 18
+  would buy source-byte fidelity on two old lines at the cost of a fourth 5 s stage
+  and a third decode dialect. Revisit only if users complain about v16-degraded
+  sessions on v0.8.x servers.
+- Worst case to a v16 session: ~15 s after join (three stages). Acceptable — v16
+  discovery is already 5 s and self-heals late.
+- The downgrade guard generalizes: a LOWER-version SessionConfig arriving while a
+  higher-version session is established re-announces the current version instead of
+  downgrading (today's `:208-223` logic, per rung).
+
+## 7. Mismatch guard for legacy clients on a different MC version
+
+A v19/v18/v16 handshake carries no MC version, and cross-MC legacy sessions cannot be
+served (native-id formats). Best-effort detection, applied at the gate BEFORE the
+compat rungs register anybody:
+
+- **Reflective Via probe** (`common/` seam + platform impls, the
+  `MoonriseReadCompat` zero-compile-dep pattern): `Via.getAPI().getPlayerVersion(uuid)`
+  — present when ViaVersion (Paper/Folia) or ViaFabric (Fabric) is installed, which
+  is the ONLY way a cross-MC client can be connected directly. Protocol ≠ the
+  server's native protocol → the gate answers a legacy handshake with **no
+  registration** and one INFO line naming the versions ("LOD unavailable for <name>:
+  client MC <x> vs server <y> — client must update LSS"). All failure shapes → probe
+  absent → no behavior change (the resolve ladder / warn-once / null-latch shape of
+  the other compat bridges). Kill switch: `enableViaMismatchGuard` (§2.2) — the
+  guard denies registration off a third-party API, so operators need an override if
+  a Via API drift ever misreports protocols.
+- **v20 clients are always detectable** via the handshake `mcDataVersion` — and
+  always servable, so mismatch there only feeds diagnostics.
+- **Documented hole**: Via on a Velocity/Bungee proxy is invisible to the backend;
+  legacy clients behind it stay undetected (they get today's garbage behavior until
+  they update). Release notes say so.
+
+## 8. Measured size impact
+
+Method: parsed 400 real overworld columns (26.2, `test-server/paper` world region
+files — genuine played terrain), extracted every served section's block/biome
+palettes, computed the palette-layer cost under each encoding
+(`scripts/palette_size_analysis.py`; packed arrays + light identical across
+encodings). Baselines from `compressed-columns-design.md`: raw column ≈ 30–35 KB,
+zstd-1 wire frame ≈ 5,342 B/col.
+
+| | per column (mean) |
+|---|---|
+| served sections / block palette entries / distinct identities | 9.6 / 93.5 / 38.0 |
+| current palette bytes (VarInt global ids) | ~255 B |
+| identity-DICTIONARY encoding (chosen) | ~1,429 B → **+1,174 B/col** |
+| identity strings inline per entry (rejected) | ~2,906 B → +2,651 B/col |
+| dictionary strings after compression (zlib proxy) | ~308 B |
+
+**Denominator care (review MAJOR — the original draft mixed measures):** the
++1,174 B is **+5.7 % of the palette+packed measure the script computes** (~20.6 KB;
+light nibbles and headers excluded) and **+3.4–3.9 % of the full 30–35 KB raw
+column**. The wire figure divides a dictionary measured on THIS corpus by a frame
+size measured on the compressed-columns corpus (cross-corpus), and the proxy has
+known biases in both directions: zlib-6-over-strings-alone omits ~131 index bytes
+and doesn't subtract the current palette's own compressed cost (understates), while
+the `BIOME_ID_B = 1.5` assumption overstates the current biome cost (~65 biomes =
+always 1 VarInt byte). Net planning envelope: **raw +3.5–6 %, wire ≈ +4–6 %**;
+store rows grow with the wire figure (row == frame). **Phase 0 includes the
+settling measurement** — encode this corpus through BOTH real encoders and diff
+actual zstd-1 frames — before any release-notes or store-growth number is
+published. The bandwidth limiter charges raw bytes (unchanged policy — verified:
+`QueuedPayload.estimatedBytes` raw-denominated, `recordSend` charges it), so
+configured caps see the raw figure. Modded servers (longer namespaces, more
+distinct states) sit somewhat above; the dictionary amortizes per column and zstd
+eats the string redundancy, so the shape holds. Pathological worst case (a
+4096-distinct-state section, ~143 KB dictionary raw) is rare, compresses heavily,
+and is bounded by the column-level 2 MiB guard + the §2.1 server-side emit check.
+
+## 9. Test plan
+
+The translation matrix is the risk concentration: three produce paths × four egress
+dialects × two platforms × (client ladder rungs) × store row formats. Coverage:
+
+**New common unit suites (Tier 1, both modules' twins where applicable):**
+- `IdentityCodecTest` — canonical form (all props, sorted, charset-safety pin
+  proving `[ ] , =` cannot occur in identifiers/props), round-trip, dictionary
+  first-seen determinism, malformed-string rejection.
+- `WireSectionCursorTest` — parse/re-emit byte identity on both layouts, cursor skip
+  correctness, truncation/negative-length containment.
+- `V20ToNativeTranslatorTest` / `NativeToV20TranslatorTest` — bijection fuzz
+  (`toNative(toV20(x)) == x` byte-exact on one registry, both container types),
+  DIRECT synthesis + re-palettization (blocks >256, biomes >8), single-value
+  sections, the **palette-collapse + packed-index remap** case, unknown-identity
+  policy.
+- **Cross-registry simulation** — the cross-MC-version proof without two MC versions
+  in one JVM: synthetic registry pairs (permuted ids — the A3-style permutation
+  blindness pin; missing entries; added entries). Encode under registry A, decode
+  under registry B: states must match BY IDENTITY; fallback fires exactly on the
+  missing set, ladder rung by rung (exact → props-dropped → curated → terminal),
+  duplicate-resolve tolerance.
+- Fallback ladder unit tests incl. the curated-table JSON loader (empty table,
+  malformed file tolerance à la config loading, user-extension merge).
+
+**Goldens (the existing cross-module byte corpus, extended):**
+- v20 goldens for the corpus sections, generated by the object path (the
+  transcode-vs-object twin discipline extends: transcoded v20 must byte-match
+  object-path v20 — new fuzz twin).
+- **Translation-chain goldens**: for each corpus column, `v20 → v19` must byte-match
+  the native v19 golden; `→ v18`/`→ v16` must match the existing splice goldens.
+  Fabric and Paper twins both pinned (`WireParityTest` extension: v20 bytes
+  Fabric == Paper).
+- `xray-masked` golden regenerated for v20; masked disk/live parity re-pinned.
+- **Cross-line fixture corpus** (review MAJOR — closes the only-manual gap): a v20
+  frame corpus CAPTURED from real 26.2 terrain is checked in as a golden fixture,
+  and the 26.1 / 1.21.11 lines' Tier-1 suites (phase 7) decode it against their
+  REAL registries — asserting identity-level content, exact fallback counts, and
+  the §2.1 count-shorts recompute. Without this, the actual issue-#85 scenario has
+  zero automated coverage anywhere, forever.
+
+**Handshake / dialect (Tier 1):**
+- Gate ladder: v20 native (with the `lss:client_info` sidecar), V19/V18/V16 rungs,
+  no-reply mismatch, flag-independence pins extended to the third rung
+  (`enableV19Compat`), the version-first legacy-announce parse on the shared
+  channel.
+- **The frozen-shape pin**: the v20 announce decodes byte-cleanly under the v19
+  `HandshakeC2SPayload` codec (no trailing bytes — the §2.2 CRITICAL), and
+  `lss:client_info` absence/malformation is ignored-safe.
+- `ConfigValidationTest` compat-defaults pin extended to `enableV19Compat` +
+  `enableViaMismatchGuard`; client-config validation for `unknownBlockFallback`
+  (parseable block id) + curated-table file malformation tolerance.
+- The `Dialects:` diag replacement's five pinned surfaces (§4.3): `DiagData` slot
+  ordering, formatter goldens, Tier-2 `CommandGameTests` exporter/formatter
+  agreement, Paper command-output tests, exporter schema parity on both platforms.
+- `WireDialectTrackerTest` — the V18CompatTracker lifecycle pins generalized:
+  pre-register marking, dimension-change survival, disconnect + Paper quit-race
+  mailbox-Remove drop, cross-dialect sheds, diag line.
+- Via-probe seam tests against real-package-name stubs
+  (`com.viaversion...` under test roots, the `AntiXrayCompat` pattern): resolve
+  ladder, mismatch → no-register, absent/throwing probe → unchanged behavior,
+  warn-once.
+
+**Client (Tier 1):**
+- Ladder tests generalizing `ClientSessionGate` coverage: three-stage timers, per-rung
+  downgrade guard, disarm on accept, reset on disconnect/join, v19-rung decode
+  dialect selection, late-config races.
+- Decode: identity resolve through a real registry (fabric-loader-junit bootstrap, as
+  the existing serializer tests do), out-of-range-sectionY discard (cursor stays
+  aligned), fallback content assertions, per-session memo + bounded warn.
+
+**Store (Tier 1):**
+- Migration suite: migrated row byte-equals a fresh v20 encode of the same source
+  (golden); `usize/chash/fhash` recomputed; watermark resume mid-walk (kill between
+  batches); fingerprint-drift → drop-and-rebuild; corrupt row → deleted, walk
+  survives; mixed-format serving (a 19-row store hit through the inverse translator
+  byte-equals its post-migration serve); schema-3 meta → ALTER upgrade; cap
+  eviction + freshness sweep indifference to `wirefmt`; `store status`
+  `migrating=` token.
+
+**Gametests (Tier 2):** crafted-frame handshakes through the production receiver for
+all four rungs (extending the specimen set — v20 with dataVersion registering
+natively; v19 registering via the rung and receiving translated columns);
+`SerializerParityGameTests` disk-vs-live byte parity under v20 incl. masked parity;
+lifecycle pins re-run (the entrypoint-listing contract catches new classes).
+
+**Tier 3:** existing end-to-end revalidates v20 natively (decoded content assertions
+already check real block layers — they now exercise identity resolve); add an
+ingest-fallback assertion (a column carrying a synthetic unknown identity decodes to
+the fallback state at the consumer).
+
+**Soak:** all 19 scenarios inherit v20 natively (the laws are format-blind for
+NATIVE sessions; re-baseline nothing unless churn ceilings move). Additions:
+- `-Psoak.dialect=19` client lever forcing the announce version → fresh-backfill +
+  warm-rejoin as a live v19 session: the v19 egress translator gets LIVE soak
+  coverage, not just goldens. **Dialect 16 is EXCLUDED from the lever** (review
+  CRITICAL — "the laws are format-blind" is FALSE for the v16 shim): law A1's
+  ledger has no terms for the shim's sheds (`overflowBounced`/`graceDiscarded`,
+  `V16CompatManager.java:135-136,214` — not snapshot fields), and the synthetic
+  want-set's 1 Hz sole-declarer / 75 s TTL semantics break the quiescence client
+  mirror — a dialect-16 soak reds A1 by construction. v16 egress correctness is
+  covered by the translation-chain goldens + crafted-frame gametests; if live v16
+  soak coverage is ever wanted it is its own sub-task (export the shim counters
+  into snapshots, extend A1 + `--selftest`, whitelist the scenario-config keys —
+  `check_soak.py:160-164`).
+- A store-migration variant of `store-second-join`: stage a schema-3/v19-format
+  store fixture, verify warm hits from minute zero (inverse translator), migration
+  completion, and law cleanliness during the walk.
+- `bandwidth-throttle` thresholds re-checked against the raw growth (the limiter
+  charges raw bytes, so +~5 % raw shifts its margins).
+
+**Live matrix (manual, release gate for the feature):** the lss-multi-test harness +
+a Via'd 26.2 server + a real 1.21.11 client running the backported v20 client build —
+eyeball terrain + `/lss trace` fallback counters; repeat with 26.1.2. This is the
+only test that proves the actual issue-#85 scenario end-to-end.
+
+## 10. Phasing
+
+| Phase | Content | Est. |
+|---|---|---|
+| 0 | `IdentityCodec`, registry identity tables (both directions, both platforms), `WireSectionCursor` + unit suites, the §8 settling measurement (real-encoder zstd-1 frame diff) | 2–3 d |
+| 1 | v20 encode on all three produce paths + client decode + fallback ladder + handshake/gate v20 + `WireDialectTracker` | ~1 wk |
+| 2 | Legacy egress translators (v19/v18/v16 composition) + store-hit recompress + soak dialect lever | 3–4 d |
+| 3 | Client ladder (v19 rung + generalized discovery) | 2–3 d |
+| 4 | Store schema 4 + lazy read-path translation + background migration walk | ~1 wk |
+| 5 | Via probe guard + mismatch messaging | 2 d |
+| 6 | Golden/fuzz/cross-registry hardening, Tier 2/3 additions, soak runs, legacy-dialect benchmark run, live matrix | ~1 wk (overlaps) |
+| 7 | Fresh 26.1 + 1.21.11 re-ports from main, cross-line fixture suites, tri-release (+ release notes ×3 lines, CLAUDE.md update) | ~2–3 d + ~1 wk (§11) |
+
+Phases 1–5 land as one release branch (a wire bump cannot ship piecemeal), but each
+phase is independently reviewable. Total: roughly 4–6 weeks at this repo's review
+cadence.
+
+## 11. Release sequencing and backports
+
+1. **main (26.2) first** — v0.10.0, protocol 20. Safe in both directions on day one:
+   old clients hit the v19/v18/v16 rungs (translated, same-MC), new clients on old
+   servers ride the ladder. Release notes carry the Via-proxy hole and the store
+   migration note (one-time background walk; fingerprint drift still drops).
+2. **Fresh re-ports of CURRENT main to MC 26.1 and 1.21.11** (user decision
+   2026-08-06) — NOT patches to the existing `support/mc26.1` / `support/mc1.21.11`
+   branches, which are frozen at the v0.8.1 feature level (protocol 18 — no zstd
+   columns, no store-era fixes, no adaptive cadence) and would bolt v20 onto a tree
+   missing a release's worth of features. Instead: cut new support branches from
+   main at v0.10.0 and retarget the MC version, so all three lines ship the SAME
+   mod at the same feature level, differing only in MC bindings. The old branches
+   are then retired/archived. Required for issue #85 either way: the cross-version
+   story only works once those players' clients speak v20, and a client build must
+   match the client's own MC version.
+   - The known retargeting gotchas are catalogued (memory
+     `mc-version-backport-gotchas` + the 1.21.8/1.21.11 port records): loom-remap vs
+     fabric-api loom version, paperweight codebook needing Java 21 on 1.21.x, the
+     `ScopedValue`-is-preview AntiXray shim degrade on 1.21.x, per-MC-version
+     `xray-masked` goldens, section-write count-shape divergence (§2.1's pin), Bukkit
+     split world dirs, `build.yml` `support/**` coverage, dual-line `+mc<ver>`
+     release tags, per-line `release.yml` flavors + their
+     `ReleaseWorkflowContractTest` twins, `release_check.py --version` expansion
+     for the new tags, and the per-line `PluginYmlContractTest` folia-supported
+     flavor.
+   - 26.1 is a near-neighbor of 26.2 (small API delta); 1.21.11 is the larger port.
+     Estimate: ~2–3 d and ~1 wk respectively, on top of the main-line work — the
+     v0.8.0 tri-release is the precedent for shipping three lines from one feature
+     tree.
+3. The 1.21.8 / 1.20.1 lines are out of scope (see non-goals) — they stay at their
+   current releases; their servers/clients simply never enter the v20 matrix.
+4. After the re-ports ship: answer issue #85 with the concrete version pair
+   ("server ≥ v0.10.0 AND every cross-version client on its line's ≥ v0.10.0 build"),
+   all three lines released together tri-release-style.
+
+## 12. Risks / open questions
+
+- **Terminal fallback block** — `minecraft:stone` proposed; alternatives (biome-aware,
+  y-dependent air-above-surface) add complexity for marginal LOD-scale gain. DECIDE.
+- **Curated fallback table** — ship empty + config-extendable proposed; maintaining a
+  real cross-version table (à la ViaVersion/Mappings diffs) is ongoing curation cost
+  we can defer until reports arrive. DECIDE.
+- **Store migration lazy vs drop** — lazy migration specified above; if review finds
+  the mixed-format read path too fiddly, the fallback position (drop + 23 min
+  backfill re-warm) is already the fingerprint-drift path and loses only warm-start
+  value, not correctness. DECIDE (default: lazy as specced).
+- **Transition-window CPU** — every legacy-session serve pays a palette translation;
+  legacy store hits pay decompress+recompress. Bounded, shrinks as clients update,
+  but the benchmark harness should measure it (add a legacy-dialect benchmark run).
+- **Modded-registry blowup** — heavily modded servers have larger dictionaries;
+  measured shape says the dictionary + zstd contain it, but the live Modrinth server
+  (Moonrise et al., vanilla-ish registry) won't prove the heavy-mod case; note for a
+  volunteer test.
+- **Paper twin drift** — every new common seam (`IdentityCodec`, cursor, translators,
+  tracker) lives in `common/`, so the Fabric/Paper twin surface GROWS only at the
+  serializer call sites; the wire-parity + golden twins are the guard.
+- **The v18-rung-on-client question** — deliberately skipped (§6); revisit on
+  complaint volume from v0.8.x-server users.
+
+## 13. Review round (2026-08-06, three Fable lenses)
+
+Three-agent review — wire/translation correctness, store+operations,
+test-adequacy+pinned-contracts. All accepted findings are folded into the sections
+above; this records the round.
+
+**CRITICALs (both fixed in place):**
+- C2S handshake field append would hard-kick v20 clients from every legacy Fabric
+  server (trailing-bytes decoder rejection; found independently by two lenses) →
+  handshake shape frozen forever, `mcDataVersion` moved to the new
+  `lss:client_info` channel, frozen-shape Tier-1 pin added (§2.2, §9).
+- `-Psoak.dialect=16` reds law A1 by construction (shim sheds have no ledger terms;
+  synthetic want-set breaks the quiescence mirror) → lever restricted to dialect
+  19; live-v16 soak spelled out as an optional future sub-task (§9).
+
+**MAJORs folded:** v20 palette widths explicitly specified + client decodes via
+local-native translation instead of raw `section.read` (§2.1/§2.3); store meta
+stamped 20 at upgrade time — the completes-later scheme would have dropped the
+store on first restart (§5.1); §8 denominators corrected + phase-0 real-encoder
+settling measurement; kill switches `enableV19Compat` / `enableViaMismatchGuard`
+(§2.2/§4.2/§7); hostile-allocation pin preserved in the v20 decode (§2.3);
+cross-line fixture corpus so the issue-#85 scenario has CI coverage (§9); the
+diag-line replacement's five pinned surfaces enumerated (§4.3/§9).
+
+**MINORs folded:** clear-frame empty-dictionary pin; dialect-tracker/V16-session
+single lifetime; column-level 2 MiB clarification + server-side emit check;
+migration watermark rides its batch's transaction + `WRITE_FAILURE_LATCH`
+statement + `DropAll` progress reset; day-one recompress pessimization noted;
+v0.8.1 correction; re-port catalogue additions (release.yml flavors, contract-test
+twins, release_check expansion); phasing additions (benchmark run, release notes,
+CLAUDE.md).
+
+**Verified non-findings (kept on record so they aren't re-litigated):** the
+splice-composition claim is correct; S2C SessionConfig append is safe (client
+drains foreign layouts); specimen-17 survives protocol 20; `FoliaWiringContractTest`
+is unaffected by Via string constants; VSS `check_wire_identity_fabric` is
+unthreatened; rowid watermark valid on `lods_*`; eviction/sweep are
+wirefmt-indifferent; the bandwidth raw-charge claim is accurate; §5.6's
+fingerprint-stays edge is real and correctly closed; §6's no-v18-client-rung and
+§5.6 match the pinned decision record.

--- a/docs/planning/move-desync-tracer-plan.md
+++ b/docs/planning/move-desync-tracer-plan.md
@@ -1,0 +1,423 @@
+# Movement desync tracer — implementation plan v2.1 (2026-08-06)
+
+Implements §5 of `docs/planning/moved-wrongly-investigation-2026-08-06.md`: server-side
+observability for the three movement-rejection paths in 26.2's
+`ServerGamePacketListenerImpl.handleMovePlayer`, plus per-flight telemetry, so organic
+events on the live server arrive labeled with the data that decides the hypothesis.
+
+**v2 (same day): reworked after a two-Opus review round** (mixin/bytecode feasibility +
+scientific utility; findings and dispositions in §7). The v1 draft's mixin design was
+verified sound at the bytecode level where it mattered (INVOKE census, post-`move()`
+position semantics, the full Moonrise bridge), but it carried one real blocker — the
+accessor mixins would have hard-crashed *tracer-disabled* servers on a future MC field
+rename — and its success criterion licensed wrong conclusions in both directions from
+the first captured event. v2 fixes the crash surface, replaces the verdict logic with a
+three-valued criterion backed by new fields, and adds the operational hardening a
+~weekly event cadence demands. **v2.1: one MAJOR + four small fixes from the follow-up
+single-Fable full-plan review** (§7.1) — chiefly that the REFUTE arm's retro-dating
+evidence must live in the 5 Hz ring, not only the 1 Hz rows: at elytra speed the 1 Hz
+rows' ±2-chunk mask anchors ~1.5–2 chunks behind the event position, so the collision
+chunk falls outside exactly when it matters, collapsing every `sent:true` event into
+INDETERMINATE for want of data the tracer could cheaply have written.
+
+**Activation: `-Dlss.moveTrace=true`, OR the presence of a marker file
+`config/lss-move-trace.enable` (content ignored).** No config key, nothing in
+`lss-server-config.json`, absent from the documented config surface (user decision).
+The marker file is not configuration — nothing is read from it; it exists because the
+only guaranteed channels to the live host are SFTP and RCON, and the Modrinth panel's
+support for custom JVM flags is unverified (review U-9). Default absent → fully off: no
+file, no thread, hook bodies no-op after one static boolean check (the
+`-Dlss.admissionTrace` precedent).
+
+**Scope: Fabric only.** The repro server is Fabric; Paper cannot mixin. Explicitly out
+of scope until a Paper server exhibits events. The **vehicle path**
+(`handleMoveVehicle` has its own `moved wrongly!`/`moved too quickly!` warns and its
+own silent rejection) is also out of scope — stated so a log-census grep is never
+misattributed to the player path (review F-13).
+
+## 0. Design constraints
+
+1. **Must observe every client** — modded, vanilla, cheating — with zero client
+   cooperation.
+2. **Must work with LSS disabled** and for unregistered players (the E2 control
+   flights): tracer lifecycle hangs off Fabric server lifecycle events in `LSSMod`,
+   never off `RequestProcessingService`, and **every transport field lives in the row
+   envelope, not the `lss` block** (reviews F-4/U-6 — v1 put obuf inside `lss`, which
+   is null in exactly the control arms that need a baseline).
+3. **Inert when off, near-free when on.** Event paths fire a few times per session;
+   telemetry is cheap per §1.5. Captures assemble a record and `offer()` it to a
+   bounded queue; drops are counted, never waited on.
+4. **Diagnostic code must never take the server down — including when OFF.** This is
+   why the mixins get their own **non-required config** (§1.2): `@Accessor` has no
+   soft-fail path, and accessor mixins apply at classload regardless of the property
+   gate. A failure anywhere degrades to missing fields, warned once.
+5. **Never confidently wrong.** Fields that cannot be captured are ABSENT, not zeroed;
+   flags that could latch stale are self-invalidating (§1.2's packet-identity token);
+   quantities that differ by rung carry different names (§1.3).
+
+## 1. Components
+
+### 1.1 `dev.vox.lss.trace.MoveDesyncTracer` (fabric module, production package)
+
+The writer. Ships in the release jar (`release_check.py`'s forbidden globs cover only
+`benchmark`/`soak` — verified untouched; the new top-level package is a deliberate
+choice, noted here per review F-13).
+
+- Bootstrap from `LSSMod` behind the §0 gate; **the marker file is read once at
+  `SERVER_STARTING`** (Fable F2-11: the config dir is absolute via FabricLoader by
+  then, the static gate is set strictly before any `handleMovePlayer` can run, and the
+  upload-then-restart deploy procedure makes the check race-free by operation). When
+  enabled, one INFO at server start: `Move desync tracer ACTIVE -> <path>` — a deploy
+  missing the flag is visible in the first screenful. **The negative check is part of
+  the deploy procedure** (§4).
+- Output: `<serverDir>/logs/lss-move-trace.jsonl` (override `-Dlss.moveTrace.file=`).
+  Append across restarts; every row carries `bootId` + schema version (§1.6).
+- Single daemon writer thread (`LSS-MoveTrace`), `ArrayBlockingQueue<String>` 4096,
+  `offer()` from game threads, `dropped` counter carried in the next row. Buffered
+  writer, flush per row (rows are sparse; a crash must not lose its own event).
+- **Rotation, not truncation** (review U-13): at 128 MiB rotate once to
+  `lss-move-trace.1.jsonl` (256 MiB total cap), `LSSLogger.warn` on rotation and on
+  final cap — `latest.log` is where the operator greps; a sentinel row inside a file
+  nobody is watching is not an alert.
+- Shutdown: `SERVER_STOPPING` → drain, close.
+
+### 1.2 Mixins — own config `lss-trace.mixins.json` with `"required": false`
+
+**The v1 blocker (review F-1):** `@Accessor` has no `require` member and throws
+`InvalidAccessorException` unconditionally on a missing field; under `lss.mixins.json`'s
+`"required": true` that is a hard crash at class transform **for every server,
+including tracer-disabled ones**, on any MC bump that renames `firstGoodX` — and plain
+reflection cannot substitute (production fields are intermediary-named; the same rule
+that bans `Class.forName` on MC types). Fix: the trace mixins live in their own
+`lss-trace.mixins.json` with `"required": false` (registered alongside the main config
+in `fabric.mod.json`), so a failed accessor downgrades to a mixin WARN; the
+`((AccessorServerGamePacketListener) listener)` cast then throws `ClassCastException`
+into the tracer's catch-all — the `FabricChannelPressure` degrade shape. A Tier 1
+reflective existence pin for every accessed field (§3) turns the same drift into a red
+test at build time.
+
+**`MovementRejectHook`** (`@Mixin(ServerGamePacketListenerImpl.class)`) — **four**
+injects into `handleMovePlayer`, every body delegating to
+`dev.vox.lss.trace.MoveDesyncHooks` (the `ChunkSaveDataHook` pattern), all `require=0`,
+callbacks `lss$`-prefixed per repo convention:
+
+| inject | target | purpose |
+|---|---|---|
+| `lss$onMoveHead` | `@At("HEAD")` | stores pre-move `player.getX/Y/Z()` into `@Unique lss$startX/Y/Z` (review F-5: at HEAD the entity has not moved — `resetPosition()` reseeds `firstGood*` only — so these equal the method's `startX/Y/Z` locals exactly, making claimed-target recomputation exact for `Rot`/`StatusOnly` packets whose `packet.get*(default)` falls back to the *current* position); updates the per-player move-packet gap clock (review U-5: `move_gap_ms` / `move_gap_max_5s_ms` — the only server-side client-stall measurement, and it works identically in the LOD-off control arms) |
+| `lss$onMovedTooQuickly` | the `moved too quickly!` warn INVOKE — targeted by **descriptor alone**, `warn(String, Object[])`, `remap = false` on the slf4j `@At` (reviews F-6/F-7: the two warns have distinct descriptors, so no ordinal is needed) | reconstructs the check's inputs exactly: cumulative deltas from `firstGood*`, `expectedDist` from `getDeltaMovement()`, and **both** `delta_packets` (raw burst size) and `delta_packets_used` (the post-clamp value the check applied — review F-8: a >5 burst is *penalized* to 1, and an analyst given only the raw count computes the wrong threshold) |
+| `lss$onMovedWrongly` | the `moved wrongly!` warn INVOKE — descriptor `warn(String, Object)`, `remap = false` | at this point `player.getX/Y/Z()` IS the post-`move()` simulated stop (bytecode-verified); stores the packet reference into `@Unique lss$wronglyPacket` (review F-3: a packet-identity token, not a boolean — no HEAD clear needed, self-expires with the packet, and a partially-applied mixin degrades to `logged_wrongly:false` instead of latching true) |
+| `lss$onMoveRejected` | the rejection `teleport(DDDFF)V` INVOKE, anchored **semantically** by a `@Slice(from = the wrongly-warn INVOKE)` + ordinal 0 within the slice — "the first teleport after the `moved wrongly` warn site" (review F-6: a bare ordinal silently retargets if vanilla reorders; the slice encodes what the code means). The teleport `@At` keeps default `remap = true` — it is a target-class method | fires for BOTH the logged rejection and the **silent** `isEntityCollidingWithAnythingNew` rejection (zero observability today); `logged_wrongly = (lss$wronglyPacket == packet)` |
+
+`clampHorizontal`/`clampVertical` are private statics (`Mth.clamp` ±3.0E7/±2.0E7) and
+are replicated in the hook bodies. No `@Local`/LocalCapture anywhere (MixinExtras
+`@Local` is on the classpath as a fallback if the HEAD capture ever proves
+insufficient — review F-5 — but v2 does not need it). `lss$wronglyPacket` retains a
+strong reference to the last rejected packet for the listener's lifetime — a few
+hundred bytes that die with the connection; deliberate (Fable F2-11).
+
+**Accessors** — `AccessorServerGamePacketListener` (`firstGoodX/Y/Z`, `lastGoodX/Y/Z`,
+`receivedMovePacketCount`, `knownMovePacketCount`, `awaitingPositionFromClient`), in
+the non-required config. **`AccessorPlayerChunkSender` is dropped** (review F-13):
+`PlayerChunkSender.isPending(long)` and `chunkSender` are public, which covers the
+vanilla rung's one keystone question with zero added crash surface; the rung's
+remaining private gauges are low-value on a deployment target where the rung is inert.
+
+### 1.3 Chunk-delivery state — two-rung resolver, `dev.vox.lss.trace.ChunkSendState`
+
+Rung order resolved once per JVM (lazy holder, `MoonriseReadCompat.build()` seam
+pattern — verified as the right precedent shape, F-10):
+
+1. **Moonrise rung** (the live server): `Class.forName` on
+   `ca.spottedleaf...ChunkSystemServerPlayer` (non-MC package — precedent-consistent),
+   MethodHandle `moonrise$getChunkLoader()` — **null-checked into "none" per call**
+   (F-10: it returns null in the dimension-change window) — then the public
+   `getSentChunksRaw()` plus reflective `Field` reads of `sendQueue`,
+   `chunkTicketStage`, `lastSendDistance`, `lastChunkX/Z`. All reads are server-thread
+   (Moonrise asserts `TickThread` on every mutator — thread-safety verified stronger
+   than v1 claimed). Captured per queried chunk / row (fields per review U-1/U-2):
+   - `sent_mask_5x5`: 25-bit membership bitmask of `sentChunks` around the anchor +
+     `anchor:[cx,cz]` — a **mask, not a count**, so the 1 Hz flight rows retro-answer
+     "when was this specific chunk first sent" at 1 s resolution (the send-time bound
+     Moonrise itself cannot give — it does not timestamp sends);
+   - `sent_r1`: 9-bit mask (a diagonal-chunk collision is otherwise unattributable);
+   - `stage`: the queried chunk's `chunkTicketStage` byte (0 NONE / 1 LOADING /
+     2 LOADED / 3 GENERATING / 4 GENERATED / 5 TICK) — distinguishes "**the server
+     hadn't loaded it either**" (falsifies the wire hypothesis for that event; wire
+     mitigations would do nothing) from "server had it and hadn't sent it";
+   - `send_radius` (`lastSendDistance`) + `loader_center` (`lastChunkX/Z`) — `sent:
+     false` is evidence only *inside* the radius, and a lagging loader center is its
+     own starvation mechanism;
+   - `send_queue` size + `send_head_stage`: the stage of `sendQueue.firstLong()` —
+     Moonrise's drain `break`s at a head whose neighbors aren't generated, so a large
+     queue with a not-ready head is **server-side head-of-line blocking** (a Chunky-
+     pregen-compatible mechanism the investigation never listed — review U-2).
+2. **Vanilla rung** (E6 local rig; unreachable on the live server): `chunkSender`
+   public field + public `isPending(long)`. Field is named **`not_pending`** — NOT
+   `sent` (review U-12): vanilla removes from `pendingChunks` at *collection* time and
+   never-tracked chunks are also "not pending", so this is a strictly weaker predicate
+   that cannot support the confirm criterion. Vanilla-rung rows are context, not
+   keystone evidence, and the differing field name makes cross-rung aggregation a
+   visible type error rather than silent nonsense.
+3. **No signal** → `rung:"none"`, fields absent, warn once.
+
+### 1.4 Row envelope and LSS context
+
+Envelope (every row): `v` (schema int), `bootId`, `wallMs`, `tick`, player id/name/dim,
+**`obuf`** (fresh read at capture time via the channel-pressure probe — widened via
+**the same public-factory refactor the yield plan's §1.1 probe-snapshot extension
+specifies; whichever PR lands first implements the combined shape** (Fable F2-8) — v1
+had it package-private, a compile blocker — needs no LSS registration, so control
+flights carry it),
+`latency_ms` (`connection.latency()` — free, but 15 s-smoothed: a link-quality
+baseline that sizes the sent-staleness allowance, NOT a stall detector — review U-1),
+`mspt`, `online`, `dropped`.
+
+`lss` block (null when unregistered/disabled — and that null is itself the A/B label):
+`registered`, `since_s`, `caps`, `proto`, `dialect` (v18/v16 rung if any — review
+U-16: "modded v19 client" is central to the census and must be machine-readable),
+`send_queue`, `bw_window`, and `yielded` **when the transport-yield feature exists**
+(phrased as a dependency; it is unimplemented today).
+
+**Boot row** (review U-7 — without it E4's bandwidth sweep is unanalyzable):
+`{"type":"boot"}` carrying schema version, `tz_offset_min` (log correlation needs the
+server's TZ), LSS + MC versions, moonrise/c2me/chunky presence, the resolved rung, and
+a snapshot of load-bearing config (`bytesPerSecondLimitPerPlayer`/`Global`,
+`lodDistanceChunks`, `lodStore`, `outboundBufferCeilingKB`,
+`lodYieldsToVanillaTransport` if present). Analysis keys on `v`.
+
+### 1.5 Event rows and flight telemetry
+
+Event rows (`too_quickly` / `wrongly` / `rejected`) — schema **split by type**
+(review U-14: `too_quickly` returns before `move()` ever runs, so `simulated`/
+`residual` are ABSENT there, not null/zero):
+
+- all: `origin` (`lastGood*` for wrongly/rejected, `firstGood*` for too_quickly —
+  review U-4: v1 captured it and never emitted it, leaving the swept segment
+  unreconstructable), `claimed`, `fall_flying`, `speed`, `awaiting_tp`,
+  `move_gap_ms`, `move_gap_max_5s_ms`, send-state block(s);
+- `too_quickly`: `delta_packets`, `delta_packets_used`, `expected_dist`;
+- `wrongly`/`rejected`: `simulated` (the collision point — `move()` sweeps, so the
+  stop IS on the swept path), `residual`, `residual_h`, `restored` (the teleport
+  destination = the pre-move position from `lss$startX/Y/Z` — the player-felt snap
+  distance is `claimed − restored`, not `claimed − simulated`; reviews F-9/U-4),
+  `logged_wrongly`, `entity_collide` (`!level.getEntityCollisions(player,
+  sweptAABB).isEmpty()` — a boat/shulker produces the same residual as terrain and is
+  otherwise invisible; review U-3), `stop_block` (the block state id at the collision
+  face — names what the server thinks stopped them), and send-state for BOTH the
+  simulated-stop chunk and the claimed chunk.
+
+Flight telemetry (review U-11 — v1's 1 Hz/fast-players-only missed the population and
+the timescale):
+
+- **Arm condition**: `isFallFlying()` OR speed > 6 blocks/s OR **the player's LSS send
+  queue is non-empty** (actively streaming LOD — the actual hypothesis population;
+  walking players during the backfill flood were invisible to v1's trigger) OR an
+  event in the last 30 s.
+- **1 Hz `flight` rows** for armed players: position, speed, `sent_mask_5x5` +
+  loader fields, `obuf`, `latency_ms`, `lss` block, `mspt`, and the level's loaded-
+  chunk count (moves visibly under Chunky pregen — the "was pregen running" signal,
+  review U-16).
+- **5 Hz in-memory ring** (40 samples @ every 4 ticks, primitive fields only, no JSON
+  off the event path): flushed as `flight_ring` rows ahead of any event row — 8 s of
+  5 Hz trailing context, which 1 Hz structurally cannot give for a sub-second
+  collapse, including for a first event with no prior 1 Hz rows. **Per-sample fields
+  explicitly include `sent_mask_5x5` + anchor and the loader-center fields**
+  (Fable F2-4: 25 hash-set membership tests at 5 Hz are negligible, and without the
+  mask in the ring the §1.6 REFUTE arm is structurally unsatisfiable at flight speed —
+  an elytra player moves ~2 chunks/s, so the 1 Hz rows' anchor trails 1.5–2 chunks
+  behind the event position and the collision chunk exits the ±2 mask exactly in the
+  regime the tracer exists for; at 5 Hz it stays comfortably inside for the whole
+  latency+500 ms lookback), plus position, speed, `obuf`, and the gap clock.
+- **Per-player state cleanup** (Fable F2-9): gap clocks, rings, and arm timers are
+  cleared on disconnect via the lifecycle events the tracer already hangs off —
+  trivial rates today, but a weeks-long campaign must not leak by construction.
+
+### 1.6 The success criterion — three-valued, honestly (reviews U-1/U-2/F-4)
+
+v1's binary confirm/refute licensed wrong conclusions in both directions. v2:
+
+- **CONFIRMS** the missing-terrain clip: `sent:false` at the collision chunk AND
+  inside `send_radius` AND `stage >= 2` (LOADED or beyond — the server had it and
+  hadn't sent it). Note `stage <= 1` is its own decisive result: the *server* didn't
+  have the terrain — a server-side loading/generation shortfall, not a wire problem.
+- **REFUTES** it for that event: `sent:true` AND the preceding **`flight_ring` rows**
+  (the 5 Hz ring flushed ahead of every event — the 1 Hz rows cannot carry this
+  evidence at flight speed, Fable F2-4) show the chunk already sent ≥ (`latency_ms` +
+  500 ms) before the event AND `obuf` small at event time — then the client had ample
+  time to receive and apply, and attention moves to the residual vector
+  (`entity_collide`, `stop_block`).
+- **INDETERMINATE**: `sent:true` without that prior-row evidence. On Moonrise,
+  `sentChunks` stamps at the instant of the Netty write and the sender is
+  effectively unthrottled, so `sent:true` is expected to be common and **a deep
+  `obuf` at event time with `sent:true` supports the same conclusion by the transport
+  measurement** (packets written but queued behind LOD bytes). The server cannot
+  prove the client *applied* a chunk — Moonrise has no chunk ACK at all — so the
+  sent-but-not-applied direction is closable only client-side. **One indeterminate
+  event is the trigger to build the client-side hole map** (investigation §5.2),
+  which v1 deferred with no re-entry condition.
+
+Also stated plainly (review U-15): a `wrongly` row without a paired `rejected` row in
+the same tick was **accepted with a warning** — no rubber-band. Player-felt
+rubber-bands = `too_quickly` + `rejected`. The investigation's census conflated these.
+
+## 2. What the tracer deliberately does NOT do
+
+- No config key, no `/lsslod` verb. **One diag line, present only while the tracer is
+  active** (review U-10 — restoring investigation §5.1.3's promised counter):
+  `MoveTrace: rung=moonrise rows=N drops=0 tooquick=A wrongly=B rejected=C silent=D`.
+  This is simultaneously the post-deploy verification (`rung=moonrise` over RCON in
+  one call, instead of discovering `rung:none` from a week of unlabeled events) and
+  the on-demand silent-rejection rate the whole investigation was missing. Tracer
+  off → the line is absent; the diag surface is unchanged.
+- No client-side changes (the §5.2 hole map is the *named follow-up*, triggered by an
+  indeterminate verdict).
+- No packet capture beyond the HEAD gap-clock; no per-move rows.
+- No soak/schema integration; the harness never sets the property.
+- No vehicle-path coverage (§ preamble).
+
+## 3. Tests
+
+- **Tier 1 — `MoveDesyncTracerTest`**: constructor-injected sink/enablement; writer
+  lifecycle, overflow drops counted, rotation at the cap + warn, JSON goldens per row
+  type (absent-vs-null discipline pinned), disabled instance writes nothing.
+- **Tier 1 — pure-core split** (review F-12): the hook bodies are a thin MC-typed
+  capture layer over an MC-free core (`MoveEventMath` — residual/clamp/gap math,
+  `MoveRow` — rendering); Tier 1 drives the core (a `ServerPlayer` cannot be
+  constructed under fabric-loader-junit).
+- **Tier 1 — `MoonriseSendStateCompatTest`**: resolution ladder against
+  real-package-name stubs under `fabric/src/test/java/ca/spottedleaf/` (precedent:
+  `MoonriseReadCompatTest`): resolve, mod-absent → vanilla rung, shape drift →
+  no-signal + one warn, **null chunk-loader → "none" per call** (the dim-change
+  window).
+- **Tier 1 — field-existence pins** (review F-1): reflective `getDeclaredField` for
+  every accessor target and every Moonrise `Field` read, against the real named
+  classes (the test JVM runs in the named namespace — `LanHookContractTest` proves MC
+  classes load there; note that test is *reflective*, not a bytecode scan — F-11).
+- **Tier 1 — `MoveTraceHookContractTest`**: source-regex pins on the mixin
+  (targets/`require=0`/delegation-only/`remap=false` on slf4j `@At`s/the
+  `lss-trace.mixins.json` listing + its `"required": false`), PLUS an **ASM
+  `ClassReader`/`ClassNode` scan** of the real `handleMovePlayer` (ASM is already on
+  the test runtime classpath via fabric-loader; the `FoliaWiringContractTest`
+  constant-pool idiom cannot count per-method INVOKEs — F-11) asserting: exactly one
+  `warn(String,Object[])` and one `warn(String,Object)` INVOKE, exactly three
+  `teleport(DDDFF)V` INVOKEs, and the **relative order** (the wrongly-warn offset
+  lies between teleports #2 and #3) — the slice-anchor's tripwire.
+- **Tier 2 — `MoveTraceGameTests`** (new class; MUST be listed in the
+  `fabric-gametest` entrypoint — `GameTestEntrypointContractTest` enforces): via the
+  test seam (`enableForTest(inMemorySink)` — the gametest JVM does not set the
+  property). **The stock mock player cannot fire the `wrongly` warn — it is
+  hard-coded CREATIVE** (review F-2: `GameTestHelper$3` overrides `gameMode()` to
+  CREATIVE and the warn is gated `!isCreative()`). The test hand-rolls a survival
+  player replicating the factory's steps (`new ServerPlayer(...)`, `new
+  Connection(SERVERBOUND)`, `EmbeddedChannel`, `CommonListenerCookie.createInitial`,
+  `placeNewPlayer`) — `hasClientLoaded()` is true out of the box and gametests run on
+  the server thread, so `connection.handleMovePlayer(...)` is directly drivable.
+  **One fresh player per assertion** (a rejection latches `awaitingPositionFromClient`
+  and every later move early-returns; the mock connection never ticks, so
+  `resetPosition()` reseeds per call and `delta_packets` climbs monotonically —
+  budgeted, not fought). Assertions: (a) an 18.5-block claim → `too_quickly` row with
+  both packet-count fields; (b) a claim ending inside placed blocks → `rejected` row
+  with `logged_wrongly` matching whether the warn fired; (c) the `wrongly` row via
+  the survival player. Documented fallback if the hand-rolled player fights back:
+  keep (a)+(b) on the creative mock — both reachable — and drop only (c).
+- **Tier 1 — diag golden** (Fable F2-10): the conditional `MoveTrace:` line in
+  `DiagnosticsFormatter` gets golden coverage — present-when-active,
+  absent-when-off — following the `V18Compat` conditional-slot precedent.
+- **`scripts/check_move_trace.py`** (review U-14): stdlib validator, `--validate` +
+  `--selftest`, enforcing required keys per row type, `v` compatibility, per-boot
+  monotonic `wallMs`, monotone `dropped`, rung/field consistency (`sent_mask_5x5`
+  only on `rung:"moonrise"`). Its selftest fixtures ARE the Tier 1 goldens (shared
+  file under `scripts/testdata/`) so writer and reader cannot drift — the
+  `check_soak.py --selftest` culture applied to this file.
+
+## 4. Deployment & operation (Modrinth server)
+
+1. Build from a branch **without the transport yield armed** (review U-8): the yield
+   suppresses exactly the obuf signal that decides hypothesis (c); the tracer must
+   collect the baseline first. (The yield plan v2 is default-off, which satisfies
+   this — the constraint is recorded so a combined build doesn't flip it.)
+2. SFTP the jar; `touch` the marker file over SFTP (or set the JVM flag if the panel
+   allows); Restart via archon.
+3. **Verify, in order**: `Move desync tracer ACTIVE` in `latest.log` (absent = the
+   gate didn't take — do not wait a week to learn it from an empty file);
+   `rcon.py "lsslod diag"` shows `MoveTrace: rung=moonrise` (`rung=none` = the
+   reflective bridge failed and every event will arrive unlabeled); after the first
+   flight, the JSONL is visible over SFTP.
+4. Collect by SFTP; run `check_move_trace.py --validate` before analysis; delete
+   after each pass. Rotation bounds disk (§1.1).
+5. Events feed the investigation's E-series; the §1.6 verdict decides the next step
+   (notably: indeterminate → build §5.2's client hole map). **Analysis must partition
+   rows by the boot row's `lodYieldsToVanillaTransport` snapshot** (Fable cross-plan):
+   an armed-yield collection period shifts the envelope `obuf` distribution by design,
+   and mixing armed and unarmed boots corrupts the hypothesis-(c) baseline.
+
+## 5. Effort (v2)
+
+| piece | estimate |
+|---|---|
+| Tracer + hooks + pure core + schema | ~half a day |
+| Mixins (own config) + accessors + contract tests + field pins | ~half a day |
+| Moonrise rung (incl. stage/radius/center/head fields) + tests | ~half a day |
+| Tier 2 (hand-rolled survival player) | ~half a day, the stated fallback bounds it |
+| `check_move_trace.py` + shared fixtures | ~2 hours |
+| Deploy + verification pass | ~an hour |
+
+No wire changes, no protocol bump, no config-file surface, no Paper changes.
+
+## 6. What the tracer can and cannot decide (kept honest)
+
+- Hypothesis (a) — collision chunk not client-delivered: decidable per §1.6, with the
+  indeterminate class explicitly named and its escalation path defined.
+- Hypothesis (b) — stalls LOD-caused: `move_gap_*` measures the stall server-side on
+  every row including control arms (the E2 A/B then attributes it); flat
+  `latency_ms` alongside large move-gaps points at main-thread stalls over link
+  degradation (the keep-alive reply is written off the client main thread — U-5).
+- Hypothesis (c) — wire head-of-line: `obuf` in the envelope on all arms.
+- Out of reach server-side, by construction: client *apply* confirmation (Moonrise
+  has no chunk ACK). That is §5.2's job, triggered as above.
+
+## 7. Review round record (2026-08-06, two Opus reviewers: feasibility + utility)
+
+| finding | disposition |
+|---|---|
+| F-1 accessors can't soft-fail; required config would crash tracer-disabled servers on MC drift | v2 §1.2: own `lss-trace.mixins.json` `"required": false` + cast-degrade + Tier 1 field pins |
+| F-2 gametest mock player is hard-coded CREATIVE — `wrongly` unreachable | §3 Tier 2: hand-rolled survival player, fresh per assertion, documented fallback |
+| F-3 `loggedWrongly` HEAD-clear could latch true if partially applied | §1.2 packet-identity token, degrades false |
+| F-4/U-6 obuf inside `lss` block = no control-arm baseline; keystone saturated on Moonrise | §1.4 envelope `obuf` (public probe access); §1.6 obuf as the Moonrise discriminator |
+| F-5 claimed-target recompute diverges for non-`Pos` packets post-move | §1.2 HEAD capture of pre-move position; clamp replication; `@Local` noted as fallback |
+| F-6/F-7 warn descriptors distinct (no ordinals needed); slice-anchor the rejection teleport; `remap=false` on slf4j `@At`s; count-scan can't catch reordering | §1.2 targeting scheme; §3 ASM scan asserts counts AND relative order |
+| F-8 raw `delta_packets` is not the number the check used | §1.5 emits both raw + used |
+| F-9/U-4 rubber-band destination + origin missing from schema | §1.5 `origin` + `restored` |
+| F-10 null chunk-loader in dim-change window; thread-safety verified stronger | §1.3 null → "none"; noted |
+| F-11 ASM available; constant-pool idiom insufficient; `LanHookContractTest` mis-described | §3 corrected |
+| F-12 hook bodies untestable without a layer split | §3 pure core |
+| F-13 drop `AccessorPlayerChunkSender` (public `isPending`); vehicle path; package naming | §1.2 dropped; preamble; §1.1 |
+| U-1 `sent:true` cannot refute (no ACK anywhere on Moonrise); "no recent stall" wasn't captured | §1.6 three-valued verdict; §1.3 masks; `latency_ms`; move-gap fields |
+| U-2 `sent:false` can false-confirm (server-unloaded / out-of-radius / head-of-line) | §1.3 `stage`/`send_radius`/`loader_center`/`send_head_stage`; §1.6 conjuncts |
+| U-3 entity collisions indistinguishable from terrain | §1.5 `entity_collide` + `stop_block` |
+| U-5 no server-side stall measurement existed | §1.2 HEAD gap clock; §6 |
+| U-7 no boot row / schema version — E4 unanalyzable | §1.4 boot row + `v` |
+| U-8 yield deploy would destroy the (c) baseline | §4.1 sequencing constraint |
+| U-9 activation single-point-of-failure on an unverified panel feature | marker-file fallback (not a config key) |
+| U-10 no post-deploy rung verification; §5.1.3's diag counter dropped | §2 active-only diag line |
+| U-11 1 Hz misses sub-second collapse; speed trigger misses walking backfill players | §1.5 LSS-streaming arm + 5 Hz ring |
+| U-12 vanilla-rung `sent` is a different quantity | §1.3 `not_pending` rename |
+| U-13 silent stop at cap mid-campaign | §1.1 rotate + warn |
+| U-14 nothing pins the reader; `too_quickly` carried meaningless fields | §3 validator + shared fixtures; §1.5 per-type schema |
+| U-15 `wrongly` ≠ rubber-band | §1.6 stated; census corrected |
+| U-16 caps/proto/dialect, `awaiting_tp`, loaded-chunk count, §5.2 re-entry trigger | §1.4/§1.5/§1.6 |
+
+### 7.1 Review round record — round 2 (one Fable reviewer, full v2 pass, both plans)
+
+Verdict: "ready after fixes — all round-1 dispositions faithfully implemented; every
+bytecode-facing claim checked verifies against the decompiled 26.2 / Moonrise / C2ME
+ground truth." Fixes applied in v2.1:
+
+| finding | disposition |
+|---|---|
+| F2-4 MAJOR: REFUTE retro-dating unsatisfiable at flight speed — the 1 Hz rows' ±2 mask anchors 1.5–2 chunks behind the event; every `sent:true` would collapse to INDETERMINATE | §1.5: `sent_mask_5x5` + anchor + loader-center added to the 5 Hz ring's per-sample fields; §1.6 REFUTE keyed on `flight_ring` rows |
+| F2-8: probe widening must be the same refactor as the yield plan's snapshot extension | §1.4 combined-shape reference; one owner, whichever PR lands first |
+| F2-9: no per-player tracer-state cleanup | §1.5 disconnect sweep |
+| F2-10: conditional diag line lacked golden coverage | §3 formatter golden (V18Compat precedent) |
+| F2-11: marker-read instant unpinned; `lss$wronglyPacket` strong reference unstated | §1.1 `SERVER_STARTING`; §1.2 deliberate-retention note |
+| F2 cross-plan: armed-yield collection shifts the `obuf` distribution | §4.5 partition-by-boot-flag requirement |

--- a/docs/planning/moved-wrongly-investigation-2026-08-06.md
+++ b/docs/planning/moved-wrongly-investigation-2026-08-06.md
@@ -1,0 +1,284 @@
+# "moved wrongly!" on the live server — investigation + instrumentation plan (2026-08-06)
+
+Fresh analysis, from scratch, per user request — prior elytra-wall conclusions deliberately
+set aside. The 2026-08-01 doc is cited only for raw measurements, never conclusions.
+
+Evidence base:
+- The **complete** live-server log archive (46 files, 2026-07-21 → 2026-08-06 — this covers
+  the server's whole lifetime, nothing rotated away).
+- Live config + `/lsslod diag` over RCON, deployed jar identity (v0.9.1+26.2).
+- Decompiled MC 26.2 (mapped `minecraft-merged-deobf-26.2.jar`, Vineflower):
+  `ServerGamePacketListenerImpl`, `LocalPlayer`, `ClientLevel`, `BlockCollisions`,
+  `PlayerChunkSender`, `GameRules`.
+
+## 1. Event census (all of it — the server's entire log history)
+
+79 joins total. Movement-check warnings:
+
+| warning | count | players | days |
+|---|---|---|---|
+| `moved wrongly!` | **3** | Roihesse611, Voximus_Maximus, batidak | 08-04, 08-05, 08-06 |
+| `moved too quickly!` | **51** | Voximus_Maximus (24), AnonyBrave (25), GameSuchtYT (2) | 07-29, 08-01 (43!), 08-03 |
+| `Can't keep up` (server tick behind) | **0** | — | — |
+
+The three `moved wrongly` events in full context:
+
+| player | event time | after LSS registration | others online | what followed |
+|---|---|---|---|---|
+| Roihesse611 | 08-04 12:34:40 | 3 m 12 s | **nobody** | `lost connection: Disconnected` **2 s later** |
+| Voximus_Maximus | 08-05 17:32:38 | 1 m 54 s | **nobody** (Chunky nether pregen running at ~110 cps) | stayed 7 more min |
+| batidak | 08-06 13:02:00 | 1 m 28 s | **nobody** | `lost connection: Disconnected` **13 s later** |
+
+The `moved too quickly` storms likewise start moments after join: Voximus 08-01 first trip
+**19 s** after joining; AnonyBrave first trip **36 s** after joining, then ~25 trips over
+5 minutes until they quit. Both were alone on the server.
+
+Load-bearing observations:
+
+1. **Every event happened with exactly one player online.** Multi-player bandwidth
+   contention and global-cap effects are ruled out. This is a single-client phenomenon.
+2. **Zero `Can't keep up` in 2.5 weeks.** The server tick loop was never meaningfully
+   behind — sustained server overload is effectively ruled out as the driver. (Fine-grained
+   MSPT spikes below the 2 s-behind threshold remain possible; the tracer below samples
+   MSPT to close that residual.)
+3. **Every affected session is a modded v19 (0.9.x) client** (`capabilities=3` handshakes)
+   in its **first ~3 minutes** — i.e. during the LOD backfill flood, when the server streams
+   at the full per-player cap and the client decodes/ingests hardest.
+4. **The retuned caps did not fix it**: batidak's event is from *today*, on v0.9.1 with the
+   15 MB/s per-player / 60 MB/s global caps.
+5. Two of three `moved wrongly` events were followed by a disconnect within seconds
+   (`Disconnected` = the TCP connection closed — covers both a deliberate quit and a client
+   crash; a hung-but-alive client would show `Timed out`, of which there is exactly 1 all
+   month).
+6. The `moved too quickly` deltas are diagnostic: 17–19 blocks *per packet*, i.e. right at
+   the elytra threshold √300 ≈ 17.3 (see §2). At ~1.7 blocks/tick elytra speed that is
+   **half a second or more of flight claimed in one movement step** — the signature of the
+   client's tick loop stalling and catching up, or of a network burst.
+7. Footnote (unchased): Roihesse611's and batidak's *first* sessions of the day each show
+   **no LSS handshake at all** and lasted under 2 minutes; both rejoined and handshook
+   normally. Possibly a client-side first-join init race in our client mod — worth an
+   eventual look, unrelated to movement.
+
+## 2. What the two warnings actually mean on 26.2 (decompiled, not folklore)
+
+From `ServerGamePacketListenerImpl.handleMovePlayer` (26.2 mojmap):
+
+**`moved too quickly!`** — cumulative distance this tick vs an allowance of
+`300 (elytra) / 100 (normal)` **per move packet**, with a burst clamp: if more than **5**
+move packets arrive in one server tick, the packet count is **clamped to 1**, so a burst of
+queued packets gets a single packet's allowance. Consequence: *any* client stall (or network
+stall) > ~0.5 s during fast elytra flight trips it almost by construction — the queued
+packets arrive as a burst, the clamp strips their allowance, and the cumulative delta
+(~18 blocks) exceeds √300. The server teleports the player back (rubber-band). This check —
+and only this check — is gamerule-gated: `player_movement_check`, `elytra_movement_check`.
+
+**`moved wrongly!`** — the server replays the client's claimed delta through real collision
+(`player.move(MoverType.PLAYER, …)`) and compares. The vertical residual is always forgiven
+(the long-standing `yDist > -0.5 || yDist < 0.5` tautology zeroes it), so on 26.2 this
+warning fires **only for a horizontal residual > 0.25 blocks** — i.e. *the client claims it
+flew through space the server considers solid*. Sleeping/creative/spectator/dimension-change
+and the **post-firework-impulse grace** are exempt — so these events are not the rocket
+boost itself. Not gamerule-gated.
+
+**The silent third path** — even when the distance residual passes, a move that ends
+overlapping *new* server-side collision (`isEntityCollidingWithAnythingNew`) is rejected
+and teleported back **with no log line at all**. The logs therefore *undercount*
+player-felt rubber-banding; "a lot of players" complaining is consistent with 3 logged
+events + 51 too-quickly events + an unknown number of silent rejections.
+
+### 2.1 The 26.2 regression that makes this possible
+
+**26.2 removed the client's unloaded-chunk movement freeze.** On earlier lines,
+`LocalPlayer.tick()` refused to run physics unless the chunk at the player's own position
+was loaded (`hasChunkAt`) — a player who outran chunk delivery froze mid-air (the "wall").
+On 26.2, `LocalPlayer.tick()` gates only on `connection.hasClientLoaded()` (a one-time
+login/respawn flag), `ClientLevel` has no per-chunk entity-tick gate, and `BlockCollisions`
+**skips unloaded chunks entirely** (null chunk → no collision). A 26.2 client that outruns
+vanilla chunk delivery keeps flying, with **no collision**, through terrain it has never
+received.
+
+The server, meanwhile, *does* have those chunks loaded (they're inside the player's ticket
+radius; server-side loading is fast — Moonrise, avg 0.5 ms reads, 110+ cps under Chunky).
+So the moment the flight path intersects server-solid terrain the client hasn't received:
+horizontal residual > 0.25 → **`moved wrongly!`** → teleport-back. If the client is only
+*near* terrain, the silent `collidingWithAnythingNew` rejection fires instead.
+
+### 2.2 The feedback loop that starves the client of terrain
+
+Vanilla chunk sending (`PlayerChunkSender`) is throttled by the **client's own ACKs**:
+`desiredChunksPerTick` comes from the client's `ChunkBatchReceived` reply (its self-measured
+processing rate, clamped 0.01…64, start 9), and at most 10 unacknowledged batches
+(1 until the first ACK) may be in flight. A client whose main thread is stalling —
+GC pauses, decode/apply work — ACKs late and reports a collapsed rate, so **the server cuts
+vanilla chunk delivery to a crawl, potentially 0.01 chunks/tick, while the player keeps
+flying at ~33 blocks/s.** Client-side stalls don't just cause rubber-bands directly; they
+actively starve the client of the terrain it is about to fly into.
+
+**Correction (2026-08-06, same day, verified against Moonrise-Fabric 1.1.0 bytecode):
+the ACK feedback loop above applies only to vanilla-chunk-system servers — NOT the live
+server.** Moonrise's `RegionizedPlayerChunkLoader$PlayerChunkLoaderData` schedules chunk
+sends itself (own priority `sendQueue` + `StaggeredRateLimiter`, `MAX_RATE` 10000/tick)
+and calls the *static* `PlayerChunkSender.sendChunk` per chunk — vanilla's batch/ACK flow
+control (`sendNextChunks`, `desiredChunksPerTick`, `unacknowledgedBatches`) never runs,
+and the per-player `chunkSender` instance state is inert. On Moonrise, a stalling client
+cannot slow the sender; the backlog lands in the **Netty outbound buffer / TCP window**
+instead — which shifts the starvation mechanism for the live server toward transport
+head-of-line (LOD bytes queued ahead of chunk packets in the shared obuf) and client-side
+apply lag, and *strengthens* the case for the M1 transport-yield mitigation and for obuf
+data in every tracer row. Consequence for instrumentation: the tracer must read
+**Moonrise's** `sentChunks`/`sendQueue` (public `getSentChunksRaw()`, interface-injected
+`moonrise$getChunkLoader()`) on Moonrise servers and vanilla's `PlayerChunkSender` only as
+the fallback rung — reading vanilla state on the live server would produce confident
+nonsense. Plans: `move-desync-tracer-plan.md`, `vanilla-first-lod-yield-plan.md`.
+
+## 3. Causal model (primary hypothesis)
+
+```
+LOD stream at the per-player cap (15 MB/s raw today; 21–25 MB/s in the 08-01 incident band)
+        │  client must decompress (zstd) + decode + ingest into Voxy
+        ▼
+client main-thread stalls / GC pauses           ← directly evidenced by the √300-edge
+        │                                          burst deltas in `moved too quickly`
+        ├───────────────► burst arrivals + the >5-packet clamp → `moved too quickly!`
+        ▼                                          → teleport-back rubber-bands
+slow ChunkBatchReceived ACKs, low desiredChunksPerTick
+        ▼
+vanilla chunk delivery collapses (§2.2) while flight continues at full speed
+        ▼
+client crosses into terrain it never received — 26.2 no longer freezes it (§2.1)
+        ▼
+client physics: no collision. server physics: mountain.
+        ▼
+horizontal residual > 0.25 → `moved wrongly!` (+ silent rejections nearby)
+        ▼
+rubber-banding player quits (2 of 3 disconnected within seconds) — or the client
+was already dying (OOM/crash) and the bad movement was its death throes
+```
+
+What the evidence already supports vs. what still needs proof:
+
+- **Supported**: the 26.2 mechanics (decompiled, §2); events cluster in the backfill-flood
+  window on modded clients with nobody else online; server tick and disk exonerated; client
+  stalls of ≥0.5 s provably occurred (burst deltas); the prior doc's raw measurements put
+  the incident at 21–25 MB/s *raw* sustained to one client (a client-processing-bound
+  signature, ~3–4 MB/s on the wire after zstd).
+- **Not yet proven** (instrumentation targets): (a) that the collision point of a
+  `moved wrongly` event lies in a chunk the client hadn't received/ACKed — the keystone
+  claim; (b) that the client stalls are LOD-caused rather than the player's machine being
+  generally weak (A/B settles this); (c) whether the wire share (head-of-line behind LOD
+  bytes) contributes materially vs. pure client CPU/GC (obuf data settles this).
+
+## 4. Alternatives kept open (and how each gets decided)
+
+| alternative | current standing | decided by |
+|---|---|---|
+| Vanilla-inherent 26.2 problem, LSS only amplifies | plausible — any slow chunk delivery + elytra now clips terrain | E2c control flight (clean vanilla client, LOD server off) |
+| Fly-hack / cheat clients | unlikely (timing tied to backfill phase, all modded handshakes) | tracer records speed/route per event |
+| Weak client hardware, LOD irrelevant | possible for individual players | E2b (`receiveServerLods=false` same client, same route) |
+| Client crash garbage (dying client sends junk) | consistent with 2-of-3 instant disconnects | tracer event-vs-disconnect timestamps |
+| Server MSPT spikes below the warn threshold | mostly excluded (0 warnings, 1-player load) | tracer samples MSPT at event time |
+| Chunky pregen load | present in exactly 1 of 3 events | tracer + no-Chunky periods |
+
+## 5. Instrumentation plan — the "movement desync tracer"
+
+The decisive property: **server-side instrumentation sees every client, modded or not,
+with no client cooperation.** Ship it in LSS (config-gated), deploy to the Modrinth server,
+and let organic traffic generate labeled events.
+
+### 5.1 Server side (LSS, new; works for all players)
+
+Config: `moveDesyncTrace` (default **true** — it is one JSONL line per event plus a 1 Hz
+per-flying-player sample; negligible), writing `logs/lss-move-trace.jsonl` (size-capped ring).
+
+1. **Event rows** — mixin `@Inject` at the three rejection points in
+   `ServerGamePacketListenerImpl.handleMovePlayer` (`moved wrongly` warn, `moved too
+   quickly` warn, and the **silent** `isEntityCollidingWithAnythingNew` teleport-back,
+   which today has no observability at all). Capture:
+   - claimed position/delta, simulated residual vector (the server already computed all of
+     it — vanilla just throws the numbers away and logs only the player name),
+   - `deltaPackets` (burst size), `isFallFlying`, server-side speed, post-impulse state,
+   - **chunk-delivery state at the collision point** (accessor mixin into
+     `PlayerChunkSender`): `pendingChunks` size, whether the collision chunk is
+     pending-to-send, `unacknowledgedBatches`, `desiredChunksPerTick` — this single row
+     proves or refutes the keystone claim (§3a),
+   - LSS per-player state: send-queue depth, bandwidth-window bytes this second, obuf
+     snapshot (`FabricChannelPressure` already reads `bytesBeforeUnwritable` — plumbing
+     exists), columns in flight, seconds since LSS registration,
+   - server MSPT window average.
+2. **Flight telemetry rows** — 1 Hz per player, only while `isFallFlying` or speed > ~10
+   blocks/s: position, speed, `PlayerChunkSender` state, obuf, LSS send rate. Gives every
+   event a trailing context window (was chunk delivery already collapsing? for how long?).
+3. **Silent-rejection counter** in `/lsslod diag` — measures the real player-facing
+   rubber-band rate the logs currently hide.
+
+### 5.2 Client side (our client builds — for controlled repro, not the fleet)
+
+Extend `/lss trace` JSONL with:
+- **tick-stall events**: client tick gap > 100 ms, with decode-queue depth, consumer
+  ingest backlog (`pendingIngestBacklog`), GC-time delta (GarbageCollectorMXBeans), heap;
+  directly tests "the stalls are LOD-caused",
+- **chunk-hole map**: 1 Hz, client-side loaded status of the 9×9 chunk area around the
+  player (which columns are missing right now),
+- **teleport-back events** (`ClientboundPlayerPosition` receipt) with the hole map at that
+  instant — the client-side mirror of a server rejection.
+
+### 5.3 Effort estimate
+
+Server tracer: ~1 mixin + 2 accessor mixins + a JSONL writer (the soak exporter pattern,
+reusable), a config key, ~a day incl. tests. Client additions: trace event types on
+existing plumbing, ~half a day. No wire changes, no protocol bump.
+
+## 6. Experiments — to run later (dev box is busy with profiling; nothing here has been run)
+
+Ordered by information-per-effort:
+
+- **E1 — deploy the tracer build to the Modrinth server and wait.** Organic events occur
+  roughly weekly (3 in the last ~3 days as traffic picked up). Success criterion: for each
+  `moved wrongly`, the event row shows the collision chunk pending/unACKed (hypothesis
+  confirmed) or client-known (hypothesis dead, look at residual vectors instead).
+- **E2 — controlled A/B, one route** (spawn → ~2000 blocks, low over terrain, full boost):
+  (a) our client, LOD on; (b) same client, `receiveServerLods=false`; (c) clean vanilla
+  client. Count logged + silent rejections per km. Separates LSS-caused from
+  vanilla-inherent from machine-inherent.
+- **E3 — arm transport deference live**: `outboundBufferCeilingKB=8192` on the Modrinth
+  server, then watch per-player `obuf_hw`/`deferred=` during an E2a flight. Tests the wire
+  head-of-line contribution. (Diag note: `obuf_hw` is per-player — an empty server shows
+  nothing; someone must be flying.)
+- **E4 — bandwidth knee sweep with tracer metrics** (5/10/20/40 MB/s raw): find the event
+  onset; a knee constant in *wire* MB/s ⇒ pipe-bound, constant in *raw* MB/s ⇒
+  client-processing-bound (the discriminator the 08-01 doc proposed but couldn't measure).
+- **E5 — client spark profile** during an E2a repro on the user's machine: attributes the
+  stalls (GC vs zstd/decode vs Voxy ingest vs meshing). Server-side spark is currently
+  disabled (`spark-*.jar.disabled`) and isn't needed for this.
+- **E6 — local shaped-link rig** (when the box frees up): real client, `tc netem` at
+  ~20 Mbps, instrumented build, `run-fabric-store` server. The only fully controlled
+  environment; also the regression harness for any fix.
+
+## 7. Candidate mitigations (decide only after E1/E2 data)
+
+- **M1 — vanilla-first deference (server, preferred direction):** pause a player's LOD
+  column flush while their `PlayerChunkSender` shows pending chunks near the player or
+  unACKed batches — retain-in-backlog semantics already exist (the obuf-ceiling path).
+  Real terrain always outranks LOD on the shared channel; the client stops receiving LOD
+  exactly when it's too busy to ingest it anyway.
+- **M2 — arm `outboundBufferCeilingKB` by default** if E3 shows obuf buildup on real links
+  (the mechanism was measured absent on the LAN rig; the live internet is the test that counts).
+- **M3 — speed-aware LOD throttle:** above ~15 blocks/s sustained, cut the per-player LOD
+  rate to a trickle; restore on slowdown. Crude but targets the exact regime.
+- **M4 — client stall governor:** on detected tick-gap stalls, proactively send the
+  backpressure clear batch + shrink the want-set. Extends #71, which keys on queue depths
+  and cannot see GC/render stalls.
+- **M5 — NOT recommended:** `elytra_movement_check=false` silences the `moved too quickly`
+  rubber-bands (it is gamerule-gated on 26.2) — but not `moved wrongly`, and it masks the
+  data we're trying to collect.
+- **M6 — upstream report:** if E2c shows a clean vanilla client clipping terrain under slow
+  delivery, the 26.2 freeze-gate removal is a vanilla regression worth reporting with that
+  repro.
+
+## 8. Why logs alone can't settle it
+
+Vanilla logs `moved wrongly!` with **only the player name** — no position, no residual, no
+delivery state; the silent rejection path logs nothing; server MSPT isn't recorded
+(tabtps is live-only, spark disabled); client chunk-delivery state exists nowhere
+server-side today. Every one of those is a one-line capture at a choke point we can mixin —
+that's §5.

--- a/docs/planning/perf-profile-round-2026-08-06.md
+++ b/docs/planning/perf-profile-round-2026-08-06.md
@@ -1,0 +1,200 @@
+# Server-side CPU profile round — 2026-08-06
+
+Evidence-driven performance pass over the SERVER side of the mod, per the standing goal:
+minimize CPU overhead without sacrificing throughput. Generation is out of scope (always
+slow and heavy by design); this round profiles the **read/serve paths** and the
+**store backfill walk** on both platforms.
+
+All runs on main @ 28ec1ac (post-PR #84), WSL2 box (16 cores), idle (load 0.00, no
+leftover test servers — checked). JFR `settings=profile` on every server JVM; band
+attribution + per-column CPU via the existing `analyze_profile_jfr.py` machinery.
+
+## ERRATUM (2026-08-06, found by the implementation-plan review round)
+
+**The F1/F2/F3 configs were not what this doc's Runs table implies.**
+`profile_disk_read.sh` never exports `BENCHMARK_CONFIG_STAGED=1`, so `benchmark.sh`'s
+neutral-staging block (added 2026-08-02) silently replaced the staged config: F1
+actually ran the **shipped defaults** — 3 reader threads (auto), not the staged 5;
+15 MiB/s per-player cap (and the wire ran at 93% of it, so the serve arm was
+bandwidth-bound, not CPU-bound); generation enabled (unreached — the 90 s run never
+crossed the pre-generated disc's edge, `sources.generation == 0`). Every `PROFILE_*`
+knob of that harness is currently inert. The band splits and hotspot rankings in this
+doc are honest profiles of the real serve path under default config and stand; the
+absolute per-column numbers are corpus- and config-specific context, and **must not be
+used as A/B baselines** — the implementation plan's Phase 0 fixes the harness and
+re-baselines. Number corrections from the review's re-derivation: serve-path
+LSS-attributed ≈ **262 µs/col** (not 224 — window accounting), memo-machinery samples
+under `MemoizedNbtCodec` on the backfill thread = **76 (25% of the thread)** (not ~87 /
+29%), backfill IO-Worker whole-recording count **415** (410 was the windowed subset),
+and of F1's 366 IO-Worker samples **274 carry an LSS frame** (the rest is vanilla's own
+save IO — the plan's Phase 3 gate counts the filtered number).
+
+### Re-baseline under the fixed harness (2026-08-06, same day)
+
+After the one-line `BENCHMARK_CONFIG_STAGED` fix, two verified arms
+(`profile-results/rebaseline-20260806*/`, 0 clobber lines, staged config confirmed live):
+
+- **Run A — staged config (5 reader threads, 20 MiB raw cap, gen off), 150 s:** active
+  window 79 s, 45.2k disk columns at ~572 col/s (data phase rides the 20 MiB raw cap),
+  server CPU 56.2 s, LSS-attributed 18.0% → **~222 µs/col** (upper-bound denominator).
+  **IO-Worker 488 samples (390 LSS-frame) vs the entire 5-thread pool 316 (311)** — the
+  single vanilla thread still out-works the whole pool. Bands: zip 6.3%, nbt 5.8%,
+  serialize 4.5%. Memo machinery ~60 samples on the pool.
+- **Run B — same + 100 MiB caps (CPU-bound), 120 s:** the whole 45.2k-column world
+  serves in a **28 s window at ~1,615 col/s**, server 1.54 cores, LSS-attributed
+  **39.0%** → ~368 µs/col. **IO-Worker 454 (409 LSS-frame) vs pool 327 (318)** — at the
+  throughput ceiling the IOWorker is the busiest serving thread by ~7× per-thread.
+  Bands: nbt 16.2%, zip 11.0%, serialize 9.2%. This arm makes sections/s a REAL
+  regression detector (the capped arm cannot be one).
+
+Both runs confirm the original hotspot ranking and strengthen R1's motivation. Known
+arm artifact: at R=256 the spiral crosses the pre-generated world's edge (ring ~128+),
+and with gen off the tail is a not-found storm answered `NOT_GENERATED` once per
+position — the wire-slope window self-truncates before most of it, and future arms
+should size duration to the data phase (~80 s at 20 MiB, ~30 s at 100 MiB).
+
+## Runs
+
+| id | condition | harness | result |
+|---|---|---|---|
+| F1 | Fabric no-cache cold disk-read serve, R=256, store off | `profile_disk_read.sh run vanilla 1 90 256` | valid arm; 32,608 cols served in 75 s active |
+| F2 | Fabric warm-join store off/on A/B, R=96 | `store_gate.sh warm 1 120` | GATE PASS (hit ratio 0.988, addressable cut 97.8%) |
+| F3 | Fabric store backfill walk, 1000 col/s cap, server-only | custom (runBenchmarkServer, no client) | 45,589 cols deposited in 55 s (~830/s effective) |
+| P1 | Paper warm-rejoin (Moonrise LOW reads + warm resync) | `SOAK_PLATFORM=paper soak.sh warm-rejoin` + jcmd JFR | soak PASS, 0 violations |
+| P2 | P1 + `SOAK_LODSTORE_OVERRIDE=full` (deposit path) | same | soak PASS; 3,304 deposits |
+
+Artifacts: `profile-results/perf-round-20260806/`, `store-gate-results/perf-round-20260806/`.
+
+Measurement caveats (documented in `analyze_profile_jfr.py`): NativeMethodSample
+under-weights native time ~2×, so absolute µs/col understate zip/zstd work; the huge
+`unattributed` share is mostly epoll-parked Netty threads; the Paper soak world is
+superflat, so Paper per-column signal is thin — the shared `common/` pipeline carries the
+Paper conclusions.
+
+## Headline numbers
+
+**F1 — cold disk-read serve (the main read path), per column served:**
+- ~224 µs/col LSS-attributed (band share 14.9% of 49 CPU-s active). ~430 col/s at ~10% of one core.
+- Band split of LSS work: zip 40% (region zlib inflate ~105 samples, vanilla net deflate 56,
+  wire zstd 45, region-save deflate 11), nbt-parse 29%, transcode/serialize 21%, other 10%.
+- **Thread placement is the striking part**: the single-threaded vanilla IOWorker executor
+  carries 366 samples (inflate + full NBT parse of every LSS read) vs 207 on the whole
+  5-thread LSS reader pool. The IOWorker does ~2× the on-CPU work of the pool that
+  nominally owns reading.
+- Allocation: 14.6 GB sampled weight in 75 s (~195 MB/s) — dominated by NBT parse garbage
+  (String 1.28 GB, HashMap$Node ~1.9 GB combined, HashMap$EntryIterator 328 MB). GC still
+  cheap (111 pauses, 292 ms total) but this is the churn budget.
+
+**F2 — warm store path:** store hits are microsecond-class (read avg 16 µs, p95 29 µs,
+69.8× vs off-arm disk read). LSS bands ~37 µs/col. The single biggest *serve-related*
+CPU item on the warm path is now vanilla's `CompressionEncoder` deflate of the
+already-zstd wire frames: ~11 µs/col, i.e. ~30% tax on top of the LSS serve cost.
+Store on-arm cut sampled allocation 4× vs off-arm (3.7 GB vs ~14 GB).
+
+**F3 — backfill walk (~994 attributable samples over 55 s, ~400 µs/col direct):**
+- vanilla-IOWorker side (inflate + NBT parse of backfill reads): 410 samples — 41%
+- backfill thread (transcode + memo lookups): 301 — 30%; of which ~87 (29% of the thread)
+  are pure memo-key machinery (CompoundTag hashCode/equals/iterator allocs)
+- SQLite batcher: 283 — 29%; of which contentHash (FNV-1a byte loop) 80 ≈ 28% of the
+  thread, zstd-1 compress 65, NativeDB.step/commit ~130
+- Backfill reads ride the SAME single vanilla IOWorker executor as serve reads.
+
+**P1/P2 — Paper:** the Paper-specific rungs add nothing pathological. Run-2's CPU burst
+is Moonrise chunk reload + lighting (vanilla), not LSS; `launchAsyncLoad` submissions are
+minor. In P2's deposit burst (2,144 deposits in ~10 s) the store batcher thread does not
+even reach the thread top-list — on the superflat soak corpus, Paper deposit cost is
+unmeasurably small; F3's Fabric numbers are the authoritative deposit-cost measurement
+(same `common/` batcher). One design confirmation: P2 ended with store hits = 0 — on a
+server that stays up, the warm timestamp cache answers resyncs before the store rung is
+ever consulted; the store pays off across restarts and cold client caches, as designed.
+
+## Ranked recommendations
+
+### R1 (largest structural win): move inflate + NBT parse off the vanilla IOWorker executor
+The background-priority rung currently runs `RegionFileStorage.read(pos)` — pread + zlib
+inflate + full `NbtIo` parse — inside the IOWorker's single-threaded executor
+(`ChunkDiskReader.backgroundRead`, fabric). Measured: that thread does ~2× the CPU of the
+entire reader pool on the serve path, and the backfill walk adds its own 41% there.
+
+Feasibility VERIFIED against 26.2 bytecode: `RegionFile.getChunkDataInputStream` is
+`synchronized` and returns a `DataInputStream` over `createStream(ByteBuffer, int)` — a
+`ByteArrayInputStream` over a **private heap copy** read during the call. So the split is:
+on the executor, resolve the region file + call `getChunkDataInputStream` (file IO +
+copy only); hand the stream to the LSS reader pool for inflate + parse + transcode.
+The executor confinement stays (it is the mutual-exclusion domain for RegionFileStorage's
+region-file cache), read-your-writes semantics are unchanged (this path already gave them
+up, documented), and the fallback ladder / `ChunkDiskReaderTest` pins are untouched — the
+change is inside the background rung only.
+
+Effect: most of the IOWorker-side LSS work moves to the multi-threaded pool
+(re-baseline run A: 390 of 488 IO-Worker samples carry an LSS frame vs 311 on the whole
+5-thread pool; the F3 backfill window's IO-Worker work was similarly ~all-LSS — ad-hoc
+measurement, superseded by the plan's Phase 0 counters). Total CPU ~neutral, but: (a) LSS stops monopolizing the one
+thread vanilla's own saves/loads need — directly shrinking the documented A7
+timeout-storm mechanism ("one >10 s IOWorker stall event expiring all five blocked
+readers"); (b) read throughput headroom rises without adding threads; (c) the backfill
+stops taxing the serve path's bottleneck thread.
+
+### R2 (largest CPU cut): selective NBT parse on the LSS disk path
+The nbt band is 29% of serve-path LSS CPU and the majority of the 195 MB/s allocation
+churn, and most of a chunk's NBT is subtrees LSS never reads (block_entities,
+block_ticks, fluid_ticks, structures, PostProcessing, Heightmaps, ...). A selective
+loader (vanilla's StreamTagVisitor infrastructure, or a hand-rolled skip-scan over the
+NBT token stream) that materializes only `sections` (+ DataVersion/status/coords/light
+flags) would cut parse CPU roughly in half and allocation churn by more.
+Constraints: the transcoder, x-ray pre-gate, and per-section fallback ladder consume the
+full section subtree — keep those whole; skip only top-level keys never consulted.
+Ship behind a kill switch mirroring `useNbtTranscode` conventions (flag-off = full parse),
+and note the NBT-leniency pins (tech-review round 2, R2-1) when writing tests.
+Scope correction (implementation plan, 2026-08-06): this applies only where LSS owns the
+parse call — i.e. the Fabric background rung AFTER R1 hands LSS the raw stream. Every
+current rung (vanilla `storage.read`/`chunkMap.read`, Moonrise `loadDataAsync`, Paper)
+returns an already-parsed tag from platform code, so R2 without R1 has nowhere to act.
+
+### R3 (cheap, contained): cache-friendly memo key for MemoizedNbtCodec
+The palette memo keys a raw `CompoundTag`: every hit pays `AbstractMap.hashCode`
+(allocates an EntryIterator, re-hashes freshly-parsed Strings) + structural
+`AbstractMap.equals`. Measured: ~40% of the transcode subtree on the serve path
+(~9% of serve LSS CPU), ~29% of the backfill thread, plus the 328 MB EntryIterator churn.
+Fix: wrap keys in a small holder computing a one-pass, allocation-free structural hash
+(cache it in the holder; equals falls back to tag equality only on hash match). No wire,
+no store, no behavior change; the memo cap/semantics stay as pinned.
+
+### R4 (store-schema bump): replace contentHash FNV-1a with CRC32C
+`LodStoreService.contentHash` is a byte-at-a-time FNV-1a loop — inherently serial,
+~1 B/cycle. It is 28% of the SQLite batcher thread under deposit load, and frame
+deposits ALSO compute chash+fhash on the processing thread (the pipeline choke) for
+compressed sessions. `java.util.zip.CRC32C` is a JDK intrinsic (~10+ GB/s, SSE4.2/AVX)
+and serves the same purpose here (corruption detection, not crypto). The hashes are
+store-internal, so this is a store schema bump — drop-and-rebuild on upgrade, the
+established policy for derived data (precedent: registry-fingerprint drift). Combine
+with any other store format change to avoid a standalone rebuild.
+
+### R5 (document, don't code): the vanilla double-compression tax
+Vanilla's network `CompressionEncoder` deflates every packet above
+`network-compression-threshold`, including LSS's already-zstd column frames — measured
+~17 µs/col cold-path, ~11 µs/col (a ~30% overhead) on the warm store path, on the Netty
+event loop. There is no per-packet opt-out in the vanilla framing, and recommending a
+global threshold change would hurt vanilla chunk-packet bandwidth. Record it as a known
+structural tax (ops note: proxy-side compression offload changes the calculus on
+networks that terminate compression at Velocity/etc.). Revisit only if a future protocol
+bump wants to weigh "raw + vanilla deflate" against "zstd + wasted deflate" — measured
+today, zstd-1 + tax still wins on total CPU and on client decode.
+
+### R6: backfill — no dedicated work
+At max pace the walk costs ~0.33 core and finishes a 64-region world in <1 min; its
+biggest component is the shared read path, so R1–R3 are its levers too. The MIN_PRIORITY
+worker + MSPT gate already bound its impact.
+
+### R7: the store remains the dominant warm-path CPU eliminator
+Re-validated this round: 97.8% addressable-CPU cut, 69.8× hit-latency win, 4× allocation
+cut. It stays opt-in by policy (world-folder doubling), but the docs recommendation to
+enable it on servers that can afford the disk stands — no serve-path micro-optimization
+approaches its effect.
+
+## Non-findings (checked, healthy)
+- Probe suppression (2026-08-05 round) is working: serialize-live band is 0.3–0.6%.
+- GC: sub-0.5% of wall time in every run.
+- SQLite read rung: 16 µs avg / 29 µs p95 — not a cost center.
+- Send/flush path (`flushSendQueue`, batching, sweeps): single-digit samples everywhere.
+- Paper lifecycle/mailbox machinery: invisible in the profile (healthy).

--- a/docs/planning/perf-round-2026-08-06-implementation-plan.md
+++ b/docs/planning/perf-round-2026-08-06-implementation-plan.md
@@ -1,0 +1,497 @@
+# Implementation plan — perf round 2026-08-06 recommendations (post-review v3)
+
+Source findings: `docs/planning/perf-profile-round-2026-08-06.md` (R1–R7, plus its
+erratum). This plan covers the implementable items (R3, R4, R1, R2, R5) in landing
+order, each with correctness gates and a performance-verification protocol.
+R6 (backfill) and R7 (store adoption) require no code by their own findings.
+
+**Review round (2026-08-06, three Opus agents — concurrency, pinned-decisions,
+methodology):** v1 of this plan was reviewed and substantially revised. The two
+design-level outcomes: R1 now hands over **raw compressed bytes**, not a live stream
+(resolves stream-ownership, timeout-abandon leak, unbounded pool parse, and external
+`.mcc` detection in one move), and R3's primary key design is the **structural-identity
+wrapper**, not a flat canonical string (collision-unsafe: separator injection + type
+collapse could serve wrong terrain). The methodology review additionally found the
+harness bug recorded in the findings doc's erratum (`BENCHMARK_CONFIG_STAGED` — every
+`PROFILE_*` knob inert) and re-derived the acceptance arithmetic. Dispositions are
+inlined per phase; verified-as-fact review results are stated as fact, not hedged.
+
+**Second review round (2026-08-06, one Fable agent, full-plan pass over v2 + the
+re-baseline data):** verified all v2 design revisions as sound (raw-bytes handover,
+structural Key, CRC32C spec, Phase 0 diagnosis, root-key set, phase composition) and
+found three gate-definition MAJORs fixed in this v3: the hibw throughput gate now has a
+real metric (pooled cols ÷ pooled window — the `sections_per_second` field is
+full-run-denominated and auto-passes), the round-acceptance backfill gate is summed
+over the conserved three-thread universe at ≥15% (the two-thread ≥25% was unpassable —
+Phase 3 moves parse ONTO the backfill thread), and Phase 0 items 3–5 now build the
+marker-level counters, walk timing, and allocation persistence the Phase 1/2/4 gates
+read. Plus: the three-branch `createChunkInputStream` reconstruction spec, the
+shadow-vanilla-helpers + drift-risk + external-coverage notes, the order-independent
+hash-combine spec with the capacity-forcing test, the new-production-code status of the
+config echo line, and the split-kill-switch decision point in Phase 3's rollback.
+
+**A/B discipline (all phases):** same-session interleaved arms, ABBA-ordered with one
+discarded warm-up rep, **counts pooled across reps** (never per-rep ratios averaged),
+gates as cut-ratios with a Poisson 95% lower bound reported. The frozen 2026-08-06
+artifact numbers are context, never targets — each gate re-measures its own base arm.
+Before any measuring session: `pgrep -af 'lss.multitest|test-server'` must be empty.
+Before Phase 1's first gated run: one **A/A control** (base ref vs base ref, 3 reps of
+the standard arm PLUS a hibw pair) to establish this box's spread on every gated metric
+— no such control exists in the archive, and the hibw ceiling gate's ±5% must be sized
+against the measured A/A spread, not assumed.
+
+## Landing order
+
+| phase | item | note |
+|---|---|---|
+| 0 | measurement tooling prerequisites | blocks all gated measurement |
+| 1 | R3 memo key | smallest code change |
+| 2 | R4 contentHash → CRC32C | carries the round's one store schema bump (v3→v4) |
+| 3 | R1 background-read split | Fabric structural; creates the LSS-owned parse site |
+| 4 | R2 selective NBT parse | hard-dependent on Phase 3 |
+| 5 | R5 ops note + doc corrections | docs only |
+
+One PR per phase, each carrying its A/B evidence in the description.
+
+---
+
+## Phase 0 — measurement tooling prerequisites
+
+None of the phase gates are runnable with the tooling as committed. Build, in one PR:
+
+1. **`profile_disk_read.sh` AND `compress_gate.sh`: export `BENCHMARK_CONFIG_STAGED=1`**
+   around their benchmark.sh invocations — each stages a config that benchmark.sh's
+   neutral-staging block (landed 6856bcb, 2026-08-02) silently replaces, so every
+   `PROFILE_*` knob and compress_gate's `useCompressedColumns` arm variable are inert
+   (profile_disk_read found by review; compress_gate found by the post-review
+   blast-radius audit — its archived runs predate the block, so the recorded
+   protocol-19 evidence is clean). **Status: the `profile_disk_read.sh` export is DONE
+   (2026-08-06, verified by the re-baseline runs — 0 clobber lines, staged config
+   confirmed live in the JFR).** Remaining: the same one-liner in `compress_gate.sh`,
+   and the effective-config assertion in both. **The echo line is NEW production code**
+   (today nothing echoes config at service start): add one INFO line echoing
+   `useNbtTranscode`/`diskReaderThreads`/(later `useSelectiveNbtParse`), treat its
+   format as a script-consumed contract (small format pin), and the run scripts grep it
+   into `meta.json` as part of `arm_valid` — an ignored config key must fail the arm,
+   not silently compare two identical arms. Note the `profile_disk_read.sh` fix is
+   working-tree-only today; the Phase 0 PR lands it.
+2. **Ref-vs-ref arms in `profile_disk_read.sh`**: `base`/`change` arm vocabulary behind
+   `PROFILE_BASE_REF`, using the `benchmark_compare.sh` worktree pattern
+   (`git worktree add --detach` + rsync'd base world + prebuild of both roots). ABBA
+   ordering across reps (the current `for rep; for arm` runs a fixed order — systematic
+   first-position bias).
+3. **`scripts/backfill_profile.sh`** (used ad hoc this round, never committed): written
+   to the scripts contract — `OUT_ROOT` default, documented `PROFILE_*` knobs, the
+   :25565 port-conflict guard — and it records **walk start/end timestamps + deposit
+   counts into `meta.json`** (from the backfill log lines), defining the Phase 2 gate's
+   deposits/s = deposits ÷ walk seconds. No committed export carries walk timing today
+   (`server.json`'s store block is a cumulative end-of-run dump).
+4. **`analyze_profile_jfr.py`**: (a) a windowing mode for client-less runs
+   (`--window full|t0:t1`) so backfill runs emit `bands.json` + `flame.collapsed`
+   (wire-slope detection has nothing to detect without a client); (b) per-thread ×
+   band × has-LSS-frame counters in `bands.json` — the Phase 3 gate needs
+   "IO-Worker samples carrying an LSS frame", which no committed artifact can express;
+   (c) **per-marker × thread counters** over a configurable stack-marker class list —
+   `MemoizedNbtCodec` (its `Key` must be a NESTED class, or be added to the list, so
+   "samples under MemoizedNbtCodec" stays a stable identifier across phases),
+   `LodStoreService.contentHash`, `SelectiveChunkNbtLoader` — these are what the
+   Phase 1/2/4 gates actually read; this round's 76/80/~60 numbers were ad-hoc scripts,
+   the exact practice this item ends; (d) **persist per-class allocation weight**
+   (today printed, never written) for the Phase 4 allocation gate; (e) extend
+   `DISK_PATH_MARKERS` with `AbstractChunkDiskReader` and the Phase 3/4 classes
+   (`ChunkRawRead` site, `SelectiveChunkNbtLoader`) — otherwise the moved parse
+   reclassifies to `nbt-other` and the Phase 3/4 gates break silently.
+5. **`scripts/compare_profile.py`**: pairs base/change stamp dirs, prints pooled band
+   counts, **pooled marker-counter cuts, per-column allocation weight
+   (÷ `columns_received`)**, µs/col, and Poisson CIs — the arithmetic every gate below
+   states. Also computes the hibw ceiling metric: pooled `sources.disk_read` ÷ pooled
+   wire-slope window seconds.
+6. **Re-baseline**: PARTIALLY DONE (2026-08-06, findings doc "Re-baseline" section):
+   two verified arms exist — staged-config 20 MiB (79 s data window, IO-Worker
+   390 LSS-frame vs pool 311, ~222 µs/col) and 100 MiB CPU-bound (28 s window,
+   ~1,615 col/s at 1.54 cores, IO-Worker 409 vs pool 318, ~368 µs/col). These are the
+   standing CONTEXT numbers; phase gates still run their own same-session base arms.
+   Arm-duration guidance from these runs: standard arm 150 s (~80 s data phase at
+   R=256 before the world-edge not-found tail), **hibw arm 90–120 s** (the world
+   exhausts in ~30 s — longer runs only grow the not-found tail). The backfill arm
+   still needs its committed script + windowing (items 3–4).
+
+Classifier tripwire, checked in every A/B: `nbt-other` and `serialize-live` counts must
+be stable across arms within counting noise — they are vanilla/probe work no phase
+touches, so movement there means the classifier moved, not the code.
+
+---
+
+## Phase 1 — R3: structural-identity cached-hash memo key (`MemoizedNbtCodec`)
+
+**Problem (measured, corrected by review):** the palette memo keys raw `CompoundTag`s;
+every lookup pays `AbstractMap.hashCode` (EntryIterator allocation per nested compound)
+and every hit pays full structural `AbstractMap.equals`. 76 samples under
+`MemoizedNbtCodec` on the backfill thread (25% of it), ~54 on the serve path (~40% of
+the transcode subtree), plus the 328 MB/75 s EntryIterator churn.
+
+**Design (review-revised):** a `Key` wrapper holding the (copied) tag and a
+**precomputed one-pass structural hash** built with `CompoundTag.forEach`
+(allocation-free, unlike entrySet iteration), `equals` delegating to `Tag.equals` —
+structural identity is retained exactly as the class javadoc pins ("the entry tag
+itself is the cache key") and as both reviewed prior designs (brainstorm Ideas A and G)
+chose. **The flat canonical-string key from plan v1 is rejected**: raw disk tags are
+mod/corruption-controlled, and both separator injection (`{a:"x;b=y"}` vs
+`{a:"x", b:"y"}`) and type collapse (`{p:"1"}` vs `{p:1b}` under stringification)
+collide — a collision returns another entry's `globalId` straight onto the wire and
+into the store, a silent wrong-terrain serve no re-declaration heals.
+
+Constraints carried from review:
+- `tag.copy()` in `decodeAndCache` is the **remainder** normalization, not key hygiene —
+  it must survive (deleting it re-pins the first caller's whole chunk NBT from a
+  JVM-lifetime static map). Say so in a comment.
+- No shared/static builder or hasher state — the memo is hit from the reader pool AND
+  the backfill thread concurrently. Per-call locals only.
+- The precomputed hash must be **order-independent per compound level** (sum/xor
+  combine, matching `AbstractMap.hashCode` semantics) — a sequential combine hashes
+  equal-content tags differently when their backing maps iterated in different orders
+  (capacity-history dependent), silently degrading to duplicate memo entries. And the
+  walk must recurse **allocation-free through nested `CompoundTag`/`ListTag` values**
+  (palette entries carry a `Properties` sub-compound) or the nested iterator churn
+  survives. `CompoundTag.forEach(BiConsumer)` exists in 26.2 (verified).
+- The `Key` class is **nested inside `MemoizedNbtCodec`** so the Phase 0 marker
+  counters ("samples under MemoizedNbtCodec") remain a stable identifier through
+  Phase 4's band subtraction.
+- Eliminable machinery is ~50% (backfill) / ~44% (serve) of the memo samples **before**
+  charging the new hash walk; the hit path keeps `ConcurrentHashMap.get` +
+  `String.hashCode` work. Gate accordingly (below), and report the new key-construction
+  cost as its own named term (samples under the `Key` constructor/hash walk).
+
+**Correctness gates:** **new** `MemoizedNbtCodecTest` + `PaperMemoizedNbtCodecTest`
+(none exist today — the `memoSizeForTest` seam has zero callers): cap stop, warn-once,
+hit/miss, defensive copy, and an explicit collision-adjacent case (equal-content
+different-insertion-order tags hit the same entry — the test must FORCE different
+backing-map capacities, since same-capacity maps usually iterate identically and the
+test passes vacuously otherwise; different tags never collide). Existing
+byte-identity pins stay the real proof: six nbt-corpus goldens, transcode-vs-object
+fuzz, `SerializerParityGameTests`, `:paper:test` twins.
+
+**Perf verification** (ref-vs-ref, Phase 0 tooling, 3 reps × 150 s ABBA + backfill arm):
+1. Backfill arm: samples under `MemoizedNbtCodec` on the backfill thread, pooled.
+   **Gate: ≥30% cut** (Poisson 95% lower bound above 0 required; the measured headroom
+   is ~50% minus new-key cost, so ≥30% is achievable, ≥50% was not).
+2. Serve arm: same metric on the reader pool + `serialize` band share.
+   **Gate: ≥20% cut pooled; `columns_received` parity within ±2%** (the bandwidth-capped
+   rig makes sections/s a null instrument — parity is the honest check).
+3. Secondary: per-column sampled allocation weight not regressed.
+
+**Rollback:** revert (no persisted state, no wire).
+
+---
+
+## Phase 2 — R4: `contentHash` FNV-1a → CRC32C (store schema v4)
+
+**Problem (measured):** byte-at-a-time FNV-1a is 80 samples ≈ 28% of the SQLite batcher
+thread under deposit load; frame deposits also compute chash+fhash on the processing
+thread for compressed sessions.
+
+**Audit — resolved by review, stated as fact:** `contentHash` has exactly four call
+sites: the batcher raw-deposit insert, the two reader-side validations, and the
+processing-thread frame-deposit pre-compute. Corruption detection only; never an
+identity/dedup key; never crosses a jar boundary; `DirtyContentFilter.fnv1a64` is a
+separate function with its own 0-sentinel and stays FNV. The XXH64 contingency from
+plan v1 is dead — CRC32C proceeds.
+
+**Change** (`common/.../LodStoreService.java`, `SqliteLodStore.java`):
+- `java.util.zip.CRC32C`, **`new CRC32C()` per call — never a static field, never a
+  ThreadLocal** (mutable, non-thread-safe, and called from three thread families; a
+  shared instance produces wrong hashes that drive the row-poison purge into deleting
+  good rows). The cost is the update intrinsic, not the allocation.
+- Zero-extended into the existing 64-bit columns — sound (both validations compare
+  same-function longs; `usize == 0` short-circuits before any hash compare, so the
+  CRC-of-empty degenerate value is never consulted). Record in the PR: detection
+  strength drops 2⁻⁶⁴ → 2⁻³² per corrupted row, on derived data whose worst case is one
+  wrong LOD column that the purge ladder then deletes.
+- Rename the three surfaces that would become lies: the `LodStoreService.contentHash`
+  javadoc ("FNV-1a 64"), the private `fnv1a` wrapper name in `SqliteLodStore`, and the
+  schema-history comment — which also gains its `4:` line.
+- Bump `SCHEMA_VERSION` 3 → 4. Drop-and-rebuild is the established derived-data policy;
+  done-mark reset is **automatic by construction** (`deleteDbFiles` unlinks the db that
+  contains the `backfill` table — nothing to build). Rollback symmetry verified:
+  `metaMatches` is an equality compare, so an old jar against a v4 store also rebuilds.
+- Release-note obligation goes somewhere durable: append the item to the next
+  release-notes draft doc in `docs/planning/` (established pattern), `### Performance`,
+  no platform qualifier (both platforms), noting the one-time store rebuild
+  (~25 min re-backfill at 500 col/s for a 10 GB store).
+
+**Correctness gates:** `SqliteLodStoreTest` hash/validation pins updated; a v3→v4
+drop-and-rebuild-fires-once test (registry-fingerprint-drift pattern);
+`store_gate.sh warm` AND `cold` GATE PASS on the change ref — noting `warm` is a
+hit-path gate that structurally cannot see a deposit-side change; **`cold` (deposits on,
+`COLD_REGRESSION_CEIL` 10%) is the store gate that can**; store soaks
+(`store-second-join`, `store-save-storm`, `store_offline_edit.sh` — whose cross-phase
+probe hashes are client-side and exercise chash only indirectly, via
+mismatch-purges-row; still valuable, not "end-to-end chash").
+
+**Perf verification** (ref-vs-ref, backfill arm):
+1. `LodStoreService.contentHash` samples on the batcher thread, pooled.
+   **Gate: ≥80% cut vs the same-session base arm** (large effect size — CRC32C intrinsic
+   vs a serial byte loop — this is the one gate where ≥80% is defensible), deposit
+   throughput not regressed — deposits/s = deposits ÷ walk seconds, from
+   `backfill_profile.sh`'s walk-timing `meta.json` (Phase 0 item 3; no committed export
+   carries walk timing today).
+2. `store_save_storm.sh` non-regression at the harness's **own** bound —
+   `max(1.0 CPU-s, 25% of the off arm)` on an n=1 pair with ~0.5 s observed noise. The
+   plan-v1 ">5%" bound was finer than the instrument and is withdrawn.
+
+**Rollback:** revert; the schema mismatch rebuilds the store in either direction.
+
+---
+
+## Phase 3 — R1: split the Fabric background read (raw-bytes fetch on IOWorker, inflate+parse on pool)
+
+**Problem (measured; re-baselined 2026-08-06 under the fixed harness):**
+`backgroundRead` runs `RegionFileStorage.read(pos)` — pread + zlib inflate + full NBT
+parse — on the vanilla IOWorker's single-threaded executor. Re-baseline run A (staged
+config, 5 reader threads, 20 MiB cap): IO-Worker **390 LSS-frame samples vs 311 across
+the entire 5-thread pool**. Run B (100 MiB, CPU-bound, ~1,615 col/s at the throughput
+ceiling): **409 vs 318** — the busiest serving thread by ~7× per-thread, with the nbt
+band at 16.2% of all samples. Backfill reads share the same choke (412 of its 415
+IO-Worker samples are LSS-attributed). This is the mechanism of the documented A7
+timeout storms, and at the ceiling it is the serve path's top structural constraint.
+
+**Design (review-revised — raw bytes, not a live stream):** the executor closure hands
+over a value object, not an open resource:
+
+- New seam `ChunkRawRead` (functional interface, injection-testable) used **only** by
+  the background rung. **`ChunkNbtRead` is unchanged** — the Moonrise rung returns its
+  bridge future directly and the rung-order pin asserts tag identity (`assertSame`), so
+  widening the shared interface would touch all eight ladder pins; a separate seam
+  touches none of them.
+- On the executor: resolve the region file (`@Invoker` for the private
+  `RegionFileStorage.getRegionFile` — which **never returns null and creates on
+  demand**; absence is signalled downstream), then read the chunk's **raw compressed
+  record**: `record RawChunkBytes(byte[] compressed, byte version)`, empty/absent →
+  `Optional.empty()`. This needs a small raw-read surface on `RegionFile` (the wrapped
+  `getChunkDataInputStream` only exposes the *decompressing* view): a mixin method that
+  resolves the sector record — and, for external chunks, reads the `.mcc` bytes into
+  the buffer **on the executor** (file IO stays on the executor; reader/writer of a
+  given `.mcc` stay serialized exactly as today, sidestepping the non-`ATOMIC_MOVE`
+  replace hazard). The v1 "lazy pool IO for externals" fallback is **withdrawn**
+  (review: it breaks a serialization that exists today and its atomicity premise was
+  wrong). Conservative alternative if the raw surface gets ugly: on the external flag,
+  fall back to `storage.read(pos)` full-parse-on-executor for that column (rare,
+  already-oversized).
+- On the pool (`readAndSerializeSections` overload consuming the raw record —
+  `record RawChunkRecord(byte[] payload, byte version)`, "payload" not "compressed":
+  `VERSION_NONE` (id 3) payloads are uncompressed): the reconstruction must mirror
+  `createChunkInputStream`'s **three branches** (verified in 26.2 bytecode), not just
+  the happy path — (a) `RegionFileVersion.fromId` returns **null** for unknown ids, so
+  a naive `.wrap(...)` NPEs; unknown id resolves **authoritative not-found**, matching
+  vanilla; (b) `VERSION_CUSTOM` (id 127) logs and resolves not-found; (c) a valid id
+  wraps — and `wrap` includes the `FastBufferedInputStream` layer, so valid-branch
+  equivalence holds by construction. Then `NbtIo.read` → the unchanged serialize path.
+  All pool-side work is **pure CPU over private in-memory bytes**: no fd, no stream
+  ownership, no close protocol, nothing for a timed-out `future.get` to leak (a
+  `byte[]` is just garbage). The timeout statement is now honest:
+  `DISK_READ_TIMEOUT_SECONDS` bounds the executor fetch; pool-side inflate+parse is
+  bounded work over a bounded buffer.
+- Parse failures land in the same per-chunk triage (`readAndDeliver`'s
+  `catch (Throwable)` with the `TimeoutException` discriminator — verified). One PR
+  check: failures now arrive unwrapped rather than in `ExecutionException`; nothing
+  branches on the wrapper today, keep it that way. Null-record shapes (truncated
+  header, missing stream, bad version) resolve as authoritative not-found, matching
+  `storage.read`'s null today.
+- Scope hygiene: the pool-side `NbtIo.read` stays **outside** the AntiXray
+  `callSerializing` shim (the existing comment documents that exclusion; update it).
+- Mixin surface: the `getRegionFile` invoker + the `RegionFile` raw-read method, both
+  registered in `lss.mixins.json` and pinned by a listing test
+  (`ChannelAccessorContractTest` pattern). The raw-read method must **prefer
+  `@Shadow`/`@Invoker` on vanilla's own private helpers** (`getOffset`,
+  `isExternalStreamChunk`, `createStream`, the external-path resolution) over
+  re-deriving the header/sector constants — the region record format is a
+  per-MC-version reimplementation risk, and shadowed members fail LOUDLY on rename
+  (`defaultRequire: 1`) where hand-rolled parsing would silently misread. Coverage
+  honesty: the external (`.mcc`) and truncated-header branches have no real-file
+  coverage (`SerializerParityGameTests` exercises internal chunks; the `ChunkRawRead`
+  seam pins are injected-value tests, and mixin classes refuse loading under
+  fabric-loader-junit) — add an oversized-chunk parity gametest, or document the
+  residual gap explicitly in the PR.
+- Doc updates in the same PR: `backgroundRead` javadoc, CLAUDE.md's `ChunkDiskReader`
+  paragraph, `read-scheduler-design.md` §10.4 — all three say "reads straight from
+  RegionFileStorage", which becomes fetch-only.
+- Note for gate reading: backfill reads also split, so backfill's moved parse lands on
+  the **backfill thread** (not `LSS Disk Reader`) — the conservation check must expect
+  that.
+
+**Correctness gates:** Tier 1 — `ChunkDiskReaderTest` keeps all eight existing ladder
+pins untouched (fallback predicate, throwable latch, warn-once, Moonrise rung order +
+`assertSame`, config rollback, null bridge, typed latch ×3, async-failure non-latch)
+and gains new pins via the `ChunkRawRead` seam (fetch on injected executor, parse on
+calling thread, absent/corrupt/external variants). Tier 2 — `SerializerParityGameTests`
+(`backgroundPriorityReadMatchesForegroundReadForDiskLoadedColumn` is the end-to-end
+byte proof) + `RegionFaultGameTests` containment. Soaks: `fresh-backfill`,
+`disk-saturation` (`disk.saturated == 0` with `superseded ≥ 100`), `warm-rejoin`.
+
+**Perf verification** (ref-vs-ref, 3 reps × 150 s ABBA + backfill arm, Phase 0 tooling):
+1. **LSS-frame-filtered IO-Worker samples** (per-thread × has-LSS-frame from the new
+   `bands.json`), pooled. **Gate: ≥75% cut** (re-baseline context: 390 of 488 on the
+   standard arm, 409 of 454 on the hibw arm; the gate is the same-session ratio).
+   Vanilla residual on that pool reported separately — it is *expected to rise*
+   slightly (the save queue drains faster), which is why the unfiltered count is not
+   the gate.
+2. Conservation sanity: total LSS-attributed samples roughly flat, moved work
+   reappearing on `LSS Disk Reader` (serve arm) / backfill thread (backfill arm);
+   classifier tripwire (`nbt-other`, `serialize-live` stable).
+3. Throughput, TWO arms with different roles (established by the re-baseline): the
+   **hibw arm** (`PROFILE_BW_PER_PLAYER` = global = 100 MiB, 90–120 s) is CPU-bound at
+   ~1,615 col/s and carries the ceiling gate. **Metric definition matters:** NEVER
+   `server.json`'s `sections_per_second` — it is denominated over the full run duration
+   on a corpus-fixed world, so two arms auto-agree regardless of ceiling (and the field
+   counts columns, not sections). The ceiling metric is **pooled `sources.disk_read` ÷
+   pooled wire-slope window seconds over ≥3 hibw reps** (`compare_profile.py` computes
+   it; the ~1–2 s `cpu.jsonl` cadence quantizes a single 28 s window by ±4–7%, which
+   pooling absorbs). **Gate: ceiling within ±5% or better, with ±5% validated against
+   the A/A hibw spread first.** The **standard 20 MiB arm** is bandwidth-capped, where
+   any throughput number is a null instrument and the check is `columns_received`
+   parity ±2%.
+4. `disk_reader.avg_read_time_ms` directional only (18% pool utilisation on a warm page
+   cache — little dynamic range).
+5. Backfill arm: LSS-frame IO-Worker samples ≥50% cut pooled; walk time flat (the
+   MIN_PRIORITY thread now carries strictly more per-column work — the pacing gate must
+   hold).
+6. Directional, non-gating: fresh-backfill `disk.errors` on this box (A7-class,
+   variance-prone, branch-A/B triage if red).
+
+**Rollback:** **revert** is the primary path. For a live-server incident needing a
+config-only mitigation, `useBackgroundReadPriority=false` exists and works but is
+coarse — a full read-protection opt-out that also drops the Moonrise rung (pinned as a
+true rollback); acceptable for an emergency, wrong as the phase's rollback story.
+Because the `ChunkRawRead`/`ChunkNbtRead` seam split retains both code paths anyway, a
+dedicated split kill switch is nearly free — decide at PR time whether to expose it as
+config (project convention favors it for the round's riskiest change) or keep the seam
+internal.
+
+---
+
+## Phase 4 — R2: selective NBT parse at the Phase 3 parse site
+
+**Problem (measured, decomposed by review):** the nbt band is 211 samples on the serve
+path, but its composition bounds the win: ~37 are memo machinery (Phase 1's target),
+~94 are **inflater byte movement** (skipping a subtree still consumes its bytes through
+the inflater), ~50 are structure building (`readUTF`, `String.<init>`, `HashMap.putVal`,
+tag boxing). Selective parse eliminates the structure-building slice and its allocation
+churn; it does NOT eliminate inflate. The realistic serve-path CPU cut is ~7%; the
+headline win is allocation (the String/HashMap/StringTag/CompoundTag classes dominate
+the ~195 MB/s churn). If a larger cut is ever wanted, the design that reaches it is
+**early-abort once the whitelisted keys are read** (root-key order permitting — skips
+the tail inflate); that is explicitly out of scope for this phase and recorded as the
+stretch follow-up.
+
+**Scope (verified complete):** the consumed root-key set is exactly **`{Status,
+sections}`** — both platforms' serializers were audited; `minSectionY`/`maxSectionY`
+come from the level, not `yPos`; `DataVersion` is unread **by decision** (the R2-1
+amendment rejected DataVersion gating — it would turn every upgraded-world disc into a
+generation storm) and must never become a gate. Applies only where LSS owns the parse:
+the post-Phase-3 Fabric background rung. (`RegionFileStorage.scanChunk(ChunkPos,
+StreamTagVisitor)` is public in 26.2 and was considered as a no-mixin alternative —
+rejected: it runs on the caller thread and re-enters `getRegionFile` off-executor,
+breaking the confinement Phase 3 preserves.)
+
+**Change** (new `fabric/.../SelectiveChunkNbtLoader.java` + config):
+- Root-level whitelist reader over the Phase 3 raw record's wrapped stream: whitelisted
+  keys → standard `TagType.load`; others → `TagType.skip`. Result: a standard sparse
+  `CompoundTag`; downstream unchanged. Must reproduce `NbtIo.read`'s root handling
+  (type byte + skipped root name) and depth/size accounting exactly.
+- The whitelist is a named constant beside the serializer, and a **source-regex pin**
+  (the `SaveHookContractTest`/`StoreEnvironmentContractTest` mechanism) fails the build
+  when a new root-level getter appears in the serializer without a whitelist update.
+- **Leniency semantics, stated honestly (v1's parity claim was unachievable):** the real
+  pins are `NbtSectionSerializerTest` `malformedBlockStates_codecParseError_
+  sectionSkippedSiblingsServe` and `trulyUnparseableSection_condemnsTheColumn
+  AsAuthoritativeMiss` (+ Paper twins) — codec-level leniency inside `sections`, which
+  selective parse cannot touch; both stay green. The accepted, documented divergence is
+  one-directional: a corrupt **non-section** subtree that would have thrown under full
+  parse can now parse successfully — MORE lenient, defensible for LOD (the column's
+  sections are intact; full parse would have condemned it to the error→generation
+  ladder for data LSS never reads). On any selective-loader throw, the fallback is a
+  full `NbtIo.read` over a **fresh wrap of the same compressed buffer** (free under the
+  Phase 3 raw-record design — no re-buffering), then the normal triage.
+- Config: `useSelectiveNbtParse`, default true. Shared `ServerConfigBase` key with
+  Fabric-only effect is the established pattern (`lodStoreBackfillColumnsPerSecond`
+  precedent) — javadoc states the platform scope in that idiom. Default pinned in BOTH
+  `ConfigValidationTest` and `PaperConfigValidationTest` (the `nbtTranscodeDefaultsOn`
+  twin pattern), CLAUDE.md's config list gains the key.
+
+**Correctness gates:** selective-vs-full contract test — byte-identical serialization
+over the golden corpus, plus a fuzz twin with TWO axes: root-key orderings AND
+malformed/truncated/wrong-typed **root** bytes asserting the documented
+fallback/divergence behavior; full Tier 1 + Tier 2 + Tier 3; `fresh-backfill` +
+`dirty-broadcast` soaks; config tests above.
+
+**Perf verification** (kill-switch A/B — same jar, `PROFILE_SELECTIVE_PARSE` knob wired
+per the `PROFILE_NBT_TRANSCODE` precedent, **valid only after Phase 0's
+`BENCHMARK_CONFIG_STAGED` fix and arm-validity assertion**; 3 reps × 150 s ABBA):
+1. **Per-column sampled allocation weight** (String, HashMap$Node, StringTag,
+   CompoundTag classes ÷ `columns_received`). **Gate: ≥30% cut** — the most robust
+   metric in the round (historic rep-to-rep spread 1–3%, threshold 10–30× noise).
+2. `nbt` band **minus samples under `MemoizedNbtCodec`** (Phase 1 already removed
+   those), pooled. **Gate: ≥25% cut** (the structure-building slice of the band;
+   ≥40% of the whole band was arithmetically unavailable).
+3. `columns_received` parity ±2%; classifier tripwire as always.
+4. Backfill arm: same metrics during the walk.
+
+**Rollback:** the config flag; then revert.
+
+---
+
+## Phase 5 — R5 ops note + documentation corrections
+
+1. README ops note ("network compression and LOD traffic"): vanilla deflates every
+   packet above `network-compression-threshold`, including LSS's zstd frames (~30%
+   overhead on the warm store serve cost, measured); no per-packet opt-out exists;
+   proxy-terminated compression (Velocity) moves the cost off the server. Recommend
+   AGAINST raising the global threshold (vanilla chunk-packet bandwidth pays for it).
+2. Carry-through of the findings-doc erratum wherever its numbers were quoted.
+
+---
+
+## Round acceptance (after Phase 4)
+
+One closing interleaved ref A/B (pre-round base vs final tree, same session, 3 reps ×
+150 s ABBA + backfill arm, pooled):
+- **Serve path: expect ≥8% LSS-attributed µs/col cut, gate ≥5%.** (Plan v1's ≥25% was
+  arithmetically unreachable: R1 moves work rather than cutting it, R2's ceiling is the
+  ~50-sample structure slice, R3 nets ~2–3.5%, R4 is store-side. The review's
+  band-composition arithmetic is the reference.)
+- **Backfill/deposit arms carry the headline** — but the metric must be summed over
+  **all three carrying threads** (backfill worker + SQLite batcher + IO-Worker
+  LSS-frame), because Phase 3 deliberately moves the backfill's parse from the
+  IO-Worker ONTO the backfill thread: a two-thread sum RISES ~35% when everything
+  succeeds (the v2 gate was arithmetically unpassable). Over the conserved three-thread
+  universe (~996 base samples), the supported arithmetic is memo (~38) + contentHash
+  (~64) + the parse structure slice (~100) ≈ **gate ≥15% cut**, with per-column CPU
+  across the walk as the cross-check.
+- Per-column allocation on the serve arm: ≥30% cut (Phase 4's gate re-confirmed on the
+  final tree).
+- Throughput: hibw-arm ceiling (pooled `sources.disk_read` ÷ pooled window — the
+  Phase 3 metric definition, never the full-run-denominated `sections_per_second`
+  field) within ±5% or better; standard-arm `columns_received` parity ±2%; backfill
+  effective col/s flat.
+- `store_gate.sh warm 3 120` (three reps — the single-rep variant has no noise
+  rejection) still GATE PASS, with one pre-agreed clause: Phases 1+4 shrink the
+  **off-arm** (the disk path) while the on-arm store cost is unchanged, so metric 2's
+  relative `BAND_CPU_CUT_FLOOR` can mechanically fall below its 0.50 floor *because the
+  round succeeded*. A metric-2 miss with the addressable-cut and absolute on-arm
+  µs/col legs healthy is a **documented re-baseline of the floor, not a phase revert**.
+
+Failure handling: any gate miss reverts or flag-disables the offending phase before
+release; phases are independently shippable.
+
+## Standing risks
+
+- **WSL2 box variance** — interleaved same-session ratios, pooled counts, A/A control
+  first; suspicious result → the documented branch-A/B triage.
+- **Pinned-decision collisions** — each phase names its pins; the three-lens review
+  round has already walked them once, but implementation PRs re-verify before touching.
+- **Store rebuild on Phase 2** — deliberate schema bump with a release-note draft item;
+  bundle any future store format change into the same bump if it lands this round.
+- **Phase 3 mixin surface** — the `RegionFile` raw-read method is the one genuinely new
+  reach into vanilla internals; if 26.2's internals make it fragile, the conservative
+  external-chunk fallback (full parse on executor for that column) bounds the blast
+  radius, and the split still covers the ~99% internal-chunk case.

--- a/docs/planning/v0.10.0-mega-plan.md
+++ b/docs/planning/v0.10.0-mega-plan.md
@@ -1,0 +1,636 @@
+# v0.10.0 mega plan — perf round + move tracer + transport yield + protocol 20 (2026-08-06, v1.3)
+
+One release plan combining four reviewed plans into a single sequenced program:
+
+| source plan (normative spec for its content) | short name | state |
+|---|---|---|
+| `perf-round-2026-08-06-implementation-plan.md` (v3) | **PERF** | 3-lens + 1-Fable reviewed |
+| `move-desync-tracer-plan.md` (v2.1) | **TRACER** | 2-Opus + 1-Fable reviewed |
+| `vanilla-first-lod-yield-plan.md` (v2.1) | **YIELD** | 2-Opus + 1-Fable reviewed |
+| `cross-version-identity-encoding-plan.md` | **XVER** | 3-Fable reviewed |
+
+The four source plans remain the detailed specs. This document owns three things:
+(1) the **cross-plan reconciliations** — where combining the plans changes their
+details, recorded as explicit amendments each implementation PR must follow over the
+source text; (2) the **master landing order** with its ordering rationale; (3) the
+consolidated release/re-port/notes obligations. Where this doc and a source plan
+disagree, THIS DOC WINS — each amendment below says exactly what it overrides.
+
+**v1.1 (same day): revised after a three-Fable review round of v1.0** (integration,
+pinned-decisions, fidelity lenses — full record in §7). Headline outcomes: R-1 gains
+the structural guard for a dev-window store state that would otherwise open as valid
+and latch dead, and its hash/translation dispatch now explicitly covers BOTH store
+read rungs (`get()` and `getFrame()` — all three lenses converged on the raw rung
+being uncovered); the soak-checker config-key allowlist obligation is assigned for
+every new key, not just YIELD's; and measurement sessions get exclusive box
+ownership in the parallelism rules. **v1.2 (same day, user direction): adds §6
+implementation practices** — the program progress doc, per-PR 3-Opus review rounds,
+and the PR/evidence/decision-logging discipline. **v1.3 (same day, user
+direction): adds R-8** — the manual-test rigs (`test-server.sh` knobs, the
+`lss-multi-test` refresh) and the explicit staging/verification matrix for the
+backported 26.1 / 1.21.11 lines, wired into the A1/C4/C5/C6/D3 rows.
+
+**Release shape:** v0.10.0 ships everything: the perf round (R1–R5), the move-desync
+tracer (inert by default), the transport yield (config `lodYieldsToVanillaTransport`,
+default FALSE), and protocol 20 with the store migration — then the XVER §11 fresh
+re-ports put the same tree on MC 26.1 and 1.21.11 (tri-release). Every phase remains
+independently reviewable and (for PERF/TRACER/YIELD) independently revertible. If an
+interim release is ever wanted, stages A+B form a coherent v0.9.2 — **with one
+caveat**: shipping B2's interim store state to users creates a released from-state
+(schema 4, CRC hashes, no `wirefmt`) that C4's lazy upgrade deliberately excludes
+and structurally cannot admit (the ALTER's `DEFAULT 19` would mislabel CRC-hashed
+rows for the FNV dispatch), so a v0.9.2 cohort would rebuild twice and R-1's
+"no rebuild on upgrade" release note would be false for them. An interim release
+must either exclude B2 or knowingly accept that. None is planned.
+
+---
+
+## 1. Cross-plan reconciliations
+
+### R-1 — The store schema collision: ONE user-visible bump, 3 → 4 (overrides PERF Phase 2 and amends XVER §5)
+
+PERF Phase 2 (CRC32C) and XVER §5 (wirefmt + lazy migration) independently specify
+`SCHEMA_VERSION` 3 → 4. PERF's own standing-risk section already ordered the
+resolution: *"bundle any future store format change into the same bump if it lands
+this round."* Bundled semantics, final shipped state:
+
+- **Schema v4** = `wirefmt` row column (ALTER default 19; new deposits 20) + meta
+  `wire_format_version = 20` + **CRC32C for `chash`/`fhash` on `wirefmt = 20` rows**
+  + the `store_layout` structural-guard meta key (below).
+- **FNV-1a is retained for exactly one purpose**: validating `wirefmt = 19` rows in a
+  lazily-upgraded store (their stored hashes are FNV — verified: both read-site
+  validations compare against `LodStoreService.contentHash`, today FNV). **Hash
+  dispatch keys on the row's `wirefmt`: 19 → FNV, 20 → CRC32C — at BOTH read
+  rungs**: `get()` (the raw `StoreHit` rung, `chash` validation at
+  `SqliteLodStore.java:476` — the rung that serves v18/v16 sessions, which require
+  RAW, plus non-zstd v19 sessions via `useCompressedColumns=false` or a zstd-native
+  load failure) and `getFrame()` (`fhash` validation at `:535`). XVER §5.3 gives
+  `wirefmt` to `getFrame`'s hit record only; **this plan extends that contract
+  change to `get()`** — both SELECTs return `wirefmt`, and `StoreHit` carries it.
+  (There is no `getColumn`; v1.0 of this doc named a nonexistent method.) Without
+  the dispatch, the first warm hit of every unmigrated row computes CRC32C against
+  a stored FNV value and the mismatch-purge ladder deletes the surviving store row
+  by row — the lazy migration silently degrading to a slow drop.
+- **The translation half covers both rungs too**: a `wirefmt = 19` hit is translated
+  to v20 before serving on EITHER rung — `getFrame` per XVER §5.3
+  (decompress → translate → re-encode/recompress), and `get()` likewise
+  (decompress if framed → translate → serve raw). An untranslated raw-rung 19-row
+  serve would hand v19-native section bytes to a v20 client — the issue-#85
+  failure re-created through a shipped kill switch. Pin (§3.1): a raw-rung 19-row
+  serve byte-equals its post-migration serve.
+- **The migration walk recomputes `usize`/`chash`/`fhash` under CRC32C** as it
+  rewrites rows to `wirefmt = 20` (XVER §5.4 unchanged otherwise). All deposits are
+  CRC32C from day one, so PERF R4's batcher-thread win is fully realized
+  immediately; the FNV path survives only on warm hits of unmigrated rows and goes
+  cold as the walk completes. **The deposit upsert's ON CONFLICT update
+  (`SqliteLodStore.java:1172-1175`) additionally sets `wirefmt = 20`** — a
+  re-deposit over an unmigrated row that left the 19 tag in place would carry CRC
+  hashes under an FNV dispatch and be purged as corrupt on its next hit. Pinned
+  (§3.1).
+- **Lazy-upgrade from-state**: exactly `schema_version=3 ∧ wire_format_version=19`
+  — the released v0.9.x state (XVER §5.1 unchanged). Everything else falls through
+  to `metaMatches` → drop-and-rebuild — with one structural exception the next
+  bullet closes.
+- **`metaMatches` compares meta KEYS only, never table structure — C4 adds a
+  structural guard.** One reachable dev-window state proves the need: a store
+  rebuilt by a **C1..C3-era build** (B2's schema 4 + C1's protocol 20 ⇒ meta
+  `4 ∧ 20`, but NO `wirefmt` column — the ALTER lands only at C4). At a C4+ build
+  that meta passes the equality compare, the store opens as valid, every
+  `wirefmt`-referencing SELECT throws (triaged as a transient SQLException — read
+  as a miss, never purged), and the batcher's failing INSERTs latch the store dead
+  at `WRITE_FAILURE_LATCH` (20) — recoverable only by hand-deleting `store.db`.
+  Guard: stamp a meta layout key (`store_layout = wirefmt`) from BOTH the
+  fresh-create path and the upgrade path and include it in `metaMatches` (it rides
+  the existing equality mechanism; a `pragma table_info` presence probe on open is
+  the equivalent alternative). The §3.1 from-state matrix gains
+  `(schema 4 ∧ wire 20 ∧ no wirefmt column) → drop`.
+- **Dev-window semantics**: PERF Phase 2 lands mid-cycle and bumps
+  `SCHEMA_VERSION` to 4 with drop-and-rebuild exactly as its spec says — that
+  behavior is a **dev-window interim**, superseded in-release when stage C4 lands
+  the lazy path. A Phase-2-era store (schema 4, no `wirefmt`, CRC hashes, meta
+  wire 19) correctly drops at C4+ builds via `metaMatches` (wire 19 ≠ 20).
+  Phase 2's PR text must say this; its FNV function is **renamed but kept**
+  (legacy-row validator, comment pointing at C4) rather than deleted, so C4 doesn't
+  re-introduce it.
+- **PERF Phase 2's release-note item is rewritten**: shipped v0.10.0 upgrades from
+  v0.9.x do NOT rebuild the store — they get the lazy ALTER + background walk
+  (XVER's note). The "one-time rebuild, ~25 min re-backfill" text applies only to
+  fingerprint/codec drift and to dev-window builds. The v3→v4
+  drop-and-rebuild-fires-once test from PERF Phase 2 is superseded at C4 by the
+  XVER migration suite (upgrade-in-place from `3∧19`; drop from every other
+  from-state — the Phase-2-era and C1..C3-era states join the test's from-state
+  matrix).
+- **Rollback symmetry preserved**: an old jar against a v4 store rebuilds via
+  `metaMatches` equality, both directions, unchanged.
+- **Live-server deploy hazard (operational)**: between B2 (Phase 2 lands) and C4
+  (lazy path lands), any dev build deployed to the Modrinth server costs the ~4 GB
+  live store — and the consequence differs by sub-window: a **B2..C0-era** deploy
+  drops-and-rebuilds (~23 min backfill) and costs a SECOND rebuild at the next
+  protocol-20 deploy (wire 19 ≠ 20); a **C1..C3-era** deploy rebuilds into the
+  `4∧20`-no-`wirefmt` state, which absent the structural guard would poison the
+  final deploy into the latch state (with the guard: another drop-and-rebuild).
+  Hold live deploys in this window. The stage-A deploys (R-3) predate B2, so
+  baseline collection is unaffected.
+- This reconciliation also resolves XVER §12's lazy-vs-drop DECIDE to **lazy as
+  specced**; §12's other two DECIDEs (terminal fallback `minecraft:stone`, curated
+  table ships empty) resolve to their proposed defaults via §3.2.
+
+### R-2 — Probe-snapshot refactor: the TRACER PR owns it (resolves the mutual F2-8 deferral)
+
+TRACER §1.4 and YIELD §1.1 each reference the other ("whichever PR lands first
+implements the combined shape"). Resolved: **the tracer PR (A1) lands first and
+implements the combined shape as specified in YIELD §1.1** — `ChannelPressureProbe`
+gains the default method `snapshot()` returning
+`{pendingBytes, highWaterMark, writable}` (default
+`{pendingOutboundBytes(), unknown, unknown}` so every lambda site compiles and
+degrades to no-yield), plus the public factory widening both platform adapters.
+**This makes A1 touch Paper code** (the `PaperChannelPressure` factory) — TRACER
+§5's "no Paper changes" claim holds for the tracer proper, not its carrier PR;
+recorded here as the override. The yield PR (A2) consumes the refactor and adds
+only the gate/floor/prune. Test split: **A1 pins the degrade VALUES** (a
+bare-lambda/legacy probe snapshots to `{pending, unknown, unknown}`); **A2's gate
+pins re-assert the behavior** ("legacy probe → never yields") — the YIELD §6
+degrade pin is part of the fail-safe surface, not just the refactor, so it lives
+with the gate.
+
+### R-3 — Tracer before yield, and both deployed EARLY (operational sequencing)
+
+TRACER §4.1's constraint (baseline collected with the yield unarmed) is satisfied
+structurally — the yield ships default-FALSE — but the real driver is **data
+latency**: organic desync events arrive at ~weekly cadence, so every week of tracer
+runtime is a week of baseline. Therefore:
+
+- A1 (tracer) merges first and is **deployed to the Modrinth server immediately as a
+  dev build** (SFTP jar + `touch config/lss-move-trace.enable` + archon restart +
+  the TRACER §4.3 verification ladder), while stages B/C proceed.
+- **The A2 build (yield present, inert, default FALSE) is also deployed to the live
+  server at A2-merge time — before B2 opens the R-1 store-hazard window** — so the
+  later E3 arming is a config flip, not a deploy. If the arming build ever needed
+  rebuilding inside the window, R-1's deploy hold applies to it like any deploy
+  (wait for post-C4, or knowingly pay the rebuild).
+- The yield stays unarmed on the live server until the baseline is judged
+  sufficient; arming is the E3 one-key A/B with **event rates as the metric**
+  (YIELD §4). Analysis partitions rows by the boot row's
+  `lodYieldsToVanillaTransport` snapshot (both plans already require this).
+- The **default flip stays post-v0.10.0** (YIELD §4: flip cites the E3 measurement,
+  with the §2.2 redesigned persistence-remnant damper as a stated precondition).
+  v0.10.0 ships the mechanism, not the policy.
+
+### R-4 — Measurement ordering: the perf round closes before the v20 encode lands
+
+All PERF gates are same-session interleaved A/Bs, so landed-order mostly doesn't
+matter — with one exception: the **round-acceptance closing A/B (PERF "Round
+acceptance") must run against the final PERF tree BEFORE stage C1's v20 encode
+rewrite merges.** The v20 emitter changes the serialize/transcode composition (adds
+dictionary building, removes the >256 object-fallback for encoding), which would
+confound the three-thread backfill arithmetic and the serve-path µs/col cut against
+their pre-round base. Concretely: B5 is a merge gate for C1, and **the closing
+A/B's arms are pinned**: base = B0's parent commit (post-A2, so A1/A2's
+nonzero-but-negligible per-flush/per-packet costs sit in BOTH arms), change = the
+B4 merge (pre-C0, so no v20 classes sit in either arm).
+
+XVER's own costs are then measured separately: its Phase 0 settling measurement
+(real-encoder zstd-1 frame diff) covers SIZE, and the C6 benchmark run covers CPU
+with **two arms**: the legacy-dialect arm (translation cost, XVER §12) and a
+**native-v20 arm** (serve µs/col vs the B5 tree) — the shipped tree's serve cost is
+otherwise never measured, since B5 deliberately predates the encode. §3.2's
+release-note numbers are phrased as perf-round wins; the native-v20 arm is what
+licenses any end-to-end v0.9.x→v0.10.0 claim. The C6 run uses the PERF Phase 0
+tooling (ref-vs-ref arms, pooled counters; optionally extend the marker class list
+with `IdentityCodec`/translator classes so the new cost is attributable rather than
+lumped into `nbt-other` — and if the markers are extended, re-check the classifier
+tripwire expectations for that run only).
+
+### R-5 — Perf ∩ protocol 20 layering (amends XVER §4.1's reading of the transcode path)
+
+The three perf changes and the v20 encode occupy **disjoint layers of the same
+pipeline**, in this order: raw fetch (PERF Phase 3) → inflate + selective parse
+(PERF Phase 4) → transcode emit (XVER v20). C1's rewrite must preserve the two
+upstream layers:
+
+- **`MemoizedNbtCodec` stays hot under v20** — XVER §4.1 retains the id resolve for
+  the two count shorts and the x-ray mask pre-gate, which run per palette entry on
+  every transcoded section. PERF Phase 1's structural-identity `Key` therefore
+  remains fully load-bearing; nothing in C1 may regress it, and the `Key` stays a
+  nested class (the marker-counter identifier contract).
+- **PERF Phase 3's `ChunkRawRead` seam and Phase 4's `SelectiveChunkNbtLoader` are
+  untouched by v20** — they operate on region bytes and NBT structure, upstream of
+  emit. The selective-parse whitelist stays exactly `{Status, sections}` (v20
+  consumes no new root keys — the dictionary is built from the section palettes,
+  inside `sections`). The source-regex whitelist pin must keep passing through C1.
+- XVER §4.1's "the >256-palette object-path fallback can be RETIRED for encoding"
+  concerns **the transcoder's pre-existing per-section fallback ladder** (which
+  PERF Phase 4 leaves in place — Phase 4's own fallback is the separate root-level
+  full-`NbtIo.read` path): the palette-size trigger goes; the malformed-shape
+  triggers and the mask pre-gate stay (both plans agree). C1 updates the
+  per-section ladder tests accordingly.
+
+### R-6 — Diag/observability surface accretion order
+
+Three additions touch `DiagnosticsFormatter` goldens and exporter parity in
+sequence: A1 adds the conditional `MoveTrace:` line (V18Compat conditional-slot
+precedent — note C1 later *replaces* the `V18Compat:` slot with `Dialects:`, so the
+precedent text in TRACER §3 refers to the pattern, not the surviving line); A2 adds
+`yielded=` + `yield.ticks_total`/`yield.bytes_withheld_total`; C1's `Dialects:`
+replacement then re-touches the five pinned surfaces XVER §4.3 enumerates — by C1
+time those goldens include the A1/A2 tokens, which is routine golden churn, listed
+here so nobody reads it as drift.
+
+Tracer row-schema accretion follows the same ownership rule (writer and reader
+cannot drift — TRACER §3): **A2 adds `yielded` to the tracer's `lss` block and
+updates `check_move_trace.py` + the shared fixtures in the same PR** (resolves the
+mutual deferral: TRACER §1.4 phrased `yielded` as a dependency on the yield, YIELD
+§5 phrased it as a dependency on the tracer — under this landing order the yield PR
+owns it); **C1 does likewise for the `dialect` field gaining `v19`** (read from
+`WireDialectTracker` once it exists — until then the field is v18/v16-only).
+
+### R-7 — Re-port catalogue additions (amends XVER §11.2)
+
+The 26.1 / 1.21.11 re-ports now carry the whole v0.10.0 tree, which adds three
+per-MC-version surfaces to the known-gotchas catalogue:
+
+1. **The tracer's bytecode-facing pins**: the ASM `handleMovePlayer` scan (INVOKE
+   counts + relative order) and the reflective field-existence pins are
+   per-MC-version by construction — each line re-verifies them; where a line's
+   bytecode genuinely diverges, adjust the pins for that line (the non-required
+   `lss-trace.mixins.json` + cast-degrade is the runtime safety net either way; a
+   line where the tracer can't be made sound ships with it degraded, not blocked).
+2. **PERF Phase 3's `RegionFile` raw-read mixin**: the region record format is a
+   per-MC-version reimplementation risk (PERF's own standing risk). The
+   @Shadow/@Invoker-on-vanilla-helpers rule makes drift loud; each line re-verifies
+   the shadowed members and the three-branch `createChunkInputStream`
+   reconstruction against that line's bytecode.
+3. **PERF Phase 4's root-parse handling**: `NbtIo` root shape is stable across
+   these lines, but the whitelist source-regex pin re-verifies against each line's
+   serializer (1.21.11's count-set divergence is already in the catalogue; the v20
+   count-shorts pin — XVER §2.1 — is the wire-side answer).
+
+The pre-existing catalogue (loom-remap, paperweight Java 21, ScopedValue,
+per-MC-version `xray-masked` goldens — regenerated for v20 anyway — build.yml
+`support/**`, dual-line tags, release.yml flavors + contract-test twins,
+`release_check.py --version` expansion, PluginYml folia flavor) applies unchanged —
+with one direction-flip flag: **fresh re-port branches inherit main's
+folia-supported PRESENCE pin** and must actively re-derive the correct per-line
+flavor (the old support branches already carried theirs; a fresh cut does not).
+Estimate impact: +1–2 d on the 1.21.11 line.
+
+### R-8 — Manual-test infrastructure and backport verification (new obligations; amends the A1/C4/C5/C6/D3 rows)
+
+Two manual rigs exist and both need program work — neither is on any source plan's
+task list, so the obligations live here.
+
+**`test-server.sh` (in-repo, the 26.2 dev rig — Fabric :25564 / Paper :25566 /
+Folia :25567).** Config staging needs NO changes for the new keys — it stages
+shipped defaults plus only rig-specific overrides, so `lodYieldsToVanillaTransport`,
+`useSelectiveNbtParse`, `enableV19Compat`, and `enableViaMismatchGuard` all fall
+through correctly (verified non-change). Three stage-owned additions:
+
+- **A1**: an `LSS_MOVE_TRACE=1` knob that touches `config/lss-move-trace.enable` on
+  the staged servers — the dev rig IS the tracer's vanilla-rung environment
+  (TRACER §1.3's E6 rig), and manual flights there are how the row schema gets
+  eyeballed before the live deploy.
+- **C5**: a Via variant (`LSS_VIA=1` / `run-fabric-via`) staging
+  ViaFabric+ViaBackwards on the Fabric server (ViaVersion+ViaBackwards on Paper —
+  the issue-#85 join path) — the mismatch guard is dead code on a rig without Via,
+  and the guard + its kill switch need a live pull before the D3 matrix. Old-MC
+  clients for the denial test already exist (the `lss-multi-test` Prism profiles +
+  its v0.8.0-era jars).
+- **C4** (no script change): `run-fabric-store`'s existing world store is the
+  natural lazy-migration eyeball — watch `/lsslod store status` `migrating=`,
+  confirm warm hits from minute zero, then one old-jar boot against the migrated
+  store to see the rollback drop-and-rebuild fire.
+
+**`lss-multi-test` (out-of-repo at `~/projects/lss-multi-test` — six servers,
+3 Fabric + 3 Paper, ports :25580–:25585, per-line Prism client profiles; a one-off
+currently pinned at v0.8.0).** Refreshed at D3 as the tri-release verification rig:
+
+- Update `SERVER_DEFS` to the v0.10.0 RC jars built from main + the two FRESH
+  re-port branches (the header's old `support/*` branch SHAs retire with those
+  branches); rebuild `jars/`; re-check the per-line fabric-api pins; the Java 21
+  pin for the 1.21.11 pair stays.
+- Add the Via dimension to the 26.2 pair (ViaVersion+ViaBackwards on `paper-26.2`
+  and/or ViaFabric+ViaBackwards on `fabric-26.2`).
+- Per-line Prism profiles gain the **backported v20 client builds**; keep one
+  legacy-LSS profile (v0.9.1) for rung checks.
+- Box discipline applies with teeth: these six servers ARE the documented
+  2026-07-28 A7 incident (forgotten multi-test JVMs redding fresh-backfill twice)
+  — `./run.sh stop` + the `pgrep` check close every matrix session (§2).
+
+**The verification matrix** (tracked as a checklist in the progress doc; depth per
+the support-line effort budget — CI tiers carry each line's automated load, manual
+work is smoke, never a gauntlet):
+
+1. **Same-MC native, per line** (D3 — the per-line staging/smoke): join → cold
+   backfill arc → warm rejoin with store hits → `/lsslod diag` shows
+   `Dialects: v20=1` → `store status` clean. Fabric AND Paper per line.
+2. **Cross-MC v20** (D3 — needs the backported clients): a 1.21.11 client on its
+   line's v20 build → the Via'd 26.2 server, and a 26.1 client likewise — terrain
+   eyeballs correct, `/lss trace` fallback counters bounded, no decode loops.
+   **The only end-to-end issue-#85 proof.** This is XVER §9's "live matrix" —
+   note its cross-MC cells structurally CANNOT run at C6 (the backported clients
+   don't exist until D3): C6 runs cells 3–4 below, D3 completes the matrix.
+3. **Mismatch guard** (C6 — runnable with the EXISTING v0.8.0-era 1.21.11 client
+   jars against the C5 Via rig): old-LSS old-MC client → Via'd 26.2 v20 server →
+   registration denied + the one INFO line; flip `enableViaMismatchGuard` off →
+   today's garbage behavior returns (documented, proving the kill switch).
+4. **Same-MC legacy rungs** (C6, optional eyeball — the crafted-frame gametests
+   carry these): a v0.9.1 client → v20 server (v19 rung); a v20 client → a v0.9.1
+   server (client ladder).
+
+D3's tags are pushed only after cells 1–2 are green on every line — tags are
+irreversible publishes.
+
+---
+
+## 2. Master landing order
+
+| stage | content | source spec | gates to merge |
+|---|---|---|---|
+| **A1** | Probe-snapshot refactor (combined shape incl. the Paper factory, R-2) + move-desync tracer + `LSS_MOVE_TRACE` rig knob (R-8); **immediate live deploy** (R-3) | TRACER v2.1 + YIELD §1.1 | tracer Tier 1/2 suites, `check_move_trace.py --selftest`, snapshot-degrade VALUE pin, deploy-verification ladder |
+| **A2** | Transport yield, default FALSE (gate + floor + flush-side prune; damper stays CUT); tracer `lss` block gains `yielded` + validator fixtures (R-6); **live deploy of the inert build pre-B2** (R-3) | YIELD v2.1 | YIELD §6 Tier 1 suite incl. the never-yields degrade pin, soak allowlist same-commit |
+| **B0** | Measurement tooling (BENCHMARK_CONFIG_STAGED completion, ref-vs-ref arms, backfill_profile.sh, jfr analyzer extensions, compare_profile.py, A/A control) | PERF Phase 0 | tooling self-checks; A/A control run before B1's first gated run |
+| **B1** | R3 structural-identity memo key | PERF Phase 1 | its A/B gates (≥30% backfill-thread cut, ≥20% serve, parity ±2%) |
+| **B2** | R4 CRC32C + interim schema bump (dev-window semantics per R-1; FNV renamed-and-kept) | PERF Phase 2 as amended by R-1 | its A/B gates (≥80% batcher cut, deposits/s flat, store gates/soaks) |
+| **B3** | R1 background-read split (raw-bytes handover; split kill-switch decision at PR time — if exposed as config, soak allowlist + §3.2 entry ride the same PR) | PERF Phase 3 | its A/B gates (≥75% IO-Worker LSS-frame cut, hibw ceiling ±5%, conservation) |
+| **B4** | R2 selective NBT parse (`useSelectiveNbtParse`, default true) + its soak-allowlist entry | PERF Phase 4 | its A/B gates (≥30% alloc cut, ≥25% band-minus-memo cut) |
+| **B5** | **Round-acceptance closing A/B** — merge gate for C1; arms pinned per R-4 (base = B0 parent, change = B4 merge) | PERF "Round acceptance" | ≥5% serve µs/col, ≥15% three-thread backfill, store_gate clause |
+| **C0** | IdentityCodec + registry tables + WireSectionCursor + settling measurement | XVER Phase 0 | unit suites; settling numbers recorded before any size claim ships |
+| **C1** | v20 encode (all three produce paths, R-5 layering preserved) + client decode/fallback ladder + handshake/gate + WireDialectTracker + diag `Dialects:` (R-6, incl. tracer `dialect` follow-through + validator) + `enableV19Compat` soak-allowlist entry | XVER Phase 1 | goldens/fuzz/parity twins, frozen-shape pin, hostile-frame pin |
+| **C2** | Legacy egress translators (v19/v18/v16) + store-hit recompress + `-Psoak.dialect=19` lever | XVER Phase 2 | translation-chain goldens, dialect-19 soaks |
+| **C3** | Client ladder (20→19→16 discovery) | XVER Phase 3 | ladder Tier 1 suite |
+| **C4** | Store schema 4 FINAL: lazy ALTER + `wirefmt` + `store_layout` structural guard + per-wirefmt hash/translation dispatch on BOTH rungs (R-1) + background migration walk | XVER Phase 4 as amended by R-1 | migration suite incl. the R-1 from-state matrix + both-rung dispatch/translation pins; store-migration soak variant; rig-store migration eyeball (R-8) |
+| **C5** | Via mismatch guard + messaging + `enableViaMismatchGuard` soak-allowlist entry + `test-server.sh` Via variant (R-8) | XVER Phase 5 | probe-seam stub tests |
+| **C6** | Hardening: cross-registry sims, Tier 2/3 additions, v20 fixture-corpus capture (XVER §9), full soak passes (all 19 Fabric + the 5-scenario Paper + 4-scenario Folia sets), benchmark run with legacy-dialect + native-v20 arms (R-4), live-matrix cells 3–4 (guard + same-MC legacy rungs — R-8) | XVER Phase 6 | everything green incl. the guard cell; matrix cells 1–2 complete at D3 (R-8) |
+| **D1** | Docs: PERF Phase 5 (R5 ops note + erratum carry-through), release notes (§3.2), CLAUDE.md updates (incl. the stale folia-supported "ABSENT" text in the Test Commands bullet + `PluginYmlContractTest`'s javadoc) | PERF Phase 5 + this doc | — |
+| **D2** | v0.10.0 main release (protocol 20, schema 4) | release checklist | pre-flight build + `release_check.py`, Tier 3 green on the release commit |
+| **D3** | Fresh 26.1 + 1.21.11 re-ports (R-7 catalogue incl. the folia-flavor direction flip) + cross-line fixture decode suites (XVER §9 / Phase 7 — the only automated issue-#85 coverage) + `lss-multi-test` refresh + per-line staging/smoke + cross-MC v20 matrix cells 1–2 (R-8) + tri-release + issue #85 answer | XVER §11 + §9 + R-8 | per-line pre-flights; matrix cells 1–2 green on every line BEFORE any tag is pushed |
+
+Parallelism notes: A and B are **independent mechanisms with minor shared
+surfaces** (`ServerConfigBase` + config-validation pins, service wiring for the
+probe factory / config echo / yield counters, `DiagnosticsFormatter` goldens,
+`check_soak.py` allowlists) — merge-conflict-level only; sequence the PRs, don't
+fork them. **Box discipline: measurement sessions own the box exclusively** —
+every B-phase A/B, the B5 acceptance, and C6's soak/benchmark passes run with no
+concurrent builds, gametests, or parallel-stage work (the repo's A7 history is
+exactly this failure mode; PERF's `pgrep` check catches leftover processes, not
+concurrent work). Interleaving of workstreams is calendar-level only. C0 can start
+alongside late B phases (common-module additive code), but C1 waits for B5 (R-4).
+C2/C3 are parallelizable after C1. The XVER constraint that phases C1–C5 land as
+**one release branch** (a wire bump cannot ship piecemeal) stands — "land" above
+means merge to the v0.10.0 integration branch, not to a released main.
+
+**Ordering rationale, compressed:** tracer first because live data has weeks of
+latency and the yield's E3 gate consumes it (R-3); yield second because it's small,
+default-off, and consumes A1's refactor; perf before v20 because its phases are
+small, independently gated, and their acceptance arithmetic must close on a
+stable-format tree (R-4), and because CRC32C-before-migration is what makes the
+schema story converge on one bump with a trivial hash dispatch instead of a
+dual-era hash zoo (R-1); v20 last because it's the largest, its store phase absorbs
+the schema endgame, and its transcode simplifications layer cleanly on top of the
+perf-restructured pipeline (R-5).
+
+---
+
+## 3. Consolidated obligations
+
+### 3.1 Testing (delta view — each source plan's suite stands; these are the merge-created additions)
+
+- R-1: the C4 migration suite's from-state matrix gains the Phase-2-era dev state
+  (schema 4, no wirefmt, wire 19 → drop) AND the C1..C3-era state
+  (schema 4, wire 20, no wirefmt → drop via the `store_layout` guard). Dispatch
+  pins run on **both read rungs** (`get()` and `getFrame()`): a 19-row validates
+  FNV and serves TRANSLATED (the raw-rung serve byte-equals its post-migration
+  serve); a 20-row validates CRC32C; a migrated row re-validates CRC32C; a
+  re-deposit over an unmigrated row re-tags `wirefmt=20` and validates CRC32C; a
+  corrupted row of each era purges.
+- **Config-key allowlist rule** (the twice-shipped R4-class defect —
+  `check_soak.py`'s own comments record it): every new server config key lands
+  with its `check_soak.py` `SERVER_CONFIG_KEYS`/`SERVER_CONFIG_BOOL_KEYS` entry in
+  the same commit. Assignments: A2 `lodYieldsToVanillaTransport` (already YIELD
+  S-8), B4 `useSelectiveNbtParse` (also the next A7 kill-switch-A/B candidate —
+  without the entry the documented triage is unwritable), C1 `enableV19Compat`,
+  C5 `enableViaMismatchGuard`, and B3's split kill switch if the PR-time decision
+  exposes it as config.
+- R-2: A1 carries the `snapshot()` default-method degrade VALUE pin; A2 carries the
+  gate pins incl. "legacy probe → never yields"; the
+  `ChannelAccessorContractTest` sibling assertion (YIELD S-9b) lands in A2.
+- R-5: C1 re-runs the selective-parse whitelist source-regex pin and the
+  per-section transcode fallback-ladder tests under the v20 emitter; the
+  transcode-vs-object fuzz twin extends to v20 (already in XVER §9).
+- R-6: golden churn lands per stage; C1's five-surface enumeration is re-checked
+  against the then-current goldens (which include A1/A2 tokens); tracer-schema
+  accretions (A2 `yielded`, C1 `dialect` v19) update `check_move_trace.py` + the
+  shared fixtures in the same PR.
+- R-7: per-line re-verification items join the re-port checklists.
+
+### 3.2 Release notes (v0.10.0, all three lines; format per CLAUDE.md)
+
+- **New Features**: cross-MC-version LOD serving (protocol 20) + the supported
+  version matrix + the Via-proxy detection hole; the vanilla-first transport yield
+  (default off, what it does, proxy best-effort caveat).
+- **Performance**: the perf round's wins, phrased as perf-round numbers (from the
+  B5 closing A/B); any end-to-end v0.9.x→v0.10.0 claim cites the C6 native-v20 arm
+  (R-4). CRC32C store hashing.
+- **Configuration**: `lodYieldsToVanillaTransport` (false), `useSelectiveNbtParse`
+  (true), `enableV19Compat` (true), `enableViaMismatchGuard` (true), client
+  `unknownBlockFallback` (`minecraft:stone`) + `crossVersionBlockFallbacks`
+  (ships empty) — the latter two resolve XVER §12's DECIDE items to their proposed
+  defaults; plus B3's split kill switch if exposed.
+- **Store**: one-time background migration walk (NOT a rebuild — R-1); wire/store
+  size +~4–6% pending C0's settling measurement (publish the measured figure, not
+  the estimate); fingerprint drift still drops.
+- Folia items mention experimental status, as always. The tracer is deliberately
+  absent from the notes (no documented surface — user decision in TRACER).
+
+### 3.3 Explicitly OUT of v0.10.0 (recorded so nothing silently re-enters)
+
+- The yield **default flip** + the redesigned persistence-remnant damper (its
+  precondition) — later release, cites E3 (YIELD §2.2/§4).
+- The client-side hole map (investigation doc
+  `moved-wrongly-investigation-2026-08-06.md` §5.2) — built when an INDETERMINATE
+  verdict triggers it.
+- M3 rate reservation; per-tick yield smoothing cap; send-queue proximity
+  re-ordering (the YIELD v3 levers).
+- PERF Phase 4's early-abort inflate stretch.
+- Store-survives-mod-changes (XVER §5.6 follow-up); the client v18 rung (XVER §6);
+  identity-level `MaskSet.containsIdentity` cleanup.
+- 1.21.8 / 1.20.1 lines (XVER non-goal; they never enter the v20 matrix).
+
+---
+
+## 4. Risks (merge-level; source-plan risks stand)
+
+1. **Release size.** One release carries a wire bump, a schema bump, a structural
+   read-path change, and two new subsystems. Mitigations already in the plans: every
+   PERF phase independently revertible with A/B evidence; yield default-off; tracer
+   inert-by-default; v20 kill switches (`enableV19Compat`, `enableViaMismatchGuard`)
+   + `useSelectiveNbtParse` + `useNbtTranscode` + the Phase-3 split kill-switch
+   decision. The residual risk is interaction surface, which C6's hardening (all 19
+   Fabric scenarios + the 5-scenario Paper and 4-scenario Folia sets + dialect-19
+   soaks + live matrix) is sized for.
+2. **The R-1 hash dispatch is the one genuinely new invention of this merge** — it
+   exists in neither source plan and had no prior review at v1.0. The three-Fable
+   round (§7) attacked it specifically: the mechanism held, and the round added the
+   structural guard, the raw-rung coverage, and the upsert re-tag pin. Its §3.1 pin
+   set is the contract.
+3. **Schedule coupling**: B5-gates-C1 serializes the two big workstreams. If the
+   perf round's measurement sessions drag (box variance, A/A control redos), C0 can
+   proceed but C1 queues. Accepted — the alternative (concurrent format churn under
+   the acceptance A/B) invalidates the round's evidence.
+4. **Live-store window** (R-1): a mis-timed live deploy between B2 and C4 costs the
+   4 GB live store — one rebuild in the B2..C0 sub-window (plus a second at the
+   final deploy), a poison-then-latch in the C1..C3 sub-window absent the
+   structural guard. Operational discipline item, stated in both PR texts.
+5. **Tracer data may lag the release**: if no organic events arrive before D2,
+   v0.10.0 still ships (the tracer/yield are mechanism, not policy — R-3); the E3
+   A/B and flip decision simply continue on the live server post-release.
+
+## 5. Effort / timeline (calendar, at this repo's review cadence)
+
+| stage | estimate |
+|---|---|
+| A1 + A2 + live deploys | ~4 d (tracer ~2.5 d, yield ~1.5 d) |
+| B0–B5 incl. measurement sessions + acceptance | ~1.5–2 wk |
+| C0–C6 | ~4–5 wk |
+| D1–D3 (docs, release, re-ports ×2) | ~1.5–2 wk (R-7: +1–2 d on 1.21.11; the R-8 multi-test refresh + matrix, ~1 d, rides inside the envelope) |
+| **total** | **~8–10 wk**, tracer baseline accumulating from week 1 |
+
+## 6. Implementation practices (program-wide)
+
+### 6.1 Progress tracking — `docs/planning/v0.10.0-progress.md`
+
+Created at program start, **before A1's first commit** (the
+`lod-store-implementation-plan.md` + `lod-store-progress.md` precedent). This plan
+stays the frozen spec; the progress doc carries the living state. A plan deviation
+is legal only as a PAIR: a dated decisions-log entry AND an edit to this plan at
+the overridden text (pointer back to the log entry) — never a silent divergence.
+Sections:
+
+- **Stage table**: one row per stage — status (pending / in-progress / PR #N in
+  review / merged / gate-passed), dates, PR links, and gate verdicts with the
+  run-stamp dirs of their A/B evidence (so any later question about a gate re-opens
+  the actual artifacts, not a memory of them).
+- **Decisions log**: dated entries for every decision made along the way — the
+  PR-time decision points this plan explicitly leaves open (B3's split kill switch,
+  C0's settling numbers replacing the §3.2 size estimate, E3
+  baseline-sufficiency), plan deviations (paired with a plan edit, above), and
+  user decisions recorded as "user decision YYYY-MM-DD" per repo convention.
+- **Measurement ledger**: every A/B session — date, box-state confirmation (the §2
+  exclusivity check + `pgrep` clean), arms/refs, pooled numbers, verdict. The A/A
+  control's measured spreads live here: they size later gates (PERF's hibw ±5%
+  rule), so they must be findable.
+- **Live-deploy log**: every Modrinth-server deploy — build SHA, date, stage-era
+  of the jar, and store outcome (opened clean / dropped / migrated). Load-bearing
+  twice over: it is the R-1 hazard-window audit trail, and it is how tracer
+  analysis maps `bootId`s to build/config eras (the R-3/TRACER §4.5
+  partition-by-boot requirement).
+- **Flake/anomaly notes**: anything triaged as environmental during the program,
+  cross-referenced into CLAUDE.md's Known Test Flakes section when durable (that
+  section is the canonical home; the progress doc entry is the working note).
+
+Update at every stage boundary at minimum; decisions are logged when made, not
+batched.
+
+### 6.2 Review discipline — 3-Opus rounds per implementation PR
+
+- **Every code-carrying stage PR gets a three-Opus-subagent review round before
+  merge.** Lenses are grouped (the repo's 2–3-subagents-per-round budget) and
+  chosen per stage; the default triple is (a) correctness + concurrency,
+  (b) pinned-decisions + contract collisions, (c) test-adequacy + gate
+  methodology. Stage-specific swaps: B3 adds mixin/bytecode feasibility to (a)
+  (the round's riskiest structural change — the TRACER/YIELD rounds are the
+  template for bytecode-verifying reviews); C1 adds a wire/format lens; C4 adds
+  store/ops (the R-1 pin set is its checklist). B0 (tooling) and D1 (docs) take a
+  single-reviewer pass instead.
+- Findings tables + dispositions are recorded in the progress doc, per the source
+  plans' §-table pattern; the finding→disposition table is written when the round
+  closes, not reconstructed later.
+- Reviewers verify claims against real code/bytecode before reporting — the
+  standard every source-plan round set; unverified findings are marked PLAUSIBLE,
+  not asserted. Where a fix is non-trivial, the original finder re-verifies the
+  fix (continue the same agent) rather than spawning a fresh one.
+- **The review-findings-vs-pinned-decisions rule stands** (recorded project
+  lesson): before accepting any finding that changes behavior, check it against
+  the pinned tests and the decision record — a finding that contradicts a
+  deliberate pin is escalated to the user with the pin cited, never silently
+  "fixed".
+- Usage gating (recorded user preference): check remaining usage before launching
+  a round; above ~85% consumed, hold the round until reset rather than degrading
+  it.
+
+### 6.3 PR / branch / evidence discipline
+
+- **One PR per stage-phase, carrying its gate evidence in the description**
+  (PERF's rule, generalized program-wide): A/B numbers for B phases,
+  golden/parity/pin diffs for C phases, the deploy-verification transcript for
+  A1/A2's live deploys.
+- Branching: main stays releasable; C1–C5 land on the v0.10.0 integration branch
+  (§2); A/B/D stages PR to main directly. Merges use `--merge` per repo convention
+  (squash/rebase rewrite SHAs — fatal for anything a tag will reference).
+- **Each PR re-verifies the pins it touches before implementation, not after**
+  (PERF's standing-risk rule, program-wide): read the pinned test and the decision
+  record first; if the planned change collides, that is a §6.2 escalation before
+  code is written.
+- Docs ride the PR that makes them true — CLAUDE.md paragraphs, design-doc
+  sections, and diag/config documentation land with the change (each source plan
+  already mandates this per-phase); D1 is the consolidation sweep and the
+  stale-text cleanup, not the first write.
+- Release steps (D2/D3) follow CLAUDE.md's release checklist verbatim — including
+  the never-rerun-a-partially-published-release and annotated-tag
+  `--cleanup=verbatim` rules.
+
+### 6.4 Stage-boundary ritual
+
+At each stage merge: update the progress doc (stage table + any decisions); run
+the stage's own gate set (C6 owns the full gauntlet — don't burn it early); confirm
+the tiers the stage touched are green; log deviations. Before each measurement
+session: the §2 box-exclusivity check. Before D2: the full release pre-flight.
+
+## 7. Review round record (2026-08-06, three Fable agents: integration / pinned-decisions / fidelity)
+
+All findings below are folded into the sections above (v1.0 → v1.1). Severity as
+reported; INT/PIN/FID = the reporting lens. The raw-rung gap (INT-2/PIN-6/FID-1)
+was found independently by ALL THREE lenses — the round's strongest signal.
+
+| finding | disposition |
+|---|---|
+| INT-1 MAJOR: a C1..C3-era dev store (meta 4∧20, no `wirefmt` column) passes `metaMatches` — which compares meta keys, never table structure — opens as valid, then latches dead at `WRITE_FAILURE_LATCH` (SELECT throws triaged transient; INSERTs fail 20×); hand-delete-only recovery | R-1 `store_layout` structural-guard meta key (stamped by fresh-create AND upgrade, in `metaMatches`); from-state matrix + hazard bullet + risk 4 reworded per sub-window |
+| INT-2 / PIN-6 / FID-1 MAJOR: the raw `get()` rung (v18/v16 + non-zstd v19 sessions) had neither the hash-dispatch input nor the 19-row translation — FNV rows purged as corrupt AND untranslated v19 bytes served to v20 clients (issue #85 via a shipped kill switch); v1.0 also named a nonexistent `getColumn` and over-attributed the contract to XVER §5.3 | R-1 names `get()`+`getFrame()`; both SELECTs/hit records gain `wirefmt` (a mega-created extension of XVER §5.3); translation required on both rungs; raw-rung byte-equals pin in §3.1 |
+| PIN-1 / FID-4 MAJOR: the `check_soak.py` allowlist obligation (the twice-shipped R4-class defect) was assigned only to YIELD's key — `useSelectiveNbtParse` (the next A7 kill-switch-A/B candidate), `enableV19Compat`, `enableViaMismatchGuard` had none | §3.1 allowlist rule with per-stage assignments (B4/C1/C5 + contingent B3), reflected in the stage table |
+| PIN-2 MAJOR: "A and B are independent workstreams (disjoint files)" licensed concurrent builds/tests during measurement sessions — the documented A7 box-contention failure mode; `pgrep` catches leftovers, not concurrent work | §2 parallelism note: measurement sessions own the box exclusively; interleaving calendar-level only; "disjoint files" corrected to shared-surface reality (also INT-4/FID) |
+| INT-3 MINOR: a re-deposit over an unmigrated row must re-tag `wirefmt=20` or the FNV dispatch purges the CRC-hashed row | R-1 upsert bullet + §3.1 pin |
+| INT-5 MINOR: B5's arm refs unpinned (A1/A2 deltas and C0 classes could contaminate) | R-4: base = B0 parent (post-A2), change = B4 merge (pre-C0) |
+| INT-6 MINOR: shipped-tree serve cost never measured (B5 predates the v20 encode by design) | R-4/C6: native-v20 benchmark arm; §3.2 phrases numbers as perf-round wins |
+| INT-7 / FID-9 MINOR: E3's arming needs a yield-capable live build; timing unstated vs the R-1 deploy hold | R-3: deploy the inert A2 build pre-B2; arming becomes a config flip |
+| PIN-3 / FID-11a MINOR: "all 19 soaks × both platforms" overstates the harness (Paper=5, Folia=4 scenario sets) and omitted Folia despite `WireDialectTracker` generalizing a Folia-sensitive lifecycle | C6 row + risk 1 corrected; Folia set added |
+| PIN-4 MINOR: the "A+B = coherent v0.9.2" contingency conceals a double store rebuild for that cohort (B2's interim state is inadmissible to C4's lazy path) | Release-shape caveat added |
+| PIN-5 / FID-6a MINOR: D1 cited "§4" for release notes (it's §3.2); FID-6b: hole-map citation was TRACER §5.2, actually investigation-doc §5.2 | Both corrected |
+| FID-2 MINOR: A1 touches Paper (probe factory), silently invalidating TRACER §5's "no Paper changes" | R-2 flags the override explicitly |
+| FID-3 MINOR: the tracer `yielded` field and validator/fixture updates had no owner under the inverted landing order | R-6: A2 owns `yielded` + fixtures; C1 owns the `dialect` v19 follow-through + fixtures |
+| FID-5 MINOR: the cross-line fixture suites (the only automated issue-#85 coverage) fell between C6 and D3 | C6 names the corpus capture; D3 names the per-line decode suites (XVER §9/Phase 7 cited) |
+| FID-7 MINOR: R-5 mis-attributed the >256 fallback trigger to "PERF Phase 4's fallback ladder" (it is the transcoder's per-section ladder) | R-5 corrected |
+| FID-8 MINOR: relocating YIELD's degrade pin to A1 could discharge a behavior only A2 can test | R-2/§3.1: A1 pins values, A2 pins never-yields |
+| FID-10 MINOR: XVER §12's three DECIDEs silently resolved | R-1 tail + §3.2 state the resolutions explicitly |
+| FID-11b MINOR: §3.3 omitted the third YIELD v3 lever (send-queue proximity re-ordering) | Added |
+| PIN caution: stale folia-supported "ABSENT" text (CLAUDE.md Test Commands bullet + `PluginYmlContractTest` javadoc); fresh re-ports invert the folia-flavor derivation direction | D1 sweep item; R-7 direction-flip flag |
+
+**Verified non-findings pinned by the round** (attacked and held — do not
+re-litigate): the R-1 hash-consumer census is complete (exactly four `contentHash`
+sites; the processing-thread frame-reuse deposit is covered because deposits are
+always `wirefmt=20` and producer/validator share the one canonical hash;
+`DirtyContentFilter.fnv1a64` separate and untouched); no committed row is ever
+hash-ambiguous (the walk's rewrite rides one batcher transaction); the Phase-2-era
+state drops correctly via wire 19≠20; rollback symmetry holds both directions;
+XVER §5's upgrade-block placement survives the amended matrix; `MemoizedNbtCodec`
+genuinely stays hot under v20 (per-entry resolve feeds count shorts + mask
+pre-gate) and the `{Status, sections}` whitelist is genuinely v20-sufficient; the
+A1 live deploy is version-skew-safe (no wire/store/config surface); all four
+source sequencing constraints are present and correctly translated; the timeline
+arithmetic and every stage-table gate column match the sources; PERF Phase 2's
+gates, XVER's migratability conjuncts, DropAll reset, WRITE_FAILURE_LATCH,
+watermark-rides-batch, day-one pessimization, and §5.6 fingerprint-stays all
+survive R-1; every hunted user decision is respected (lodStore default off, VSS
+publishing disabled, no v18 client rung, yield default FALSE, tracer invisible,
+26.2/26.1/1.21.11 MC set, bandwidth caps raw-denominated); D2's gates match the
+release contract; `release_check.py`/`build.yml` handle fresh re-port branches by
+construction; R-6's accretion story is coherent with all three sources.

--- a/docs/planning/v0.10.0-progress.md
+++ b/docs/planning/v0.10.0-progress.md
@@ -1,0 +1,56 @@
+# v0.10.0 program progress (living doc; spec = v0.10.0-mega-plan.md v1.3)
+
+Created 2026-08-06 at program start, before A1's first commit (mega plan §6.1).
+The mega plan stays the frozen spec; this doc carries the living state. A plan
+deviation is legal only as a PAIR: a dated decisions-log entry here AND an edit to
+the mega plan at the overridden text — never a silent divergence.
+
+## Stage table
+
+| stage | content (short) | status | PR | gate verdict / evidence |
+|---|---|---|---|---|
+| A1 | Probe-snapshot refactor + move-desync tracer + `LSS_MOVE_TRACE` rig knob + live deploy | in-progress | — | — |
+| A2 | Transport yield (default FALSE) + tracer `yielded` field + live deploy of inert build | pending | — | — |
+| B0 | PERF measurement tooling + A/A control | pending | — | — |
+| B1 | R3 structural-identity memo key | pending | — | — |
+| B2 | R4 CRC32C + interim schema bump (dev-window semantics per R-1) | pending | — | — |
+| B3 | R1 background-read split | pending | — | — |
+| B4 | R2 selective NBT parse | pending | — | — |
+| B5 | Round-acceptance closing A/B (merge gate for C1) | pending | — | — |
+| C0 | IdentityCodec + registry tables + WireSectionCursor + settling measurement | pending | — | — |
+| C1 | v20 encode + client decode + handshake + WireDialectTracker + `Dialects:` diag | pending | — | — |
+| C2 | Legacy egress translators + store-hit recompress + dialect-19 soak lever | pending | — | — |
+| C3 | Client ladder (20→19→16 discovery) | pending | — | — |
+| C4 | Store schema 4 FINAL: lazy ALTER + wirefmt + structural guard + both-rung dispatch + migration walk | pending | — | — |
+| C5 | Via mismatch guard + `test-server.sh` Via variant | pending | — | — |
+| C6 | Hardening: sims, Tier 2/3, fixture corpus, full soaks, benchmark arms, matrix cells 3–4 | pending | — | — |
+| D1 | Docs consolidation (PERF Phase 5, release notes, CLAUDE.md sweep) | pending | — | — |
+| D2 | v0.10.0 main release — **PREP ONLY this program: pre-flight + notes + tag text; tag NOT pushed (user directive 2026-08-06)** | pending | — | — |
+| D3 | Fresh 26.1 + 1.21.11 re-ports + multi-test refresh + matrix cells 1–2 + tri-release — **tags NOT pushed (same directive)** | pending | — | — |
+
+## Decisions log
+
+- **2026-08-06 (user decision, program start)**: execute the mega plan end to end,
+  but **prep and do not run the v0.10.0 release** — D2/D3 tag pushes are out of
+  scope for this program run; everything up to and including the pre-flight,
+  release notes, and tag text is in scope. Recorded here because it amends the D2/D3
+  rows' final step.
+- **2026-08-06**: program executed by Claude (autonomous session(s)); review rounds
+  per mega plan §6.2 with the repo's 2–3-subagent budget.
+
+## Measurement ledger
+
+(one entry per A/B session: date, box-state confirmation (§2 exclusivity +
+`pgrep` clean), arms/refs, pooled numbers, verdict)
+
+- none yet.
+
+## Live-deploy log
+
+(every Modrinth-server deploy: build SHA, date, stage-era of the jar, store outcome)
+
+- none yet. Standing note: R-1 deploy hold applies between B2 and C4 merges.
+
+## Flake/anomaly notes
+
+- none yet.

--- a/docs/planning/vanilla-first-lod-yield-plan.md
+++ b/docs/planning/vanilla-first-lod-yield-plan.md
@@ -1,0 +1,334 @@
+# Vanilla-first LOD transport yield — implementation plan v2.1 (2026-08-06)
+
+Implements mitigation M1/M2 from `docs/planning/moved-wrongly-investigation-2026-08-06.md`
+as a **transport yield**: LSS column traffic defers to the connection's own backpressure
+signal, so vanilla packets — chunk data above all — are never queued behind a deep LSS
+backlog on the shared channel.
+
+**Revision history.** v1 → v2 after a two-Opus round (systems + adversarial; §8 table).
+v2 → **v2.1 after a single-Fable full-plan review** (§8.1 table), which found that v2's
+budget formula — written to fix v1's fixed threshold — degenerated into an unconditional
+~64 KiB/tick pacing cap (the probe reads at most the 64 KiB Netty high-water mark while
+the channel is writable, so `budget = max(64 KiB, highWaterMark) − pending` bound every
+tick on every link, capping LOD at ~1.25 MiB/s wire below the plan's own bandwidth
+defaults). v2.1 resolves it by following that arithmetic to its conclusion: with any
+sane decoupled ceiling the budget never binds while writable and is zero while
+unwritable — so the gate IS **Netty's writability flag**, with no budget arithmetic and
+no first-payload exemption needed at all.
+
+## 0. Purpose — and the exposure this closes anyway
+
+1. **Priority**: vanilla terrain outranks LOD on the wire. When the channel is backed
+   up, drain capacity goes to vanilla's queued packets and whatever the chunk system
+   writes next — not to more LOD.
+2. **Bounded buffering** (the stronger argument): Netty's `ChannelOutboundBuffer` is
+   unbounded — the watermarks only flip a boolean, the flush loop never consults
+   `isWritable()`, and the limiter keeps admitting up to `bytesPerSecondLimitPerPlayer`.
+   Today a client draining at 1 MB/s against a 15 MB/s stream accumulates server-side
+   direct-buffer memory without limit until the connection dies. Under the v2.1 gate the
+   LSS-attributable Netty queue is bounded by **the high-water mark + one tick's
+   admitted burst (~64 KiB + ~560 KiB wire at the shipped caps — see §1.2), with one
+   exception: the §1.4 starvation floor may add one payload per 5 s to a channel that
+   never drains** (in practice vanilla's ~30 s keep-alive timeout disconnects such a
+   client, so the floor adds at most a handful of payloads; stated because this bound is
+   the feature's primary justification).
+
+**Honest framing:** this is an *outbound-queue backpressure gate*, not a scheduler.
+While the channel is writable, LSS sends at whatever the bandwidth limiter allows —
+vanilla gets no rate reservation (that would be investigation M3, the v3 direction).
+What the gate removes is the pathology: LSS piling megabytes into an unwritable
+channel's queue ahead of vanilla's packets.
+
+**Measurement boundary:** writability is Netty's own signal that the kernel socket
+buffer stopped accepting writes and Netty is queuing. The kernel buffer underneath
+(OS-autotuned, often hundreds of KB) is invisible to it; the gate bounds the Netty-side
+queue only, and this plan makes no end-to-end latency claims. E3/E6 measure the actual
+effect on event rates.
+
+## 1. Mechanism (v2.1)
+
+### 1.1 Probe snapshot extension (shared with the tracer — ONE refactor)
+
+`ChannelPressureProbe` grows a **default method** `snapshot()` returning
+`{pendingBytes, highWaterMark, writable}`, defaulting to
+`{pendingOutboundBytes(), unknown, unknown}` so every existing lambda site (including
+`NO_SIGNAL` and every test rig) compiles and degrades to no-yield. Both platform
+adapters already read all three fields (they pass them into `OutboundBufferMath`
+today). The adapters' access is widened via one public factory — **the same refactor
+the move-desync tracer needs for its envelope `obuf` reads; whichever PR lands first
+implements the combined shape** (Fable F2-8). A third reader does not violate the "ONE
+authoritative probe read per tick" comment in `flushSendQueue` — that invariant makes
+the diag gauge and the deference decision agree within one flush; the tracer reads a
+different instant for a different purpose.
+
+### 1.2 The gate: yield while the channel is not writable
+
+In `flushSendQueue`, after the existing ceiling branch (§1.3):
+
+```
+snapshot = probe.snapshot()          // the same single read that feeds the diag gauge
+if (no signal / writable unknown) -> no yield (fail-safe, unchanged)
+if (!snapshot.writable)            -> skip this tick's column flush, retain the queue,
+                                      count the tick yielded (if queue non-empty),
+                                      still sweep departed/probe-suppress, return
+else                               -> flush normally (bandwidth limiter governs)
+```
+
+Properties, each replacing a v2 defect:
+
+- **No pacing cap on healthy links** (Fable F2-1): while writable, the limiter is the
+  only constraint — the §0 claim "LSS uses whatever capacity the limiter allows" is
+  true again. A tick's admitted burst is bounded by the limiter's 250 ms bucket
+  (~`cap/4` ≈ 3.9 MB raw ≈ ~560 KiB wire at the shipped defaults) — that burst is the
+  oscillation amplitude on a saturated link: write burst → channel flips unwritable →
+  yield until Netty drains below the **low**-water mark and flips writable (Netty's
+  own hysteresis) → next burst. A per-tick byte cap to shrink the amplitude is the v3
+  lever if E6 shows the oscillation matters.
+- **The single-payload invariant holds by construction**: a payload is only ever
+  written to a *writable* channel, so one legal maximum-size column (2 MB raw
+  v18-compat worst case) is never blocked — it can only flip the channel unwritable
+  and make *followers* wait until it drains. No first-payload exemption, no
+  `pending == 0` condition (v2's exemption was mostly dead during movement anyway —
+  Fable F2-5). The `MIN_OUTBOUND_BUFFER_CEILING_KB` invariant comment gains one
+  sentence pointing here. Consequence stated honestly: after a large raw column, a
+  slow link holds followers off until it drains — v18-compat sessions on thin links
+  ride closer to the floor rate.
+- **CI inertness is provable, not empirical**: loopback/memory channels never go
+  unwritable under our write sizes; the Tier 1 pin is simply "writable → no yield"
+  plus the existing `OutboundBufferMathTest` watermark pins. Armed-on-loopback soaks
+  behave identically to unarmed (no throughput cap to accidentally exercise — the v2
+  formula would have throttled them, F2-1).
+
+### 1.3 Ordering: ceiling first, yield second
+
+Unchanged from v2 (S-6): the `outboundBufferCeilingKB` branch keeps its position and
+its `deferred=` counter semantics. One consequence stated (Fable F2-7): **the §1.4
+floor applies to yield starvation only** — an operator-armed ceiling deferral has no
+floor, exactly as today.
+
+### 1.4 The starvation floor (liveness)
+
+Unchanged from v2 (A-4): if a player's flush has sent nothing for `YIELD_FLOOR_TICKS`
+(100 ticks = 5 s) and the queue is non-empty, send exactly one payload regardless of
+writability. Bounds worst-case LOD at ~1 column/5 s, distinguishes "yielding hard"
+from "dead", charges the limiter normally. The floor payload is drawn from the head of
+the *pruned* queue (§2.1 runs at the top of the same flush), so the floor never spends
+its one payload on terrain the prune was about to discard.
+
+### 1.5 Send-path matrix — the gate verified per supported configuration
+
+The gate never touches the chunk system, so its *mechanism* is identical everywhere;
+what differs per configuration is (a) which code writes the vanilla chunk packets the
+gate is yielding to, (b) whether the probe resolves, and (c) the traffic pattern the
+gate reacts to. All four send paths below were verified against real bytecode
+(decompiled vanilla 26.2; Moonrise-Fabric 1.1.0; C2ME 0.4.2-alpha.0.35 for 26.2), not
+assumed.
+
+| config | vanilla chunk-send path | probe | gate validity + interplay |
+|---|---|---|---|
+| **Fabric, plain** | `PlayerChunkSender` batch/ACK flow (client-metered `desiredChunksPerTick` 0.01…64, ≤10 unACKed batches) | `FabricChannelPressure` (accessor mixins → `Connection` → channel) | Baseline. Chunk batches and LOD share the obuf; the ACK flow self-limits vanilla traffic, so the channel is mostly writable and the gate rarely engages. |
+| **Fabric + C2ME** | **Still vanilla `PlayerChunkSender`** — C2ME's notickvd only *tunes* it: `MixinChunkDataSender` multiplies the ACK-reported `desiredChunksPerTick`, and the `0` ("unlimited") setting forces the memory-connection flag in the ctor, which removes the batch-size cap — chunk bursts hit the channel unmetered. notickvd's extra no-tick chunks ride the same sender. C2ME does not touch `Connection`/channel classes. | same as plain Fabric — no new resolution risk | Gate works unchanged and is MORE valuable here: uncapped/multiplied chunk bursts legitimately flip the channel unwritable, and the gate holds LOD out (at the floor rate) for exactly that duration. Honest consequence: a large notickvd join burst holds LOD near the floor for its duration — vanilla first is the feature's definition. (LSS's C2ME read-path fallback, `backgroundIncompatible`, is a different subsystem and unaffected.) |
+| **Fabric + Moonrise** (the live server) | `RegionizedPlayerChunkLoader` — bypasses vanilla scheduling entirely (own priority queue + `StaggeredRateLimiter`, calls the *static* `PlayerChunkSender.sendChunk` per chunk, no ACK feedback) | same as plain Fabric — Moonrise doesn't touch the channel plumbing either | Gate works unchanged. This is the config where it matters most: with no ACK feedback, a slow/stalling client cannot throttle Moonrise's sends — the backlog lands in the obuf, which is precisely the signal the gate reads (investigation doc §2.2 correction). It is also where the A-4 starvation regime is most likely — hence the floor. |
+| **Paper / Purpur** | Paper vendors the same spottedleaf chunk system natively (`RegionizedPlayerChunkLoader` in the server jar) — Moonrise-Fabric row applies | `PaperChannelPressure` (reflection; shipped, wired at `PaperRequestProcessingService` registration) | Gate works unchanged. **Proxy caveat (Paper-typical deployments):** behind Velocity/Bungee the channel is the server→proxy hop, so the gate sees the player's real link only insofar as the proxy propagates backpressure (Velocity does for slow clients, eventually — but a fast LAN hop plus a buffering proxy can blind the gate). On proxied networks the gate is **best-effort: it can under-yield, never over-yield** — stated in the config key's docs. |
+| **Folia** (experimental) | as Paper, regionized — region threads write chunk packets; Netty channel writes are thread-safe from any thread | as Paper; the pump-thread probe read is **already load-bearing in production today** at this exact call site (the read is unconditional for every handshaked player — S-12) | Gate works unchanged; zero new call sites, threads, or Netty API surface. Release notes mention Folia's experimental status as always. |
+| **Integrated server / LAN** | host player rides an in-memory connection (always writable → gate inert for the host); a LAN guest over real WiFi is an ordinary socket → gate applies normally — NOT covered by the CI-inertness argument; one of the live regimes the default-off period observes | same accessors | No special handling. |
+
+Per-config verification steps (all deferred — nothing runs now): loopback soaks on all
+three platforms (provably inert per §1.2 — zero baseline movement expected); the dev
+rig's C2ME A/B (`run-fabric` vs `run-fabric-no-c2me`, plus an uncapped
+`chunkSendingSpeedMultiplierPercentage=0` session); the live server as the Moonrise
+gate (E3, §4); `run-paper`/`run-folia` manual flights; the E6 netem rig for
+shaped-link behavior, one flight per config.
+
+## 2. Companion changes
+
+### 2.1 Send-queue relevance prune — main-thread, inside the flush (revised: Fable F2-3)
+
+Unchanged motivation (A-5): yield stretches queue residency from ~1 tick to minutes;
+unpruned, the post-yield drain ships kilometres-behind terrain oldest-first, and the
+M3 sweep deliberately keeps enqueued positions' done-bits pinned.
+
+**Revised mechanism** — v2 hung the prune off the eviction-cycle hook, which runs on
+the **processing thread**, while the send queue is a non-thread-safe main-thread-owned
+`PriorityQueue`: a data race as specified. v2.1: the prune runs **inside
+`flushSendQueue` on the owning thread**, gated by a tick counter to the same cadence
+(~once a minute; the queue is ≤1024 entries, an O(n) `removeIf` at that cadence is
+noise). Inputs (player chunk position, ingress radius + margin) are available
+main-thread. Per pruned entry: `decrementEnqueued` + clear its `diskReadDone` bit so a
+future declaration re-resolves honestly. No proximity re-ordering (same-position edit
+convergence depends on submission order); re-ordering stays the v3 option.
+
+### 2.2 Client fast-rescan damper — CUT from this release (Fable F2-2)
+
+v2's damper condition ("the awaited set differs from what the previous fast fire left
+behind") is **vacuous**: a fast fire requires ≥95% of the last batch answered, and
+answered positions leave the awaited set — so the set *always* differs at any moment a
+fire is permitted, and the stuck-tail state the damper targeted can never reach a fire
+in the first place (an all-stuck batch is 0% answered). The v2 test pin would have
+passed with the damper deleted.
+
+The real exposure is also narrower than the A-6 round assessed: once the yielded data
+tail exceeds 5% of a declared batch (≥40 positions at full budget), the ≥95% trigger
+fails naturally and the client self-settles to 1 Hz — the 4 Hz window is the warm-sweep
+transient (~a minute per warm rejoin), at ~51 KB/s C2S worst case.
+
+Disposition: **cut from this release** (it is non-load-bearing while the gate is
+default-off), and record the redesigned shape as the **precondition of the default
+flip**: damp on *persistence of a specific unanswered remnant* — if any position has
+been awaited across N consecutive fast fires with zero column-data deliveries in that
+span, hold 1 Hz until data arrives or the fallback cadence heals it. That distinguishes
+stuck-tail (persistent identical remnant) from healthy warm convergence (remnant
+churns), which the v2 formulation did not.
+
+### 2.3 Staleness window note (S-15, unchanged)
+
+A queued payload can carry a pre-edit snapshot for the yield's duration; the dirty path
+clears done-bits and a fresh re-serve sorts after the stale payload, so state
+converges — but the stale-hold window grows from ~1 tick to the yield duration. One
+sentence in the config key's doc; the prune caps how stale a *distant* entry can get.
+
+## 3. Interactions audited (unchanged from v2 where not noted)
+
+- **Backpressure chain**: real but delayed (S-13) — the router's send-queue gate trips
+  at the 1024-entry cap, not the first yielded tick; the interval is the §2.1 memory
+  exposure, bounded by the prune + entry cap at tens of MB per hard-yielding player,
+  transiently.
+- **No redundant work during yield** (S-13): queued entries hold `enqueuedColumns`, so
+  the enqueued rung absorbs re-declarations silently and `skipProbe` suppresses
+  re-serialization — a long yield costs memory and latency, never duplicate serves.
+- **Duplicate-serve grace / probe suppression**: stamps fire only on send success — a
+  yielded tick stamps nothing (S-11).
+- **Bandwidth limiter**: governs whenever the channel is writable (§1.2); its burst
+  bucket refilling during a yield sets the post-yield oscillation amplitude, stated in
+  §1.2.
+- **Batch responses / dirty broadcasts / session config**: bypass `flushSendQueue` on
+  both platforms (S-14), deliberately — and the resulting cadence interaction is
+  §2.2's cut-and-reschedule.
+
+## 4. Config & default
+
+`lodYieldsToVanillaTransport` (boolean, **default FALSE**) in `ServerConfigBase`,
+inherited by `PaperConfig`; no clamp (boolean precedent). Default-off is the project's
+recorded evidence discipline (config-review §8.2; the investigation's "decide only
+after E1/E2 data") — v1's default-true pre-empted the measurement its own parent
+demanded. **E3 is the one-key A/B on the live server**; its success metric is **event
+rates** (moved-wrongly / rejected counts from the tracer) — with the writability gate,
+`yielded=` engages only under real congestion, so it is a valid secondary signal
+again, but the event rate is what decides. The default flips in a later release citing
+that measurement, with §2.2's redesigned damper as a stated precondition.
+
+`JsonConfig`'s malformed-file fallback is whole-file — a broken config silently
+restores all defaults, which with default-off disarms the gate (fail-safe direction).
+Support lines: 26.2/main only; backport on demand.
+
+## 5. Observability
+
+- Per-player diag: `yielded=N` beside `obuf=…/… deferred=…`; `PlayerDiag` grows one
+  record component — compat constructor per house style, golden lines updated (S-7).
+- Service-level cumulative pair (A-7): `yield.ticks_total` +
+  `yield.bytes_withheld_total` in the service diag block, plus a one-shot INFO the
+  first time any player crosses N consecutive fully-yielded ticks — the log archive
+  carries the signal for after-the-fact complaints.
+- `check_soak.py`'s `SERVER_CONFIG_BOOL_KEYS` gains `lodYieldsToVanillaTransport` in
+  the same commit (S-8 — the twice-shipped R4-class allowlist defect).
+- Tracer integration is a dependency, not a present surface (S-10): when the tracer
+  lands, its `lss` block gains `yielded`, **and tracer analysis must partition rows by
+  the boot row's `lodYieldsToVanillaTransport` snapshot** — an armed-gate collection
+  period shifts the envelope `obuf` distribution by design (Fable cross-plan note).
+
+## 6. Tests
+
+- **Tier 1, gate** (template: the existing `FlushSendQueueTest` ceiling pins):
+  - `writable → no yield` (the CI-inertness pin) and `!writable → queue retained,
+    nothing sent, yielded counted only when non-empty, departed sweep still ran, no
+    stamping, pre-flush snapshot published` — the verified v2 invariants re-pinned on
+    the v2.1 condition;
+  - **max-size payload pin, retargeted** (A-1/S-3/F2): a `MAX_SEND_SECTIONS_SIZE`
+    payload sends on a writable channel; with the channel unwritable it waits; it is
+    never permanently blocked (the floor guarantees eventual progress);
+  - starvation floor: after `YIELD_FLOOR_TICKS` of zero sends with a non-empty queue,
+    exactly one payload; floor resets; floor draws from the post-prune head;
+  - ordering pin: ceiling fires before yield; `deferred=` vs `yielded=` attribution;
+    the ceiling path has no floor (F2-7, pinned so the asymmetry is deliberate);
+  - `snapshot()` default-method degrade: a bare-lambda probe (legacy shape) yields
+    never;
+  - no-signal never yields; overload defaults pin (short overloads = yield off, S-9a);
+  - **wiring pin** (S-9b): sibling assertion in `ChannelAccessorContractTest` for the
+    yield pass-through on both platforms.
+- **Tier 1, prune**: outside-radius entries pruned on the flush thread at the cadence
+  tick + `decrementEnqueued` + done-bit cleared; inside-radius/in-grace kept;
+  edit-order convergence unaffected; no prune work on non-cadence ticks.
+- **Tier 1, config/diag**: default-FALSE pin + Paper parity; allowlist entry
+  round-trip; golden diag lines; `PlayerDiag` compat constructor.
+- **Tier 2 / soak**: no changes; pre-release `all` on both platforms proves loopback
+  inertness (later — box busy). An armed loopback soak is now also expected-identical
+  (v2's budget would have throttled it — F2-1; worth one armed smoke run to confirm).
+- **Live gate**: §4's one-key A/B, event rates as the metric.
+
+## 7. Risks & accepted tradeoffs
+
+1. **Yield-to-floor during sustained flight is expected on the live config**: Moonrise's
+   unthrottled sender + elytra-speed churn can hold the channel unwritable for whole
+   flights; LOD runs at the floor until the player slows. That IS "vanilla first", but
+   it is player-visible, and it is why the honest v3 direction — if live data demands
+   it — is a rate *reservation* (M3), not a better clamp.
+2. **Burst-sized oscillation on saturated links** (~560 KiB wire amplitude, set by the
+   limiter's 250 ms bucket): acceptable for v2.1; a per-tick byte cap is the v3
+   smoothing lever.
+3. **Kernel-buffer blindness / no latency claims** (§0).
+4. **Proxy blindness**: best-effort behind Velocity/Bungee — under-yields, never
+   over-yields.
+5. **Memory residency during yields**: bounded by prune + entry cap (§3), transient.
+6. **v18-compat large raw columns near the floor on thin links** (§1.2) — the
+   population is the v0.7.x–v0.8.x install base on slow connections; release notes.
+7. **The benefit is derived, not observed** — which is why the default is off and the
+   first deployment is the experiment.
+
+## 8. Review round record — round 1 (two Opus reviewers: systems + adversarial)
+
+| finding | disposition |
+|---|---|
+| A-1/S-3 threshold below one legal payload, contradicting `MIN_OUTBOUND_BUFFER_CEILING_KB`'s invariant | v2.1 §1.2: writability gate — the invariant holds by construction (a payload is only written to a writable channel); Tier 1 max-payload pin retargeted |
+| A-2/S-2 probe caps at high-water while writable; kernel sndbuf invisible; v1 latency numbers unsupportable | §0 measurement boundary; all ms claims deleted; v2.1 gates on writability rather than a pending threshold |
+| S-1 burst bucket writes ~4×/tick the v1 derivation assumed | §1.2: the burst is the stated oscillation amplitude; no budget pretends otherwise |
+| A-3 "priority" framing overclaims | §0 honest framing; M3 named as the reservation direction |
+| A-4 no liveness property | §1.4 floor (kept in v2.1; §1.3/§0.2 exceptions stated) |
+| A-5 send-queue stale FIFO under long residency | §2.1 prune (v2.1: moved to the owning thread — see F2-3) |
+| A-6 status answers bypass the gate → 4 Hz reachable | §2.2 (v2.1: v2's damper found vacuous — cut, redesigned shape recorded as the default-flip precondition) |
+| S-4/A-10 default-true contradicts recorded decisions | §4 default FALSE |
+| S-5a unbounded Netty buffering is the stronger justification | §0.2 |
+| S-5b/A-9 heap residency unstated | §2.1/§3 |
+| S-6 yield-first ordering retires `deferred=` | §1.3 ceiling-first + pin |
+| S-7 `PlayerDiag` arity | §5 compat ctor |
+| S-8 soak config-key allowlist | §5 same-commit |
+| S-9 overload defaults + wiring pin | §6 |
+| S-10 tracer field described as existing | §5 dependency phrasing |
+| S-11..S-17 verified claims | kept; CI-inertness now provable (§1.2) |
+| A-7 service-level counters | §5 |
+| A-8 proxy topology; LAN ≠ loopback | §1.5 rows |
+
+### 8.1 Review round record — round 2 (one Fable reviewer, full v2 pass, both plans)
+
+| finding | disposition |
+|---|---|
+| F2-1 BLOCKER: v2 budget = unconditional ~64 KiB/tick pacing cap below the shipped bandwidth defaults; S-16 "inertness" pin proved the wrong thing; E3's `yielded=` signal confounded | v2.1 §1.2: budget deleted — gate on `writable` (reviewer's option (b) taken to its fixed point); CI-inertness pin restated as `writable → no yield`; E3 metric = event rates (§4) |
+| F2-2 MAJOR: client damper vacuous (≥95%-answered trigger guarantees the set differs at fire time); exposure self-limits past a 5% tail | §2.2 cut from release; persistence-remnant redesign recorded as default-flip precondition |
+| F2-3 MAJOR: prune raced the main-thread-owned `PriorityQueue` from the processing-thread eviction hook | §2.1 prune runs inside `flushSendQueue`, cadence-gated, owning thread |
+| F2-5 first-payload exemption's `pending == 0` mostly dead during movement; v18 large columns ride the floor | exemption deleted (unneeded under writability gating); v18 consequence stated §1.2/§7.6 |
+| F2-6 floor breaks the §0.2 bound on a dead channel | §0.2 floor exception stated (keep-alive bounds it) |
+| F2-7 floor unreachable under an armed ceiling | §1.3 stated + pinned |
+| F2-8 probe refactor needs one owner; `snapshot()` must be a default method | §1.1; degrade pin in §6 |
+| F2 cross-plan: tracer analysis must partition by the boot-row yield flag | §5 |
+
+## 9. Effort (v2.1)
+
+| piece | estimate |
+|---|---|
+| Probe snapshot (default method + public factory, shared with tracer) + writability gate + floor + ordering (both platforms) | ~half a day |
+| Relevance prune (flush-side) | ~2 hours |
+| Tier 1 suite (§6, incl. contract-test additions + allowlist) | ~half a day |
+| Docs (config key, CLAUDE.md diag guidance, release notes) | ~1 hour |
+| Pre-release soak `all` both platforms (+ one armed loopback smoke) + live one-key A/B | later, box-dependent |
+
+The §2.2 damper is out of this release's scope (default-flip precondition). Ships
+independently of the tracer; the two compose.


### PR DESCRIPTION
Lands the reviewed v0.10.0 program planning set: the mega plan (v1.3), its four source plans (PERF / TRACER / YIELD / XVER), their two parent docs (moved-wrongly investigation, perf profile round), and the living progress doc created at program start per mega plan §6.1.

Docs-only — no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)