### PR TITLE
B0: PERF measurement tooling + A/A control (v0.10.0 stage B0)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,6 +52,8 @@ jobs:
           python3 scripts/check_soak.py --selftest
           python3 scripts/soak_report.py --selftest
           python3 scripts/release_check.py --selftest
+          python3 scripts/check_move_trace.py --selftest
+          python3 scripts/compare_profile.py --selftest
 
       - name: Release-jar safety gate
         run: python3 scripts/release_check.py

--- a/common/src/main/java/dev/vox/lss/common/config/ServerConfigBase.java
+++ b/common/src/main/java/dev/vox/lss/common/config/ServerConfigBase.java
@@ -343,6 +343,29 @@ public abstract class ServerConfigBase extends JsonConfig {
     public long lodStoreMaxBytes() {
         return lodStoreMaxMB <= 0 ? Long.MAX_VALUE : lodStoreMaxMB * 1024L * 1024L;
     }
+
+    /**
+     * One-line effective-config echo, INFO-logged once at service start on both platforms.
+     *
+     * <p>The format is a SCRIPT-CONSUMED CONTRACT (PERF round Phase 0 item 1): the
+     * measurement harnesses ({@code profile_disk_read.sh}, {@code compress_gate.sh},
+     * {@code backfill_profile.sh}) grep {@code "Effective config: "} out of server.log
+     * into each run's meta.json and FAIL the arm when a staged knob does not appear
+     * here — an ignored config key must invalidate the arm, not silently compare two
+     * identical arms (the exact failure mode the 2026-08-06 findings erratum recorded).
+     * Comma-separated {@code key=value} pairs in this fixed order; new perf-sensitive
+     * knobs APPEND (scripts match per-key substrings, so appending is compatible).
+     * Pinned by ConfigValidationTest + the Paper twin.
+     *
+     * @param effectiveReaderThreads the RESOLVED pool size — 0=AUTO already applied via
+     *        {@link #effectiveDiskReaderThreads(boolean)}; echoing the raw key would hide
+     *        exactly the resolution the scripts need to see
+     */
+    public String effectiveConfigEcho(int effectiveReaderThreads) {
+        return "Effective config: useNbtTranscode=" + useNbtTranscode
+                + ", diskReaderThreads=" + effectiveReaderThreads
+                + ", useCompressedColumns=" + useCompressedColumns;
+    }
     /**
      * LOD x-ray masking (docs/planning/antixray-compat-design.md §3). "auto" (default)
      * masks iff an anti-xray engine is detected — Paper's built-in anti-xray config, or the

--- a/common/src/main/java/dev/vox/lss/common/config/ServerConfigBase.java
+++ b/common/src/main/java/dev/vox/lss/common/config/ServerConfigBase.java
@@ -355,16 +355,23 @@ public abstract class ServerConfigBase extends JsonConfig {
      * identical arms (the exact failure mode the 2026-08-06 findings erratum recorded).
      * Comma-separated {@code key=value} pairs in this fixed order; new perf-sensitive
      * knobs APPEND (scripts match per-key substrings, so appending is compatible).
-     * Pinned by ConfigValidationTest + the Paper twin.
+     * Every echoed value is the RESOLVED one — echoing a raw key would hide exactly
+     * the resolution the scripts need to see. Pinned by ConfigValidationTest + the
+     * Paper twin; the call-site wiring (resolved arguments, once per service start)
+     * is source-regex-pinned in ChannelAccessorContractTest.
      *
      * @param effectiveReaderThreads the RESOLVED pool size — 0=AUTO already applied via
-     *        {@link #effectiveDiskReaderThreads(boolean)}; echoing the raw key would hide
-     *        exactly the resolution the scripts need to see
+     *        {@link #effectiveDiskReaderThreads(boolean)}
+     * @param effectiveCompressedColumns the LIVE wire-compression state AFTER the zstd
+     *        native probe, not the config request — a probe-failed server ships raw for
+     *        every session, and echoing the request would let compress_gate.sh compare
+     *        two identical raw arms with both marked valid (B0 review M1)
      */
-    public String effectiveConfigEcho(int effectiveReaderThreads) {
+    public String effectiveConfigEcho(int effectiveReaderThreads,
+                                      boolean effectiveCompressedColumns) {
         return "Effective config: useNbtTranscode=" + useNbtTranscode
                 + ", diskReaderThreads=" + effectiveReaderThreads
-                + ", useCompressedColumns=" + useCompressedColumns;
+                + ", useCompressedColumns=" + effectiveCompressedColumns;
     }
     /**
      * LOD x-ray masking (docs/planning/antixray-compat-design.md §3). "auto" (default)

--- a/docs/planning/perf-round-2026-08-06-implementation-plan.md
+++ b/docs/planning/perf-round-2026-08-06-implementation-plan.md
@@ -70,7 +70,10 @@ None of the phase gates are runnable with the tooling as committed. Build, in on
    confirmed live in the JFR).** Remaining: the same one-liner in `compress_gate.sh`,
    and the effective-config assertion in both. **The echo line is NEW production code**
    (today nothing echoes config at service start): add one INFO line echoing
-   `useNbtTranscode`/`diskReaderThreads`/(later `useSelectiveNbtParse`), treat its
+   `useNbtTranscode`/`diskReaderThreads`/(later `useSelectiveNbtParse`) — *(B0 as
+   shipped: also `useCompressedColumns`, which IS compress_gate's arm variable, so its
+   effective-config assertion has something to match; keys append per the format
+   contract)* — treat its
    format as a script-consumed contract (small format pin), and the run scripts grep it
    into `meta.json` as part of `arm_valid` — an ignored config key must fail the arm,
    not silently compare two identical arms. Note the `profile_disk_read.sh` fix is
@@ -87,7 +90,9 @@ None of the phase gates are runnable with the tooling as committed. Build, in on
    deposits/s = deposits ÷ walk seconds. No committed export carries walk timing today
    (`server.json`'s store block is a cumulative end-of-run dump).
 4. **`analyze_profile_jfr.py`**: (a) a windowing mode for client-less runs
-   (`--window full|t0:t1`) so backfill runs emit `bands.json` + `flame.collapsed`
+   (`--window full|t0:t1` — *B0 as shipped adds `walk`, which reads the walk window
+   backfill_profile.sh parses into meta.json, so the backfill gate needs no manual
+   timestamp plumbing*) so backfill runs emit `bands.json` + `flame.collapsed`
    (wire-slope detection has nothing to detect without a client); (b) per-thread ×
    band × has-LSS-frame counters in `bands.json` — the Phase 3 gate needs
    "IO-Worker samples carrying an LSS frame", which no committed artifact can express;

--- a/docs/planning/v0.10.0-progress.md
+++ b/docs/planning/v0.10.0-progress.md
@@ -120,6 +120,25 @@ the mega plan at the overridden text — never a silent divergence.
   `profile_disk_read.sh` fix, `palette_size_analysis.py`, the dh-support doc) kept
   with a PR-body note — the Phase-0 item's PR text will record it pre-landed here.
 
+- **2026-08-07 (B0 implementation decisions, perf plan Phase 0)**: the effective-config
+  echo (`ServerConfigBase.effectiveConfigEcho`, INFO at service start on both platforms,
+  exact-format-pinned in ConfigValidationTest + the Paper twin) carries
+  `useCompressedColumns` in addition to the plan's `useNbtTranscode`/`diskReaderThreads`
+  — it IS compress_gate.sh's arm variable, and the plan's own point is that an ignored
+  arm key must fail the arm (plan item 1 annotated — the pair). `analyze_profile_jfr.py`
+  gained a third window mode `walk` beyond the plan's `full|t0:t1` (reads the walk
+  window backfill_profile.sh parses into meta.json; plan item 4 annotated).
+  `DISK_PATH_MARKERS` additions include the PROSPECTIVE Phase 3/4 class names
+  (`SelectiveChunkNbtLoader` both packages) with an in-file note that Phase 3's raw-read
+  site must land in a listed class or extend the list in the same PR. Marker counters
+  are any-frame gauges (a sample can count under several markers — deliberately NOT a
+  partition; they are "samples under X" numbers, the bands stay the partition).
+  compare_profile.py's µs/col uses `columns_received` as its denominator and 10 ms as
+  the Java sample period, restating the F5 native-@20ms caveat in its output; backfill
+  arms pool `walk.deposited` as the per-column denominator. Also folded in: the ABBA
+  matrix ordering applies to the legacy vanilla/c2me mode too (the fixed order was the
+  same first-position bias the plan calls out for ref-vs-ref).
+
 ## Measurement ledger
 
 (one entry per A/B session: date, box-state confirmation (§2 exclusivity +

--- a/docs/planning/v0.10.0-progress.md
+++ b/docs/planning/v0.10.0-progress.md
@@ -11,7 +11,7 @@ the mega plan at the overridden text — never a silent divergence.
 |---|---|---|---|---|
 | A1 | Probe-snapshot refactor + move-desync tracer + `LSS_MOVE_TRACE` rig knob + live deploy | MERGED 2026-08-07; live deploy staged, restart pending (expired panel token — see live-deploy log) | #87 | 3-lens Opus round complete, all findings fixed; T1 Fabric+Paper, T2 66/66, T3, validator selftest 34 — all green pre-PR |
 | A2 | Transport yield (default FALSE) + tracer `yielded` field + live deploy of inert build | MERGED 2026-08-07; inert build staged over the A1 jar (same pending restart) | #88 | 3-lens round: 0 correctness MAJORs, 2 discipline MAJORs + 2 pin-gap MAJORs fixed; T1 ~1236+360, T2 66/66, T3, both selftests green |
-| B0 | PERF measurement tooling + A/A control | pending | — | — |
+| B0 | PERF measurement tooling + A/A control | code+review done 2026-08-07; A/A PASS (ledger); PR pending | — | single-Opus review: 4 MAJORs + 11 minors all fixed; selftest 28 + T1 both platforms; backfill smoke reproduces F3; A/A calibrates the burst-band noise floor |
 | B1 | R3 structural-identity memo key | pending | — | — |
 | B2 | R4 CRC32C + interim schema bump (dev-window semantics per R-1) | pending | — | — |
 | B3 | R1 background-read split | pending | — | — |
@@ -139,12 +139,71 @@ the mega plan at the overridden text — never a silent divergence.
   matrix ordering applies to the legacy vanilla/c2me mode too (the fixed order was the
   same first-position bias the plan calls out for ref-vs-ref).
 
+- **2026-08-07 (B0 review round, single Opus reviewer per §6.2 — three lenses in one
+  pass)**: 4 MAJORs + 11 minors, all addressed same-day. **M1**: the echo printed the
+  REQUESTED `useCompressedColumns` before the zstd probe — a natives-less server would
+  run both compress_gate arms raw with both marked valid, the exact failure the echo
+  exists to prevent; fixed by moving the echo below the probe on both platforms and
+  passing the LIVE `wireCompressionLive` (the format pins now set the field OPPOSITE
+  to the passed value to pin argument-not-field). **M2**: an incomplete walk now
+  invalidates the backfill arm (`PROFILE_ALLOW_PARTIAL_WALK=1` opt-out) and
+  compare_profile dies on a pooled backfill arm with 0 completed-walk seconds — and
+  never fabricates a per-column denominator of 1. **M3**: zero-count cuts now report
+  +100% with a rule-of-three lower bound (full elimination — the Phase 3/4 target —
+  no longer renders "n/a"), and a 0/0 tripwire band prints an explicit UNDETECTABLE
+  warning instead of silence. **M4**: backfill_profile.sh gained the same
+  base/change ref-vs-ref arms + ABBA matrix as the serve harness (the phase gates'
+  "ref-vs-ref … + backfill arm" protocol was otherwise only satisfiable as sequential
+  blocks — the 2026-07-29 box-state confound). Minors: pooled per-thread LSS-frame
+  section (N1 — the Phase 3 gate arithmetic compare_profile omitted), window-mode
+  homogeneity check + hibw header (N2), the ±2% column-parity guard computed and
+  flagged (N3), `--selftest` (28 cases) + CI wiring alongside the other checkers —
+  including `check_move_trace.py --selftest`, which A1 had left un-wired (N4),
+  source-regex call-site pins for the echo on both platforms (N5), the StoreBackfill
+  terminal statusLine + "region(s) to process" pins plus a parse_ok guard in the
+  harness (N6), standalone `run base` repoints a stale worktree (N7), odd-reps ABBA
+  warnings + `--skip-reps` for the warm-up-rep protocol (N8), window-spec validation
+  + stale bands.json/flame.collapsed unlink before re-analysis (N9), role-labelled
+  compare rows + alloc-truncation note (N10), and the DISK_PATH_MARKERS comment now
+  records the reviewer's verified-no-op result (311/319/1 samples checked, zero
+  reclassification) instead of a wrong rationale (N11). Post-A/A addition riding the
+  same round: the classifier tripwire is now DISPERSION-AWARE (pooled t-test on
+  per-rep rates) because the A/A proved the save/probe-correlated bands 5-20x
+  over-dispersed vs Poisson — the pooled-Poisson tripwire fired on code-identical
+  arms (see the ledger entry).
+
 ## Measurement ledger
 
 (one entry per A/B session: date, box-state confirmation (§2 exclusivity +
 `pgrep` clean), arms/refs, pooled numbers, verdict)
 
-- none yet.
+- **2026-08-07 — B0 A/A control (Phase 0 item 6's gate for B1) + backfill smoke.
+  Box: exclusive** (`pgrep -af 'lss.multitest|test-server|benchmark.duration'` clean
+  before start; nothing else ran during the runs). **Backfill smoke**
+  (`profile-results/b0-smoke`, 1 rep, 150 s, cps=1000): reproduced the ad-hoc F3
+  numbers exactly — 45,589 deposited in 55 s = 828.9/s (F3: ~830/s); `--window walk`
+  reproduces the F3 gate counters (IO-Worker 407 under ChunkDiskReader, memo 80 on
+  the backfill thread, contentHash 87). **A/A** (`profile-results/b0-aa-control`,
+  3+3 reps × 150 s ABBA no-cache R=256, base=change=357782f via the worktree path;
+  change-rep3 meta honestly flags `worktree_dirty` — script-only edits landed
+  mid-matrix, not compiled into the jar, arms jar-identical): all 6 arms valid,
+  column parity 0.03%, hibw ceiling 555.6 vs 545.2 col/s (1.9%). Steady serve-path
+  metrics are QUIET as required: nbt -2.1% [-11.9,+6.9], serialize -3.7%
+  [-15.9,+7.1], ChunkDiskReader marker -1.0% [-7.5,+5.1], IO-Worker LSS +1.8%
+  [-6.6,+9.6], MemoizedNbtCodec -16.1% [-43.4,+5.9] (wide, small counts — Phase 1's
+  ≥30%-cut gate has headroom but NOT much CI margin at 150 s×3; prefer the backfill
+  arm's larger counts for the memo gate). **Calibration finding: the save/probe-
+  correlated bands are BURSTY window-edge work, 5-20x over-dispersed vs Poisson** —
+  serialize-live per-rep spread 6..164 on code-identical arms (pooled "cut" -135.7%
+  with a CI excluding 0!), nbt-other 31..74, zip -9.4% "significant", and
+  lss_attributed inherits it (-11.5% on identical code → the µs/col metric has an
+  ~±12% noise floor at this protocol). Consequence applied to the tooling: the
+  classifier tripwire now tests per-rep RATES (pooled t-test, T_CRIT table) instead
+  of pooled Poisson counts, and is quiet on this A/A while still firing on a tight
+  10x drift (selftest-pinned with this A/A's real rep data). Consequence for phase
+  gates: read the steady bands/markers and per-thread LSS splits; never gate on
+  serialize-live/nbt-other/zip absolutes or on µs/col deltas under ~12% without more
+  reps. VERDICT: harness sound, A/A PASS, B1 may proceed.
 
 ## Live-deploy log
 

--- a/docs/planning/v0.10.0-progress.md
+++ b/docs/planning/v0.10.0-progress.md
@@ -9,8 +9,8 @@ the mega plan at the overridden text — never a silent divergence.
 
 | stage | content (short) | status | PR | gate verdict / evidence |
 |---|---|---|---|---|
-| A1 | Probe-snapshot refactor + move-desync tracer + `LSS_MOVE_TRACE` rig knob + live deploy | PR #87 in review (2026-08-07) | #87 | 3-lens Opus round complete, all findings fixed; T1 Fabric+Paper, T2 66/66, T3, validator selftest 34 — all green pre-PR |
-| A2 | Transport yield (default FALSE) + tracer `yielded` field + live deploy of inert build | in-progress (2026-08-07) | — | — |
+| A1 | Probe-snapshot refactor + move-desync tracer + `LSS_MOVE_TRACE` rig knob + live deploy | MERGED 2026-08-07; live deploy staged, restart pending (expired panel token — see live-deploy log) | #87 | 3-lens Opus round complete, all findings fixed; T1 Fabric+Paper, T2 66/66, T3, validator selftest 34 — all green pre-PR |
+| A2 | Transport yield (default FALSE) + tracer `yielded` field + live deploy of inert build | MERGED 2026-08-07; inert build staged over the A1 jar (same pending restart) | #88 | 3-lens round: 0 correctness MAJORs, 2 discipline MAJORs + 2 pin-gap MAJORs fixed; T1 ~1236+360, T2 66/66, T3, both selftests green |
 | B0 | PERF measurement tooling + A/A control | pending | — | — |
 | B1 | R3 structural-identity memo key | pending | — | — |
 | B2 | R4 CRC32C + interim schema bump (dev-window semantics per R-1) | pending | — | — |
@@ -145,6 +145,12 @@ the mega plan at the overridden text — never a silent divergence.
   JSONL over SFTP after the first flight). The staged jar is wire/store/config-
   compatible with v0.9.1, so a delayed restart is safe; store expected to open clean.
   Standing note: R-1 deploy hold applies between B2 and C4 merges.
+- **2026-08-07 — A2 inert build STAGED over the A1 jar** (main @ 4c0cc35, PR #88,
+  7,720,695 bytes, size-verified). Same pending restart as above; when the panel
+  token is refreshed one restart brings up the A2-era build (tracer active via the
+  staged marker + yield present-but-unarmed), satisfying R-3's "deploy the inert A2
+  build pre-B2" in one restart. Verification ladder unchanged (TRACER §4.3), plus:
+  `/lsslod diag` must show NO `Yield:` line (unarmed default).
 
 ## Flake/anomaly notes
 

--- a/fabric/src/main/java/dev/vox/lss/networking/server/RequestProcessingService.java
+++ b/fabric/src/main/java/dev/vox/lss/networking/server/RequestProcessingService.java
@@ -135,9 +135,6 @@ public class RequestProcessingService {
         boolean prioritizedReads = config.useBackgroundReadPriority
                 && dev.vox.lss.compat.MoonriseReadCompat.resolveOrNull() != null;
         int readerThreads = config.effectiveDiskReaderThreads(prioritizedReads);
-        // Script-consumed contract: the measurement harnesses assert their staged knobs
-        // against this line (see ServerConfigBase.effectiveConfigEcho).
-        LSSLogger.info(config.effectiveConfigEcho(readerThreads));
         this.diskReader = new ChunkDiskReader(readerThreads,
                 config.useBackgroundReadPriority, config.useNbtTranscode);
         if (config.enableChunkGeneration) {
@@ -180,6 +177,11 @@ public class RequestProcessingService {
             }
         }
         this.wireCompressionLive = wireCompressionLive;
+        // Script-consumed contract: the measurement harnesses assert their staged knobs
+        // against this line (ServerConfigBase.effectiveConfigEcho). Deliberately AFTER
+        // the zstd probe so the compression value echoed is the LIVE state, not the
+        // request (B0 review M1).
+        LSSLogger.info(config.effectiveConfigEcho(readerThreads, wireCompressionLive));
 
         // LOD store (docs/planning/lod-store-implementation-plan.md): memory tier for
         // "memory", memory + SQLite for "full". Attached to BOTH consumers before any

--- a/fabric/src/main/java/dev/vox/lss/networking/server/RequestProcessingService.java
+++ b/fabric/src/main/java/dev/vox/lss/networking/server/RequestProcessingService.java
@@ -134,7 +134,11 @@ public class RequestProcessingService {
         // 8 FOREGROUND readers where the historic default was 5. (v0.9.0 review.)
         boolean prioritizedReads = config.useBackgroundReadPriority
                 && dev.vox.lss.compat.MoonriseReadCompat.resolveOrNull() != null;
-        this.diskReader = new ChunkDiskReader(config.effectiveDiskReaderThreads(prioritizedReads),
+        int readerThreads = config.effectiveDiskReaderThreads(prioritizedReads);
+        // Script-consumed contract: the measurement harnesses assert their staged knobs
+        // against this line (see ServerConfigBase.effectiveConfigEcho).
+        LSSLogger.info(config.effectiveConfigEcho(readerThreads));
+        this.diskReader = new ChunkDiskReader(readerThreads,
                 config.useBackgroundReadPriority, config.useNbtTranscode);
         if (config.enableChunkGeneration) {
             this.generationService = new ChunkGenerationService(config);

--- a/fabric/src/test/java/dev/vox/lss/ChannelAccessorContractTest.java
+++ b/fabric/src/test/java/dev/vox/lss/ChannelAccessorContractTest.java
@@ -132,6 +132,27 @@ class ChannelAccessorContractTest {
     }
 
     @Test
+    void bothPlatformsEchoTheEffectiveConfigWithResolvedArguments() throws Exception {
+        // B0 review N5 (PERF Phase 0 item 1): the echo's FORMAT is exact-pinned in the
+        // config suites, but deleting the call — or passing raw config fields where the
+        // javadoc demands resolved values — reds nothing while every measurement arm
+        // starts failing its arm_valid check (or worse: two identical arms compare as
+        // a valid A/B). Pin the call sites: resolved thread count + the LIVE post-probe
+        // compression state, on both platforms.
+        var echoCall = java.util.regex.Pattern.compile(
+                "LSSLogger\\.info\\(config\\.effectiveConfigEcho\\(readerThreads,\\s*"
+                        + "wireCompressionLive\\)\\)");
+        String fabric = Files.readString(
+                Path.of("src/main/java/dev/vox/lss/networking/server/RequestProcessingService.java"));
+        assertTrue(echoCall.matcher(fabric).find(),
+                "Fabric must echo effectiveConfigEcho(readerThreads, wireCompressionLive)");
+        String paper = Files.readString(
+                Path.of("../paper/src/main/java/dev/vox/lss/paper/PaperRequestProcessingService.java"));
+        assertTrue(echoCall.matcher(paper).find(),
+                "Paper twin must echo effectiveConfigEcho(readerThreads, wireCompressionLive)");
+    }
+
+    @Test
     void bothDiagCallSitesPassTheLiveArmedFlag() throws Exception {
         // Review C-4: a literal `true` (or the wrong field) as yieldDiagLineOrNull's
         // armed argument renders `Yield: armed=true` on every DEFAULT install — the

--- a/fabric/src/test/java/dev/vox/lss/common/store/StoreBackfillTest.java
+++ b/fabric/src/test/java/dev/vox/lss/common/store/StoreBackfillTest.java
@@ -90,6 +90,29 @@ class StoreBackfillTest {
         store.shutdown();
     }
 
+    /** The terminal statusLine is a SCRIPT-CONSUMED CONTRACT (PERF Phase 0 item 3):
+     *  backfill_profile.sh parses "complete|stopped: R regions, D deposited, S skipped,
+     *  E errors, P pauses" out of the "Store backfill " INFO line into meta.json — walk
+     *  seconds + these counters define the Phase 2 deposits/s gate. A rewording fails
+     *  SILENT on the harness side (its sed yields nothing and the run reds as
+     *  parse_ok=false), so it must red HERE first (B0 review N6). */
+    @Test
+    void terminalStatusLineIsAScriptConsumedContract() throws Exception {
+        writeRegion(0, 0, 5, 6);
+        SqliteLodStore store = openStore();
+        var bf = backfill(store, (dim, cx, cz) -> new byte[]{1},
+                new AtomicBoolean(true), new AtomicBoolean(true));
+        assertTrue(bf.start());
+        awaitDone(bf);
+        String status = bf.statusLine();
+        assertTrue(status.matches(
+                "complete: \\d+ regions, \\d+ deposited, \\d+ skipped, \\d+ errors, \\d+ pauses"),
+                "backfill_profile.sh parses this exact shape, got: " + status);
+        assertTrue(status.startsWith("complete: 1 regions, 2 deposited, 0 skipped, 0 errors"),
+                status);
+        store.shutdown();
+    }
+
     @Test
     void skipsColumnsTheStoreAlreadyHas() throws Exception {
         writeRegion(0, 0, 5, 6);
@@ -257,7 +280,10 @@ class StoreBackfillTest {
         String expectedSize = StoreBackfill.formatSize(StoreBackfill.estimateLodBytes(8192));
 
         String uncapped = bf.describePlan(plan, Long.MAX_VALUE);
-        assertTrue(uncapped.contains("2 region(s)"), uncapped);
+        // "region(s) to process" is script-consumed: backfill_profile.sh greps this
+        // wording for the walk-START timestamp (B0 review N6 — the terminal-line pin's
+        // start-side sibling).
+        assertTrue(uncapped.contains("2 region(s) to process"), uncapped);
         assertTrue(uncapped.contains("~" + expectedSize), uncapped);
         assertTrue(uncapped.contains("(uncapped)"), uncapped);
         assertTrue(!uncapped.contains("STOP"), "no stop warning without a cap: " + uncapped);

--- a/fabric/src/test/java/dev/vox/lss/config/ConfigValidationTest.java
+++ b/fabric/src/test/java/dev/vox/lss/config/ConfigValidationTest.java
@@ -609,18 +609,21 @@ class ConfigValidationTest {
     void effectiveConfigEchoIsAScriptConsumedContract() {
         var c = serverConfig();
         c.useNbtTranscode = false;
-        c.useCompressedColumns = true;
+        // The compression value echoed is the EFFECTIVE post-probe state the caller
+        // passes, NOT this field — set the field to the opposite to pin that (a
+        // probe-failed server must echo false so compress_gate reds the arm, B0 M1).
+        c.useCompressedColumns = false;
         assertEquals("Effective config: useNbtTranscode=false, diskReaderThreads=7,"
                         + " useCompressedColumns=true",
-                c.effectiveConfigEcho(7),
+                c.effectiveConfigEcho(7, true),
                 "key order and key=value spelling are what the harnesses grep");
         // The thread count echoed is the RESOLVED one the caller passes (0=AUTO already
         // applied) — the scripts assert the staged explicit value appears verbatim.
         c.useNbtTranscode = true;
-        c.useCompressedColumns = false;
+        c.useCompressedColumns = true;
         assertEquals("Effective config: useNbtTranscode=true, diskReaderThreads=5,"
                         + " useCompressedColumns=false",
-                c.effectiveConfigEcho(5));
+                c.effectiveConfigEcho(5, false));
     }
 
 }

--- a/fabric/src/test/java/dev/vox/lss/config/ConfigValidationTest.java
+++ b/fabric/src/test/java/dev/vox/lss/config/ConfigValidationTest.java
@@ -598,4 +598,29 @@ class ConfigValidationTest {
         assertEquals(400, loaded.lodColumnsPerSecondLimit, "a saved cap must bind back");
     }
 
+    /**
+     * The effective-config echo is a SCRIPT-CONSUMED CONTRACT (PERF Phase 0 item 1):
+     * profile_disk_read.sh / compress_gate.sh / backfill_profile.sh grep
+     * "Effective config: " from server.log and match per-key substrings into each
+     * run's arm_valid. Exact-string pin — a format drift here silently invalidates
+     * every measurement arm, so this must red before any script does.
+     */
+    @Test
+    void effectiveConfigEchoIsAScriptConsumedContract() {
+        var c = serverConfig();
+        c.useNbtTranscode = false;
+        c.useCompressedColumns = true;
+        assertEquals("Effective config: useNbtTranscode=false, diskReaderThreads=7,"
+                        + " useCompressedColumns=true",
+                c.effectiveConfigEcho(7),
+                "key order and key=value spelling are what the harnesses grep");
+        // The thread count echoed is the RESOLVED one the caller passes (0=AUTO already
+        // applied) — the scripts assert the staged explicit value appears verbatim.
+        c.useNbtTranscode = true;
+        c.useCompressedColumns = false;
+        assertEquals("Effective config: useNbtTranscode=true, diskReaderThreads=5,"
+                        + " useCompressedColumns=false",
+                c.effectiveConfigEcho(5));
+    }
+
 }

--- a/paper/src/main/java/dev/vox/lss/paper/PaperRequestProcessingService.java
+++ b/paper/src/main/java/dev/vox/lss/paper/PaperRequestProcessingService.java
@@ -352,8 +352,12 @@ public class PaperRequestProcessingService {
         // AUTO tier applies whenever background priority is on (unlike Fabric, which must
         // also probe for Moonrise). With the flag off the reads run FOREGROUND, so the pool
         // must be sized by the unprioritized tier — see the Fabric twin. (v0.9.0 review.)
+        int readerThreads = config.effectiveDiskReaderThreads(config.useBackgroundReadPriority);
+        // Script-consumed contract: the measurement harnesses assert their staged knobs
+        // against this line (see ServerConfigBase.effectiveConfigEcho).
+        LSSLogger.info(config.effectiveConfigEcho(readerThreads));
         var diskReader = new PaperChunkDiskReader(
-                config.effectiveDiskReaderThreads(config.useBackgroundReadPriority),
+                readerThreads,
                 config.useBackgroundReadPriority,
                 config.useNbtTranscode);
         PaperChunkGenerationService generationService = config.enableChunkGeneration

--- a/paper/src/main/java/dev/vox/lss/paper/PaperRequestProcessingService.java
+++ b/paper/src/main/java/dev/vox/lss/paper/PaperRequestProcessingService.java
@@ -353,9 +353,6 @@ public class PaperRequestProcessingService {
         // also probe for Moonrise). With the flag off the reads run FOREGROUND, so the pool
         // must be sized by the unprioritized tier — see the Fabric twin. (v0.9.0 review.)
         int readerThreads = config.effectiveDiskReaderThreads(config.useBackgroundReadPriority);
-        // Script-consumed contract: the measurement harnesses assert their staged knobs
-        // against this line (see ServerConfigBase.effectiveConfigEcho).
-        LSSLogger.info(config.effectiveConfigEcho(readerThreads));
         var diskReader = new PaperChunkDiskReader(
                 readerThreads,
                 config.useBackgroundReadPriority,
@@ -389,6 +386,11 @@ public class PaperRequestProcessingService {
                 wireCompressionLive = true;
             }
         }
+        // Script-consumed contract: the measurement harnesses assert their staged knobs
+        // against this line (ServerConfigBase.effectiveConfigEcho). Deliberately AFTER
+        // the zstd probe so the compression value echoed is the LIVE state, not the
+        // request (B0 review M1).
+        LSSLogger.info(config.effectiveConfigEcho(readerThreads, wireCompressionLive));
 
         // LOD store: memory tier for "memory", memory + SQLite for "full" — attached to
         // both consumers BEFORE the processor starts / any submit. Environment resolved

--- a/paper/src/test/java/dev/vox/lss/paper/PaperConfigValidationTest.java
+++ b/paper/src/test/java/dev/vox/lss/paper/PaperConfigValidationTest.java
@@ -242,9 +242,11 @@ class PaperConfigValidationTest {
     void effectiveConfigEchoIsAScriptConsumedContract() {
         PaperConfig c = new PaperConfig();
         c.useNbtTranscode = false;
-        c.useCompressedColumns = true;
+        // Field deliberately opposite the passed effective value — the echo must use
+        // the post-probe argument, never the config request (B0 review M1).
+        c.useCompressedColumns = false;
         assertEquals("Effective config: useNbtTranscode=false, diskReaderThreads=7,"
                         + " useCompressedColumns=true",
-                c.effectiveConfigEcho(7));
+                c.effectiveConfigEcho(7, true));
     }
 }

--- a/paper/src/test/java/dev/vox/lss/paper/PaperConfigValidationTest.java
+++ b/paper/src/test/java/dev/vox/lss/paper/PaperConfigValidationTest.java
@@ -232,4 +232,19 @@ class PaperConfigValidationTest {
                     "default for " + f.getName() + " is outside its clamp range");
         }
     }
+
+    /**
+     * Twin of the Fabric pin (ConfigValidationTest): the effective-config echo is a
+     * script-consumed contract (PERF Phase 0 item 1) and must render identically on
+     * Paper — the harnesses grep the same "Effective config: " line on both platforms.
+     */
+    @Test
+    void effectiveConfigEchoIsAScriptConsumedContract() {
+        PaperConfig c = new PaperConfig();
+        c.useNbtTranscode = false;
+        c.useCompressedColumns = true;
+        assertEquals("Effective config: useNbtTranscode=false, diskReaderThreads=7,"
+                        + " useCompressedColumns=true",
+                c.effectiveConfigEcho(7));
+    }
 }

--- a/scripts/analyze_profile_jfr.py
+++ b/scripts/analyze_profile_jfr.py
@@ -13,8 +13,17 @@ window (wire-slope detection reused from analyze_benchmark_compare.py) and repor
 Also writes <run>/flame.collapsed (root;...;leaf count) for flamegraph tooling.
 
 Usage:
-  analyze_profile_jfr.py run <run-dir>          # one run, prints report
-  analyze_profile_jfr.py compare <stamp-dir>    # all runs, per-run reports + jfr-report.md
+  analyze_profile_jfr.py run <run-dir> [--window MODE]        # one run, prints report
+  analyze_profile_jfr.py compare <stamp-dir> [--window MODE]  # all runs + jfr-report.md
+
+--window (PERF Phase 0 item 4a — client-less runs have no wire slope to detect):
+  (absent)   wire-slope active window from cpu.jsonl (the historic default)
+  full       no time filter (window_s = span of sampled events)
+  walk       the backfill walk window from the run's meta.json (backfill_profile.sh)
+  T0:T1      explicit TIME-OF-DAY seconds (the domain JFR startTime parses to)
+
+PROFILE_MARKERS: comma-separated frame-prefix overrides for the per-marker counters
+(default list in DEFAULT_MARKERS — the Phase 1/2/4 gate identifiers).
 
 Stdlib only; shells out to `jfr` (JDK 21+ for `print`; found via PATH or JAVA_HOME).
 """
@@ -189,12 +198,48 @@ DISK_PATH_MARKERS = ("dev.vox.lss.networking.server.NbtSectionSerializer",
                      "dev.vox.lss.networking.server.ChunkDiskReader",
                      "dev.vox.lss.paper.PaperNbtSectionSerializer",
                      "dev.vox.lss.paper.PaperMemoizedNbtCodec",
-                     "dev.vox.lss.paper.PaperChunkDiskReader")
+                     "dev.vox.lss.paper.PaperChunkDiskReader",
+                     # Phase 0 item 4e: the shared reader base (pool lambdas/methods declared
+                     # there render under this name, not the platform subclass) and the
+                     # PROSPECTIVE Phase 3/4 classes — the moved/selective parse must keep
+                     # classifying as disk-path work, or the Phase 3/4 gates break silently.
+                     # Phase 3's raw-read site must land in one of these classes (or be
+                     # added here in the same PR).
+                     "dev.vox.lss.common.processing.AbstractChunkDiskReader",
+                     "dev.vox.lss.networking.server.SelectiveChunkNbtLoader",
+                     "dev.vox.lss.paper.PaperSelectiveChunkNbtLoader")
 DERIVED_BANDS = ("nbt-other", "serialize-live")
 # Bands summed into the "LSS-attributable" aggregate for §0 metric 2 (per-column CPU).
 # serialize-live IS LSS code (probe serves / save-hook) and stays attributed;
 # nbt-other is VANILLA save-pipeline work misattributed before the split — excluded.
 LSS_ATTRIBUTED_BANDS = ("store", "zip", "nbt", "serialize", "serialize-live", "lss-other")
+
+# ---- Per-marker × thread counters (Phase 0 item 4c) ------------------------------------
+#
+# A sample counts under marker M when ANY frame startswith M (whole-stack, so a sample can
+# count under several markers — these are independent "samples under X" gauges, not a
+# partition like the bands). This is exactly the number the Phase 1/2/4 gates read
+# ("samples under MemoizedNbtCodec on the backfill thread"); this round's 76/80/~60 were
+# ad-hoc scripts, the practice this counter ends. MemoizedNbtCodec's Key must stay a
+# NESTED class (frames render as MemoizedNbtCodec$Key...) so the prefix keeps matching
+# through Phase 4's band subtraction. Method-level prefixes (LodStoreService.contentHash)
+# work because frames render as class.method(args).
+DEFAULT_MARKERS = (
+    "dev.vox.lss.networking.server.MemoizedNbtCodec",
+    "dev.vox.lss.paper.PaperMemoizedNbtCodec",
+    "dev.vox.lss.common.store.LodStoreService.contentHash",
+    "dev.vox.lss.networking.server.SelectiveChunkNbtLoader",
+    "dev.vox.lss.paper.PaperSelectiveChunkNbtLoader",
+    "dev.vox.lss.networking.server.ChunkDiskReader",
+    "dev.vox.lss.common.processing.AbstractChunkDiskReader",
+)
+
+
+def marker_list():
+    env = os.environ.get("PROFILE_MARKERS", "").strip()
+    if env:
+        return tuple(m.strip() for m in env.split(",") if m.strip())
+    return DEFAULT_MARKERS
 
 
 def band_for_stack(stack):
@@ -214,13 +259,44 @@ def band_for_stack(stack):
     return "unattributed"
 
 
-def analyze_jfr(run_dir, jfr_tool):
-    jfr_file = os.path.join(run_dir, "server-benchmark.jfr")
+def resolve_window(run_dir, window_spec):
+    """(mode, w0, w1) in TIME-OF-DAY seconds; w0/w1 None = no time filter.
+
+    Phase 0 item 4a: client-less runs (the backfill arm) have no wire slope for the
+    default detection, so `full` disables filtering and `walk` reads the walk window
+    backfill_profile.sh parsed into meta.json. Caveat (pre-existing in the tod domain):
+    a run crossing midnight breaks the comparison — don't profile across midnight.
+    """
+    if window_spec == "full":
+        return "full", None, None
+    if window_spec == "walk":
+        with open(os.path.join(run_dir, "meta.json")) as f:
+            walk = (json.load(f).get("walk") or {})
+        t0, t1 = walk.get("start_tod_s"), walk.get("end_tod_s")
+        if t0 is None or t1 is None:
+            raise RuntimeError("--window walk: meta.json carries no walk window")
+        return "walk", float(t0), float(t1)
+    if window_spec:
+        t0, _, t1 = window_spec.partition(":")
+        return "explicit", float(t0), float(t1)
     t_first, t_last = active_window(run_dir)
-    w0, w1 = epoch_to_timeofday(t_first), epoch_to_timeofday(t_last)
+    return "wire-slope", epoch_to_timeofday(t_first), epoch_to_timeofday(t_last)
+
+
+def analyze_jfr(run_dir, jfr_tool, window_spec=None):
+    jfr_file = os.path.join(run_dir, "server-benchmark.jfr")
+    window_mode, w0, w1 = resolve_window(run_dir, window_spec)
+    seen_tod = [None, None]  # min/max sampled-event tod (window_s for `full` mode)
 
     def in_window(fields):
         t = parse_timeofday(fields.get("startTime", ""))
+        if t is not None:
+            if seen_tod[0] is None or t < seen_tod[0]:
+                seen_tod[0] = t
+            if seen_tod[1] is None or t > seen_tod[1]:
+                seen_tod[1] = t
+        if w0 is None:
+            return True
         return t is not None and w0 <= t <= w1
 
     exec_by_thread = Counter()
@@ -235,6 +311,9 @@ def analyze_jfr(run_dir, jfr_tool):
     file_reads = defaultdict(lambda: [0, 0.0, 0.0])  # path_group -> [count, total_s, max_s]
     thread_cpu = defaultdict(lambda: [0.0, 0])       # group -> [sum user+system, n]
     total_exec = 0
+    markers = marker_list()
+    marker_by_thread = {m: Counter() for m in markers}      # Phase 0 item 4c
+    thread_band_lss = defaultdict(lambda: defaultdict(lambda: [0, 0]))  # item 4b: th->band->[lss, other]
 
     # jdk.NativeMethodSample (compressed-columns plan §5.2, review B2): time inside
     # native methods — Deflater.deflateBytes, zstd-jni — is NOT in jdk.ExecutionSample,
@@ -261,7 +340,13 @@ def analyze_jfr(run_dir, jfr_tool):
             if stack:
                 leaf = shorten(stack[0])
                 self_methods[leaf] += 1
-                bands[band_for_stack(stack)] += 1
+                band = band_for_stack(stack)
+                bands[band] += 1
+                has_lss = any(f.startswith("dev.vox.lss") for f in stack)
+                thread_band_lss[th][band][0 if has_lss else 1] += 1
+                for m in markers:
+                    if any(f.startswith(m) for f in stack):
+                        marker_by_thread[m][th] += 1
                 for fr in stack:
                     if fr.startswith("dev.vox.lss"):
                         self_methods_lss[shorten(fr)] += 1
@@ -299,21 +384,43 @@ def analyze_jfr(run_dir, jfr_tool):
         for stackline, n in collapsed.most_common():
             f.write(f"{stackline} {n}\n")
 
+    if w0 is not None:
+        window_s = round(w1 - w0, 1)
+    elif seen_tod[0] is not None:
+        window_s = round(seen_tod[1] - seen_tod[0], 1)
+    else:
+        window_s = 0.0
+
     # Machine-readable band attribution for the store gates (§0 metric 2 reads
     # lss_attributed_samples × idle-corrected CPU ÷ columns from this file).
+    # Phase 0 additions: thread_band_lss (item 4b — "IO-Worker samples carrying an LSS
+    # frame" is what the Phase 3 gate reads), markers (item 4c — the Phase 1/2/4 gate
+    # counters), alloc_by_class_mb (item 4d — was printed, never persisted; the Phase 4
+    # allocation gate divides these by columns_received).
     band_summary = {
-        "window_s": round(t_last - t_first, 1),
+        "window_mode": window_mode,
+        "window_tod": None if w0 is None else [round(w0, 1), round(w1, 1)],
+        "window_s": window_s,
         "total_exec_samples": total_exec,
         "bands": {name: bands.get(name, 0)
                   for name in [b[0] for b in BANDS] + list(DERIVED_BANDS) + ["unattributed"]},
         "lss_attributed_samples": sum(bands.get(b, 0) for b in LSS_ATTRIBUTED_BANDS),
+        "thread_band_lss": {th: {band: {"lss": v[0], "other": v[1]}
+                                 for band, v in sorted(by_band.items())}
+                            for th, by_band in sorted(thread_band_lss.items())},
+        "markers": {m: {"total": sum(cnt.values()),
+                        "by_thread": dict(cnt.most_common())}
+                    for m, cnt in marker_by_thread.items()},
+        "alloc_total_mb": round(alloc_total / 1e6, 1),
+        "alloc_by_class_mb": {c: round(wt / 1e6, 2)
+                              for c, wt in alloc_by_class.most_common(60)},
     }
     with open(os.path.join(run_dir, "bands.json"), "w") as f:
         json.dump(band_summary, f, indent=1)
 
     return {
         "run": os.path.basename(run_dir),
-        "window_s": round(t_last - t_first, 1),
+        "window_s": window_s,
         "total_exec_samples": total_exec,
         "bands": band_summary,
         "exec_by_thread": exec_by_thread.most_common(14),
@@ -334,8 +441,8 @@ def analyze_jfr(run_dir, jfr_tool):
 
 
 def render_report(r):
-    lines = [f"## {r['run']} — active window {r['window_s']}s, "
-             f"{r['total_exec_samples']} exec samples", ""]
+    lines = [f"## {r['run']} — {r['bands'].get('window_mode', 'wire-slope')} window "
+             f"{r['window_s']}s, {r['total_exec_samples']} exec samples", ""]
 
     lines.append("### CPU share by thread (exec samples)")
     tot = r["total_exec_samples"] or 1
@@ -349,6 +456,14 @@ def render_report(r):
     lines.append(f"- lss_attributed (store+zip+nbt+serialize+serialize-live+lss-other): "
                  f"{r['bands']['lss_attributed_samples']} "
                  f"({100 * r['bands']['lss_attributed_samples'] / tot:.1f}%)")
+    lines.append("")
+
+    lines.append("### Per-marker samples (any-frame prefix match; phase-gate counters)")
+    for m, rec in r["bands"]["markers"].items():
+        if rec["total"] == 0:
+            continue
+        top = ", ".join(f"{th}={n}" for th, n in list(rec["by_thread"].items())[:4])
+        lines.append(f"- {m}: {rec['total']} ({top})")
     lines.append("")
 
     lines.append("### Top self methods (leaf frames)")
@@ -388,13 +503,19 @@ def render_report(r):
 
 
 def main():
-    if len(sys.argv) < 3 or sys.argv[1] not in ("run", "compare"):
+    args = sys.argv[1:]
+    window_spec = None
+    if "--window" in args:
+        i = args.index("--window")
+        window_spec = args[i + 1]
+        del args[i:i + 2]
+    if len(args) < 2 or args[0] not in ("run", "compare"):
         sys.exit(__doc__)
     jfr_tool = find_jfr_tool()
-    if sys.argv[1] == "run":
-        print(render_report(analyze_jfr(sys.argv[2], jfr_tool)))
+    if args[0] == "run":
+        print(render_report(analyze_jfr(args[1], jfr_tool, window_spec)))
         return
-    stamp_dir = sys.argv[2]
+    stamp_dir = args[1]
     out = ["# Disk-read profile — JFR report", ""]
     for run_dir in sorted(glob.glob(os.path.join(stamp_dir, "*-rep*"))):
         if not os.path.isdir(run_dir):
@@ -404,7 +525,12 @@ def main():
             continue
         print(f"[jfr] analyzing {run_dir} ...", file=sys.stderr)
         try:
-            out.append(render_report(analyze_jfr(run_dir, jfr_tool)))
+            # `walk` only resolves for backfill runs (meta.json carries the window);
+            # a serve run in the same stamp dir falls back to its own wire slope.
+            spec = window_spec
+            if spec == "walk" and "backfill-" not in os.path.basename(run_dir):
+                spec = None
+            out.append(render_report(analyze_jfr(run_dir, jfr_tool, spec)))
         except Exception as e:  # noqa: BLE001 — a bad run must not kill the batch
             out.append(f"## {os.path.basename(run_dir)} — ERROR {e!r}")
     report = os.path.join(stamp_dir, "jfr-report.md")

--- a/scripts/analyze_profile_jfr.py
+++ b/scripts/analyze_profile_jfr.py
@@ -199,12 +199,14 @@ DISK_PATH_MARKERS = ("dev.vox.lss.networking.server.NbtSectionSerializer",
                      "dev.vox.lss.paper.PaperNbtSectionSerializer",
                      "dev.vox.lss.paper.PaperMemoizedNbtCodec",
                      "dev.vox.lss.paper.PaperChunkDiskReader",
-                     # Phase 0 item 4e: the shared reader base (pool lambdas/methods declared
-                     # there render under this name, not the platform subclass) and the
-                     # PROSPECTIVE Phase 3/4 classes — the moved/selective parse must keep
-                     # classifying as disk-path work, or the Phase 3/4 gates break silently.
-                     # Phase 3's raw-read site must land in one of these classes (or be
-                     # added here in the same PR).
+                     # Phase 0 item 4e: the shared reader base and the PROSPECTIVE Phase 3/4
+                     # classes — the moved/selective parse must keep classifying as disk-path
+                     # work, or the Phase 3/4 gates break silently. VERIFIED NO-OP on current
+                     # profiles (B0 review): every stack carrying an AbstractChunkDiskReader
+                     # frame in the 2026-08-06 artifacts also carries ChunkDiskReader
+                     # (311/319/1 samples checked across three runs), so the frozen band
+                     # numbers stay comparable. Phase 3's raw-read site must land in one of
+                     # these classes (or be added here in the same PR).
                      "dev.vox.lss.common.processing.AbstractChunkDiskReader",
                      "dev.vox.lss.networking.server.SelectiveChunkNbtLoader",
                      "dev.vox.lss.paper.PaperSelectiveChunkNbtLoader")
@@ -277,14 +279,29 @@ def resolve_window(run_dir, window_spec):
             raise RuntimeError("--window walk: meta.json carries no walk window")
         return "walk", float(t0), float(t1)
     if window_spec:
-        t0, _, t1 = window_spec.partition(":")
-        return "explicit", float(t0), float(t1)
+        t0, sep, t1 = window_spec.partition(":")
+        try:
+            if not sep:
+                raise ValueError
+            return "explicit", float(t0), float(t1)
+        except ValueError:
+            raise RuntimeError(
+                f"bad --window '{window_spec}' — legal: full | walk | T0:T1 "
+                f"(time-of-day seconds)") from None
     t_first, t_last = active_window(run_dir)
     return "wire-slope", epoch_to_timeofday(t_first), epoch_to_timeofday(t_last)
 
 
 def analyze_jfr(run_dir, jfr_tool, window_spec=None):
     jfr_file = os.path.join(run_dir, "server-benchmark.jfr")
+    # Stale-artifact guard (the discipline the shell harnesses follow): a failed
+    # re-analysis must leave MISSING outputs, never a previous pass's bands.json for
+    # compare_profile to pool unknowingly.
+    for stale in ("bands.json", "flame.collapsed"):
+        try:
+            os.unlink(os.path.join(run_dir, stale))
+        except FileNotFoundError:
+            pass
     window_mode, w0, w1 = resolve_window(run_dir, window_spec)
     seen_tod = [None, None]  # min/max sampled-event tod (window_s for `full` mode)
 
@@ -507,6 +524,8 @@ def main():
     window_spec = None
     if "--window" in args:
         i = args.index("--window")
+        if i + 1 >= len(args):
+            sys.exit("--window needs a value: full | walk | T0:T1")
         window_spec = args[i + 1]
         del args[i:i + 2]
     if len(args) < 2 or args[0] not in ("run", "compare"):

--- a/scripts/backfill_profile.sh
+++ b/scripts/backfill_profile.sh
@@ -1,0 +1,238 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Store-backfill profile harness (PERF Phase 0 item 3 — the committed form of the round's
+# ad-hoc F3 runner). SERVER-ONLY: no client joins; the measured work is the background
+# region walk (StoreBackfill) depositing the pre-built base world into a FRESH store.
+#
+# Each rep: reset world from benchmark-worlds/base (deleting any store DB so the walk has
+# regions to process), stage lodStore=full + backfill config, run :fabric:runBenchmarkServer
+# for <duration> (the wired server JFR + the external 1 Hz sampler record it), then parse
+# the walk's start/terminal log lines into meta.json — walk seconds + deposit counts are
+# what defines the Phase 2 gate's deposits/s. There is no committed export of walk timing
+# anywhere else: server.json's store block is a cumulative end-of-run dump.
+#
+# Analyze the walk window (no client -> no wire slope for the default window detection):
+#   analyze_profile_jfr.py run <run-dir> --window walk     # reads this meta.json
+#
+# Usage:
+#   backfill_profile.sh run <rep> [duration]     # one rep (duration default 300 s)
+#   backfill_profile.sh matrix <reps> [duration]
+#
+# Knobs:
+#   PROFILE_BACKFILL_CPS   lodStoreBackfillColumnsPerSecond (default 1000 = clamp max, the
+#                          F3 setting — the walk should be tooling-bound, not pace-bound)
+#   PROFILE_NBT_TRANSCODE  useNbtTranscode (default true)
+#   PROFILE_LOD_R          lodDistanceChunks (default 256; irrelevant to the walk itself)
+#   OUT_ROOT, RUN_STAMP    results root / stamp dir (default profile-results/<stamp>)
+#
+# Results: profile-results/<stamp>/backfill-rep<N>/{server.json,server-benchmark.jfr,
+#          cpu.jsonl,orchestrator.log,server.log,meta.json}
+
+MAIN_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+OUT_ROOT="${OUT_ROOT:-$MAIN_ROOT/profile-results}"
+SERVER_RUN_DIR="$MAIN_ROOT/fabric/build/run/benchmark-server"
+PROJECT_ROOT="$MAIN_ROOT"   # for mc-run.sh
+LOG_PREFIX="backfill-profile"
+
+source "$MAIN_ROOT/scripts/lib/mc-run.sh"
+trap mc_cleanup EXIT
+
+log() { echo "[backfill-profile] $*"; }
+die() { echo "[backfill-profile] ERROR: $*" >&2; exit 1; }
+
+stage_server_config() { # <path>
+    cat > "$1" <<EOF
+{
+  "enabled": true,
+  "lodDistanceChunks": ${PROFILE_LOD_R:-256},
+  "diskReaderThreads": 5,
+  "enableChunkGeneration": false,
+  "missMemoTtlSeconds": 30,
+  "useBackgroundReadPriority": true,
+  "useNbtTranscode": ${PROFILE_NBT_TRANSCODE:-true},
+  "lodStore": "full",
+  "lodStoreBackfill": true,
+  "lodStoreBackfillColumnsPerSecond": ${PROFILE_BACKFILL_CPS:-1000}
+}
+EOF
+}
+
+# "[HH:MM:SS] ..." log-line prefix -> time-of-day seconds (matches the analyzer's
+# JFR startTime domain, so meta's walk window feeds --window walk directly).
+tod_of_line() { # <line> -> seconds or ""
+    sed -n 's/^\[\([0-9][0-9]\):\([0-9][0-9]\):\([0-9][0-9]\)\].*/\1 \2 \3/p' <<< "$1" \
+        | awk '{print $1*3600 + $2*60 + $3}'
+}
+
+cmd_run() {
+    local rep="${1:?rep}" duration="${2:-300}"
+
+    [[ -d "$MAIN_ROOT/benchmark-worlds/base/world" ]] || die "no base world — build one first (benchmark.sh fresh)"
+    if ss -ltnH 'sport = :25565' 2>/dev/null | grep -q .; then
+        die "port 25565 is in use — refusing to start (soak/benchmark conflict guard)"
+    fi
+
+    RUN_OUT="$OUT_ROOT/$RUN_STAMP/backfill-rep${rep}"
+    mkdir -p "$RUN_OUT"
+    log "=== RUN backfill rep$rep (duration=${duration}s, cps=${PROFILE_BACKFILL_CPS:-1000}) ==="
+
+    # Fresh world from base, FRESH store (the walk only visits unmarked regions — a
+    # leftover store DB means 0 regions to process and a vacuous run).
+    rm -rf "$SERVER_RUN_DIR/world"
+    cp -r "$MAIN_ROOT/benchmark-worlds/base/world" "$SERVER_RUN_DIR/world"
+    rm -rf "$SERVER_RUN_DIR/world/lss-lod"
+
+    mkdir -p "$SERVER_RUN_DIR/config"
+    stage_server_config "$SERVER_RUN_DIR/config/lss-server-config.json"
+
+    # pause-when-empty-seconds=-1 is load-bearing: no client EVER joins, and a paused
+    # server neither ticks the benchmark duration counter nor advances the walk.
+    cat > "$SERVER_RUN_DIR/server.properties" <<'PROPS'
+online-mode=false
+level-seed=benchmark-seed-42
+spawn-protection=0
+max-tick-time=-1
+pause-when-empty-seconds=-1
+difficulty=peaceful
+PROPS
+    echo "eula=true" > "$SERVER_RUN_DIR/eula.txt"
+
+    # Stale-artifact guard: a crashed run must yield MISSING files, not the last run's.
+    rm -f "$SERVER_RUN_DIR/benchmark-results/server.json" \
+          "$SERVER_RUN_DIR/server-benchmark.jfr" \
+          "$SERVER_RUN_DIR/logs/latest.log"
+
+    log "Building mod..."
+    (cd "$MAIN_ROOT" && ./gradlew :fabric:build -x test -x runGameTest -x runClientGameTest --quiet)
+
+    "$MAIN_ROOT/scripts/lib/proc_sampler.sh" "$RUN_OUT/cpu.jsonl" $((duration + 300)) &
+    local sampler_pid=$!
+
+    local rc=0
+    mc_start_server "$RUN_OUT/orchestrator.log" :fabric:runBenchmarkServer \
+        -Pbenchmark.duration="$duration"
+    if ! mc_wait_server_ready "$SERVER_RUN_DIR/logs/latest.log" "$RUN_OUT/orchestrator.log" 180; then
+        rc=1
+    else
+        # Wait for the auto-shutdown tick counter, with a hard deadline (the benchmark
+        # server only halts on tick count; a stalled JVM must not hang the matrix).
+        local total_timeout=$((duration + 180)) elapsed=0
+        while kill -0 "$SERVER_PID" 2>/dev/null; do
+            if [[ $elapsed -ge $total_timeout ]]; then
+                log "deadline exceeded (${total_timeout}s) — killing stalled server"
+                kill "$SERVER_PID" 2>/dev/null || true
+                rc=1
+                break
+            fi
+            sleep 1
+            elapsed=$((elapsed + 1))
+        done
+        wait "$SERVER_PID" 2>/dev/null || true
+        SERVER_PID=""
+    fi
+
+    kill "$sampler_pid" 2>/dev/null || true
+    wait "$sampler_pid" 2>/dev/null || true
+
+    [[ -f "$SERVER_RUN_DIR/benchmark-results/server.json" ]] \
+        && cp "$SERVER_RUN_DIR/benchmark-results/server.json" "$RUN_OUT/"
+    [[ -f "$SERVER_RUN_DIR/server-benchmark.jfr" ]] \
+        && cp "$SERVER_RUN_DIR/server-benchmark.jfr" "$RUN_OUT/"
+    [[ -f "$SERVER_RUN_DIR/logs/latest.log" ]] \
+        && cp "$SERVER_RUN_DIR/logs/latest.log" "$RUN_OUT/server.log"
+
+    # Walk timing + deposit counts (Phase 0 item 3): parsed from StoreBackfill's start
+    # line ("Store backfill: N region(s) to process, estimated ~...") and terminal line
+    # ("Store backfill complete|stopped: R regions, D deposited, S skipped, E errors,
+    # P pauses"). Times are TIME-OF-DAY seconds — the domain --window walk consumes.
+    local start_line end_line
+    start_line="$(grep -m1 'Store backfill: .* region(s) to process' "$RUN_OUT/server.log" 2>/dev/null || true)"
+    end_line="$(grep -m1 -E 'Store backfill (complete|stopped):' "$RUN_OUT/server.log" 2>/dev/null || true)"
+    local walk_complete=false walk_start="null" walk_end="null" walk_seconds="null"
+    local regions=0 deposited=0 skipped=0 errors=0 pauses=0 deposits_per_s="null"
+    if [[ -n "$start_line" ]]; then
+        walk_start="$(tod_of_line "$start_line")"
+        [[ -n "$walk_start" ]] || walk_start="null"
+    fi
+    if [[ -n "$end_line" ]]; then
+        walk_end="$(tod_of_line "$end_line")"
+        [[ -n "$walk_end" ]] || walk_end="null"
+        read -r regions deposited skipped errors pauses < <(sed -n \
+            's/.*: \([0-9]*\) regions, \([0-9]*\) deposited, \([0-9]*\) skipped, \([0-9]*\) errors, \([0-9]*\) pauses.*/\1 \2 \3 \4 \5/p' \
+            <<< "$end_line") || true
+        [[ "$end_line" == *"Store backfill complete:"* ]] && walk_complete=true
+        if [[ "$walk_start" != "null" && "$walk_end" != "null" && "$walk_end" -gt "$walk_start" ]]; then
+            walk_seconds=$((walk_end - walk_start))
+            deposits_per_s="$(awk -v d="$deposited" -v s="$walk_seconds" 'BEGIN{printf "%.1f", d/s}')"
+        fi
+    fi
+
+    # Effective-config assertion (Phase 0 item 1) — same contract as the serve harness.
+    local echo_line
+    echo_line="$(grep -o 'Effective config: .*' "$RUN_OUT/server.log" 2>/dev/null | tail -1 || true)"
+    local arm_valid=true
+    [[ "$echo_line" == *"useNbtTranscode=${PROFILE_NBT_TRANSCODE:-true}"* ]] || arm_valid=false
+    [[ "$echo_line" == *"diskReaderThreads=5"* ]] || arm_valid=false
+    # A walk that never STARTED is a vacuous run (leftover store marks, staging bug).
+    [[ -n "$start_line" ]] || arm_valid=false
+
+    cat > "$RUN_OUT/meta.json" <<EOF
+{
+  "arm": "backfill",
+  "rep": $rep,
+  "ref": "$(git -C "$MAIN_ROOT" rev-parse --short HEAD)",
+  "duration_s": $duration,
+  "backfill_cps": ${PROFILE_BACKFILL_CPS:-1000},
+  "nbt_transcode": ${PROFILE_NBT_TRANSCODE:-true},
+  "config_echo": "$echo_line",
+  "walk": {
+    "complete": $walk_complete,
+    "start_tod_s": $walk_start,
+    "end_tod_s": $walk_end,
+    "walk_seconds": $walk_seconds,
+    "regions": ${regions:-0},
+    "deposited": ${deposited:-0},
+    "skipped": ${skipped:-0},
+    "errors": ${errors:-0},
+    "pauses": ${pauses:-0},
+    "deposits_per_s": $deposits_per_s
+  },
+  "arm_valid": $arm_valid,
+  "orchestrator_rc": $rc,
+  "finished": "$(date -Is)"
+}
+EOF
+    if [[ $rc -ne 0 ]]; then
+        log "run backfill rep$rep FAILED (rc=$rc) — see $RUN_OUT/orchestrator.log"
+        return 1
+    fi
+    if [[ "$arm_valid" != "true" ]]; then
+        log "run backfill rep$rep INVALID: echo='${echo_line:-<missing>}' walk_started=$([[ -n "$start_line" ]] && echo yes || echo no)"
+        return 1
+    fi
+    if [[ "$walk_complete" != "true" ]]; then
+        log "NOTE: walk did not complete within ${duration}s — deposits/s unavailable; raise the duration"
+    fi
+    log "run backfill rep$rep done -> $RUN_OUT (deposited=$deposited in ${walk_seconds}s, ${deposits_per_s}/s)"
+}
+
+cmd_matrix() {
+    local reps="${1:?reps}" duration="${2:-300}"
+    log "Matrix: ${reps} backfill reps, duration=${duration}s -> $OUT_ROOT/$RUN_STAMP"
+    for rep in $(seq 1 "$reps"); do
+        cmd_run "$rep" "$duration"
+        sleep 15
+    done
+    log "Matrix complete: $OUT_ROOT/$RUN_STAMP"
+}
+
+CMD="${1:-}"
+shift || true
+RUN_STAMP="${RUN_STAMP:-$(date +%Y%m%d-%H%M%S)}"
+
+case "$CMD" in
+    run)    cmd_run "$@" ;;
+    matrix) cmd_matrix "$@" ;;
+    *) sed -n '3,30p' "$0"; exit 1 ;;
+esac

--- a/scripts/backfill_profile.sh
+++ b/scripts/backfill_profile.sh
@@ -12,28 +12,43 @@ set -euo pipefail
 # what defines the Phase 2 gate's deposits/s. There is no committed export of walk timing
 # anywhere else: server.json's store block is a cumulative end-of-run dump.
 #
+# Arms (matching profile_disk_read.sh — the phase gates say "ref-vs-ref … + backfill arm",
+# which means the backfill A/B must interleave, not run as sequential blocks):
+#   backfill        this tree (default when PROFILE_BASE_REF is unset)
+#   base | change   ref-vs-ref behind PROFILE_BASE_REF: `change` runs THIS tree, `base` a
+#                   detached worktree at the ref (worktree + prebuild + rsync'd world).
+#                   The matrix interleaves base/change ABBA across reps.
+#
+# An INCOMPLETE walk invalidates the arm (deposits/s undefined) — raise the duration.
+# PROFILE_ALLOW_PARTIAL_WALK=1 keeps such a run pool-able if a partial profile is ever
+# deliberately wanted (compare_profile.py still refuses an arm with 0 completed seconds).
+#
 # Analyze the walk window (no client -> no wire slope for the default window detection):
 #   analyze_profile_jfr.py run <run-dir> --window walk     # reads this meta.json
 #
 # Usage:
-#   backfill_profile.sh run <rep> [duration]     # one rep (duration default 300 s)
-#   backfill_profile.sh matrix <reps> [duration]
+#   backfill_profile.sh run <arm> <rep> [duration]   # one rep (duration default 300 s)
+#   backfill_profile.sh matrix <reps> [duration]     # ABBA when PROFILE_BASE_REF is set
+#   backfill_profile.sh setup                        # ref mode: worktree + prebuild
 #
 # Knobs:
 #   PROFILE_BACKFILL_CPS   lodStoreBackfillColumnsPerSecond (default 1000 = clamp max, the
 #                          F3 setting — the walk should be tooling-bound, not pace-bound)
 #   PROFILE_NBT_TRANSCODE  useNbtTranscode (default true)
 #   PROFILE_LOD_R          lodDistanceChunks (default 256; irrelevant to the walk itself)
+#   PROFILE_BASE_REF/_WT   ref-vs-ref base ref + worktree path (see profile_disk_read.sh)
 #   OUT_ROOT, RUN_STAMP    results root / stamp dir (default profile-results/<stamp>)
 #
-# Results: profile-results/<stamp>/backfill-rep<N>/{server.json,server-benchmark.jfr,
+# Results: profile-results/<stamp>/<arm>-rep<N>/{server.json,server-benchmark.jfr,
 #          cpu.jsonl,orchestrator.log,server.log,meta.json}
 
 MAIN_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 OUT_ROOT="${OUT_ROOT:-$MAIN_ROOT/profile-results}"
-SERVER_RUN_DIR="$MAIN_ROOT/fabric/build/run/benchmark-server"
-PROJECT_ROOT="$MAIN_ROOT"   # for mc-run.sh
+PROJECT_ROOT="$MAIN_ROOT"   # for mc-run.sh (re-pointed per arm in cmd_run)
 LOG_PREFIX="backfill-profile"
+
+BASE_REF="${PROFILE_BASE_REF:-}"
+BASE_WT="${PROFILE_BASE_WT:-$(dirname "$MAIN_ROOT")/lss-profile-base}"
 
 source "$MAIN_ROOT/scripts/lib/mc-run.sh"
 trap mc_cleanup EXIT
@@ -58,6 +73,39 @@ stage_server_config() { # <path>
 EOF
 }
 
+root_for_arm() {
+    case "$1" in
+        base) echo "$BASE_WT" ;;
+        *)    echo "$MAIN_ROOT" ;;
+    esac
+}
+
+prebuild() { # <root>
+    log "Prebuilding $1 ..."
+    (cd "$1" && ./gradlew :fabric:build -x test -x runGameTest -x runClientGameTest --quiet)
+}
+
+ensure_base_worktree() {
+    [[ -n "$BASE_REF" ]] || die "arm base/change needs PROFILE_BASE_REF=<git-ref>"
+    local want
+    want="$(git -C "$MAIN_ROOT" rev-parse "${BASE_REF}^{commit}")" \
+        || die "PROFILE_BASE_REF '$BASE_REF' does not resolve"
+    if [[ ! -d "$BASE_WT" ]]; then
+        log "Creating worktree $BASE_WT @ $BASE_REF"
+        git -C "$MAIN_ROOT" worktree add --detach "$BASE_WT" "$BASE_REF"
+    elif [[ "$(git -C "$BASE_WT" rev-parse HEAD)" != "$want" ]]; then
+        log "Repointing worktree $BASE_WT -> $BASE_REF"
+        git -C "$BASE_WT" checkout --detach "$want"
+    fi
+}
+
+cmd_setup() {
+    ensure_base_worktree
+    prebuild "$MAIN_ROOT"
+    prebuild "$BASE_WT"
+    log "Setup complete: base=$BASE_WT@$BASE_REF change=$MAIN_ROOT (working tree)"
+}
+
 # "[HH:MM:SS] ..." log-line prefix -> time-of-day seconds (matches the analyzer's
 # JFR startTime domain, so meta's walk window feeds --window walk directly).
 tod_of_line() { # <line> -> seconds or ""
@@ -66,29 +114,41 @@ tod_of_line() { # <line> -> seconds or ""
 }
 
 cmd_run() {
-    local rep="${1:?rep}" duration="${2:-300}"
+    local arm="${1:?arm (backfill | base | change)}" rep="${2:?rep}" duration="${3:-300}"
+    local root="$MAIN_ROOT"
+    case "$arm" in
+        backfill) ;;
+        base|change)
+            [[ -n "$BASE_REF" ]] || die "arm '$arm' needs PROFILE_BASE_REF (ref-vs-ref mode)"
+            root="$(root_for_arm "$arm")"
+            [[ "$arm" == "change" || -d "$root" ]] || die "worktree $root missing — run setup first"
+            ;;
+        *) die "unknown arm '$arm' (want backfill | base | change)" ;;
+    esac
+    local server_run_dir="$root/fabric/build/run/benchmark-server"
 
     [[ -d "$MAIN_ROOT/benchmark-worlds/base/world" ]] || die "no base world — build one first (benchmark.sh fresh)"
     if ss -ltnH 'sport = :25565' 2>/dev/null | grep -q .; then
         die "port 25565 is in use — refusing to start (soak/benchmark conflict guard)"
     fi
 
-    RUN_OUT="$OUT_ROOT/$RUN_STAMP/backfill-rep${rep}"
+    RUN_OUT="$OUT_ROOT/$RUN_STAMP/${arm}-rep${rep}"
     mkdir -p "$RUN_OUT"
-    log "=== RUN backfill rep$rep (duration=${duration}s, cps=${PROFILE_BACKFILL_CPS:-1000}) ==="
+    log "=== RUN $arm rep$rep (root=$root, duration=${duration}s, cps=${PROFILE_BACKFILL_CPS:-1000}) ==="
 
     # Fresh world from base, FRESH store (the walk only visits unmarked regions — a
     # leftover store DB means 0 regions to process and a vacuous run).
-    rm -rf "$SERVER_RUN_DIR/world"
-    cp -r "$MAIN_ROOT/benchmark-worlds/base/world" "$SERVER_RUN_DIR/world"
-    rm -rf "$SERVER_RUN_DIR/world/lss-lod"
+    rm -rf "$server_run_dir/world"
+    mkdir -p "$server_run_dir"
+    cp -r "$MAIN_ROOT/benchmark-worlds/base/world" "$server_run_dir/world"
+    rm -rf "$server_run_dir/world/lss-lod"
 
-    mkdir -p "$SERVER_RUN_DIR/config"
-    stage_server_config "$SERVER_RUN_DIR/config/lss-server-config.json"
+    mkdir -p "$server_run_dir/config"
+    stage_server_config "$server_run_dir/config/lss-server-config.json"
 
     # pause-when-empty-seconds=-1 is load-bearing: no client EVER joins, and a paused
     # server neither ticks the benchmark duration counter nor advances the walk.
-    cat > "$SERVER_RUN_DIR/server.properties" <<'PROPS'
+    cat > "$server_run_dir/server.properties" <<'PROPS'
 online-mode=false
 level-seed=benchmark-seed-42
 spawn-protection=0
@@ -96,23 +156,25 @@ max-tick-time=-1
 pause-when-empty-seconds=-1
 difficulty=peaceful
 PROPS
-    echo "eula=true" > "$SERVER_RUN_DIR/eula.txt"
+    echo "eula=true" > "$server_run_dir/eula.txt"
 
     # Stale-artifact guard: a crashed run must yield MISSING files, not the last run's.
-    rm -f "$SERVER_RUN_DIR/benchmark-results/server.json" \
-          "$SERVER_RUN_DIR/server-benchmark.jfr" \
-          "$SERVER_RUN_DIR/logs/latest.log"
+    rm -f "$server_run_dir/benchmark-results/server.json" \
+          "$server_run_dir/server-benchmark.jfr" \
+          "$server_run_dir/logs/latest.log"
 
-    log "Building mod..."
-    (cd "$MAIN_ROOT" && ./gradlew :fabric:build -x test -x runGameTest -x runClientGameTest --quiet)
+    log "Building mod ($root)..."
+    (cd "$root" && ./gradlew :fabric:build -x test -x runGameTest -x runClientGameTest --quiet)
 
     "$MAIN_ROOT/scripts/lib/proc_sampler.sh" "$RUN_OUT/cpu.jsonl" $((duration + 300)) &
     local sampler_pid=$!
 
     local rc=0
+    PROJECT_ROOT="$root"   # mc_start_server cd's here for the gradle invocation
     mc_start_server "$RUN_OUT/orchestrator.log" :fabric:runBenchmarkServer \
         -Pbenchmark.duration="$duration"
-    if ! mc_wait_server_ready "$SERVER_RUN_DIR/logs/latest.log" "$RUN_OUT/orchestrator.log" 180; then
+    PROJECT_ROOT="$MAIN_ROOT"
+    if ! mc_wait_server_ready "$server_run_dir/logs/latest.log" "$RUN_OUT/orchestrator.log" 180; then
         rc=1
     else
         # Wait for the auto-shutdown tick counter, with a hard deadline (the benchmark
@@ -135,22 +197,25 @@ PROPS
     kill "$sampler_pid" 2>/dev/null || true
     wait "$sampler_pid" 2>/dev/null || true
 
-    [[ -f "$SERVER_RUN_DIR/benchmark-results/server.json" ]] \
-        && cp "$SERVER_RUN_DIR/benchmark-results/server.json" "$RUN_OUT/"
-    [[ -f "$SERVER_RUN_DIR/server-benchmark.jfr" ]] \
-        && cp "$SERVER_RUN_DIR/server-benchmark.jfr" "$RUN_OUT/"
-    [[ -f "$SERVER_RUN_DIR/logs/latest.log" ]] \
-        && cp "$SERVER_RUN_DIR/logs/latest.log" "$RUN_OUT/server.log"
+    [[ -f "$server_run_dir/benchmark-results/server.json" ]] \
+        && cp "$server_run_dir/benchmark-results/server.json" "$RUN_OUT/"
+    [[ -f "$server_run_dir/server-benchmark.jfr" ]] \
+        && cp "$server_run_dir/server-benchmark.jfr" "$RUN_OUT/"
+    [[ -f "$server_run_dir/logs/latest.log" ]] \
+        && cp "$server_run_dir/logs/latest.log" "$RUN_OUT/server.log"
 
     # Walk timing + deposit counts (Phase 0 item 3): parsed from StoreBackfill's start
     # line ("Store backfill: N region(s) to process, estimated ~...") and terminal line
     # ("Store backfill complete|stopped: R regions, D deposited, S skipped, E errors,
     # P pauses"). Times are TIME-OF-DAY seconds — the domain --window walk consumes.
+    # The low-disk and shutdown terminal variants have different shapes and correctly
+    # fall out as walk_complete=false.
     local start_line end_line
     start_line="$(grep -m1 'Store backfill: .* region(s) to process' "$RUN_OUT/server.log" 2>/dev/null || true)"
     end_line="$(grep -m1 -E 'Store backfill (complete|stopped):' "$RUN_OUT/server.log" 2>/dev/null || true)"
     local walk_complete=false walk_start="null" walk_end="null" walk_seconds="null"
-    local regions=0 deposited=0 skipped=0 errors=0 pauses=0 deposits_per_s="null"
+    local regions="" deposited="" skipped="" errors="" pauses="" deposits_per_s="null"
+    local parse_ok=true
     if [[ -n "$start_line" ]]; then
         walk_start="$(tod_of_line "$start_line")"
         [[ -n "$walk_start" ]] || walk_start="null"
@@ -161,8 +226,12 @@ PROPS
         read -r regions deposited skipped errors pauses < <(sed -n \
             's/.*: \([0-9]*\) regions, \([0-9]*\) deposited, \([0-9]*\) skipped, \([0-9]*\) errors, \([0-9]*\) pauses.*/\1 \2 \3 \4 \5/p' \
             <<< "$end_line") || true
-        [[ "$end_line" == *"Store backfill complete:"* ]] && walk_complete=true
-        if [[ "$walk_start" != "null" && "$walk_end" != "null" && "$walk_end" -gt "$walk_start" ]]; then
+        # Terminal line matched but the counters didn't parse: the statusLine format
+        # drifted — the run must red loudly, never record deposits_per_s = 0 (N6).
+        [[ -n "${deposited:-}" ]] || parse_ok=false
+        [[ "$end_line" == *"Store backfill complete:"* && "$parse_ok" == "true" ]] && walk_complete=true
+        if [[ "$walk_complete" == "true" && "$walk_start" != "null" && "$walk_end" != "null" \
+              && "$walk_end" -gt "$walk_start" ]]; then
             walk_seconds=$((walk_end - walk_start))
             deposits_per_s="$(awk -v d="$deposited" -v s="$walk_seconds" 'BEGIN{printf "%.1f", d/s}')"
         fi
@@ -174,14 +243,21 @@ PROPS
     local arm_valid=true
     [[ "$echo_line" == *"useNbtTranscode=${PROFILE_NBT_TRANSCODE:-true}"* ]] || arm_valid=false
     [[ "$echo_line" == *"diskReaderThreads=5"* ]] || arm_valid=false
-    # A walk that never STARTED is a vacuous run (leftover store marks, staging bug).
+    # A walk that never STARTED is a vacuous run (leftover store marks, staging bug),
+    # and an INCOMPLETE walk has no defined deposits/s (M2) — both invalidate the arm.
     [[ -n "$start_line" ]] || arm_valid=false
+    [[ "$parse_ok" == "true" ]] || arm_valid=false
+    if [[ "$walk_complete" != "true" && "${PROFILE_ALLOW_PARTIAL_WALK:-0}" != "1" ]]; then
+        arm_valid=false
+    fi
 
     cat > "$RUN_OUT/meta.json" <<EOF
 {
-  "arm": "backfill",
+  "arm": "$arm",
   "rep": $rep,
-  "ref": "$(git -C "$MAIN_ROOT" rev-parse --short HEAD)",
+  "ref": "$(git -C "$root" rev-parse --short HEAD)",
+  "worktree_dirty": $(if [[ -n "$(git -C "$root" status --porcelain 2>/dev/null)" ]]; then echo true; else echo false; fi),
+  "base_ref": "${BASE_REF:-}",
   "duration_s": $duration,
   "backfill_cps": ${PROFILE_BACKFILL_CPS:-1000},
   "nbt_transcode": ${PROFILE_NBT_TRANSCODE:-true},
@@ -204,25 +280,36 @@ PROPS
 }
 EOF
     if [[ $rc -ne 0 ]]; then
-        log "run backfill rep$rep FAILED (rc=$rc) — see $RUN_OUT/orchestrator.log"
+        log "run $arm rep$rep FAILED (rc=$rc) — see $RUN_OUT/orchestrator.log"
         return 1
     fi
     if [[ "$arm_valid" != "true" ]]; then
-        log "run backfill rep$rep INVALID: echo='${echo_line:-<missing>}' walk_started=$([[ -n "$start_line" ]] && echo yes || echo no)"
+        log "run $arm rep$rep INVALID: echo='${echo_line:-<missing>}' walk_started=$([[ -n "$start_line" ]] && echo yes || echo no) walk_complete=$walk_complete parse_ok=$parse_ok"
         return 1
     fi
-    if [[ "$walk_complete" != "true" ]]; then
-        log "NOTE: walk did not complete within ${duration}s — deposits/s unavailable; raise the duration"
-    fi
-    log "run backfill rep$rep done -> $RUN_OUT (deposited=$deposited in ${walk_seconds}s, ${deposits_per_s}/s)"
+    log "run $arm rep$rep done -> $RUN_OUT (deposited=${deposited:-0} in ${walk_seconds}s, ${deposits_per_s}/s)"
 }
 
 cmd_matrix() {
     local reps="${1:?reps}" duration="${2:-300}"
-    log "Matrix: ${reps} backfill reps, duration=${duration}s -> $OUT_ROOT/$RUN_STAMP"
+    local arm_a="backfill" arm_b=""
+    if [[ -n "$BASE_REF" ]]; then
+        arm_a="base"; arm_b="change"
+        cmd_setup
+    fi
+    log "Matrix: ${reps} reps x {$arm_a${arm_b:+, $arm_b}}${arm_b:+ ABBA}, duration=${duration}s -> $OUT_ROOT/$RUN_STAMP"
+    if [[ -n "$arm_b" && $((reps % 2)) -ne 0 ]]; then
+        log "NOTE: odd rep count leaves residual first-position bias after ABBA — prefer even reps"
+    fi
     for rep in $(seq 1 "$reps"); do
-        cmd_run "$rep" "$duration"
+        local first="$arm_a" second="$arm_b"
+        if [[ -n "$arm_b" ]] && (( rep % 2 == 0 )); then first="$arm_b"; second="$arm_a"; fi
+        cmd_run "$first" "$rep" "$duration"
         sleep 15
+        if [[ -n "$second" ]]; then
+            cmd_run "$second" "$rep" "$duration"
+            sleep 15
+        fi
     done
     log "Matrix complete: $OUT_ROOT/$RUN_STAMP"
 }
@@ -234,5 +321,6 @@ RUN_STAMP="${RUN_STAMP:-$(date +%Y%m%d-%H%M%S)}"
 case "$CMD" in
     run)    cmd_run "$@" ;;
     matrix) cmd_matrix "$@" ;;
-    *) sed -n '3,30p' "$0"; exit 1 ;;
+    setup)  cmd_setup ;;
+    *) sed -n '3,45p' "$0"; exit 1 ;;
 esac

--- a/scripts/compare_profile.py
+++ b/scripts/compare_profile.py
@@ -2,30 +2,45 @@
 """Pooled base/change cuts over profile harness runs (PERF Phase 0 item 5).
 
 This is the arithmetic every phase gate states, computed ONE way instead of ad hoc:
-pooled band counts, pooled per-marker counters (with per-thread splits), per-column
-allocation weight, LSS-attributed µs/col, Poisson CIs on every cut, and the hibw
-ceiling metric (pooled sources.disk_read ÷ pooled window seconds).
+pooled band counts, pooled per-marker counters (with per-thread splits), pooled
+per-thread LSS-frame counts (the Phase 3 gate metric), per-column allocation weight,
+LSS-attributed µs/col, Poisson CIs on every cut, and the hibw ceiling metric
+(pooled sources.disk_read ÷ pooled window seconds).
 
 Usage:
-  compare_profile.py <stamp-dir> [--arms A,B]        # both arms in one stamp dir
-  compare_profile.py <base-stamp> <change-stamp>     # arms in separate stamp dirs
+  compare_profile.py <stamp-dir> [--arms A,B] [--skip-reps N]
+  compare_profile.py <base-stamp> <change-stamp> [--arms A,B] [--skip-reps N]
+  compare_profile.py --selftest
 
 Default arms: base,change when present, else vanilla,c2me (profile_disk_read.sh's two
 modes), else backfill,backfill (a backfill A/B across two stamp dirs). Every run dir
 needs bands.json — run `analyze_profile_jfr.py compare <stamp-dir>` (with --window walk
 for backfill stamps) first; this script is a pure aggregator and never shells out.
 
+--skip-reps N drops reps 1..N from every arm — the round's "one discarded warm-up rep"
+protocol is `--skip-reps 1`; the default 0 pools everything and says so.
+
 Reading the output:
+  - rows are labelled by ROLE (base/change); the arm names appear in the header.
   - cut% = 1 - change/base pooled counts; CI is a log-normal Poisson approximation
     (se = sqrt(1/a + 1/b)). A gate "≥30% cut with the CI lower bound above 0" means
-    cut_lo > 0 and cut >= 30.
+    cut_lo > 0 and cut >= 30. change==0 reports a +100% cut with a rule-of-three
+    lower bound (1 - 3/base); base==0 with change>0 is reported as "appeared".
   - CLASSIFIER TRIPWIRE: nbt-other and serialize-live are vanilla/probe work no phase
-    touches — a cut whose CI excludes 0 there means the classifier moved, not the code.
+    touches — a significant move there means the classifier moved, not the code. The
+    tripwire test is DISPERSION-AWARE (a t-test on per-rep rates), because the
+    b0-aa-control A/A showed these bands are bursty window-edge work, 5-20x
+    over-dispersed vs Poisson on code-identical arms — the pooled Poisson CI would
+    fire on every A/B. When a tripwire band is 0 in both arms the drift check is
+    UNDETECTABLE and says so.
   - µs/col = lss_attributed_samples × 10 ms ÷ columns. profile.jfc samples Java @10 ms
     but native @20 ms, so native-heavy bands (zip) are under-weighted ~2x in ABSOLUTE
     terms; cuts are unaffected when both arms have similar native mix (the F5 caveat).
+  - alloc_by_class pools each run's top-60 classes (analyze's persistence cap), so a
+    class hovering at the tail may be slightly undercounted; totals use alloc_total.
 
-Exit: 0 on success, 2 when any pooled run is arm-invalid or artifacts are missing.
+Exit: 0 on success, 2 when any pooled run is arm-invalid, artifacts are missing,
+window modes are mixed, or a pooled backfill arm has no completed-walk seconds.
 """
 
 import json
@@ -37,6 +52,7 @@ from glob import glob
 
 SAMPLE_PERIOD_MS = 10.0          # profile.jfc Java exec-sample period
 TRIPWIRE_BANDS = ("nbt-other", "serialize-live")
+COLUMN_PARITY_WARN_PCT = 2.0     # the plan's columns_received parity guard
 
 
 def die(msg):
@@ -52,22 +68,28 @@ def load_json(path):
         return None
 
 
-def collect_arm(stamp_dir, arm):
-    """Pool all <arm>-rep* run dirs into one record."""
+def collect_arm(stamp_dir, arm, role, skip_reps=0):
+    """Pool all <arm>-rep* run dirs (rep > skip_reps) into one record."""
     run_dirs = sorted(glob(os.path.join(stamp_dir, f"{arm}-rep*")))
     run_dirs = [d for d in run_dirs if os.path.isdir(d)]
     if not run_dirs:
         die(f"no {arm}-rep* run dirs in {stamp_dir}")
     pooled = {
-        "arm": arm, "reps": 0, "refs": set(), "bands": Counter(),
+        "arm": arm, "role": role, "reps": 0, "skipped": 0, "refs": set(),
+        "bands": Counter(), "band_reps": defaultdict(list),
         "lss_attributed": 0, "total_exec": 0, "window_s": 0.0,
+        "window_modes": set(),
         "markers": defaultdict(lambda: {"total": 0, "by_thread": Counter()}),
+        "thread_lss": defaultdict(lambda: [0, 0]),   # th -> [lss, other] (Phase 3 gate)
         "alloc_by_class_mb": Counter(), "alloc_total_mb": 0.0,
         "columns": 0, "disk_read": 0, "deposited": 0, "walk_seconds": 0.0,
         "is_backfill": False,
     }
     for d in run_dirs:
         meta = load_json(os.path.join(d, "meta.json")) or {}
+        if isinstance(meta.get("rep"), int) and meta["rep"] <= skip_reps:
+            pooled["skipped"] += 1
+            continue
         if meta.get("arm_valid") is not True:
             die(f"{d}: arm_valid is not true — an invalid arm must never be pooled "
                 f"(echo='{meta.get('config_echo', '')}')")
@@ -76,8 +98,10 @@ def collect_arm(stamp_dir, arm):
             die(f"{d}: no bands.json — run analyze_profile_jfr.py compare first")
         pooled["reps"] += 1
         pooled["refs"].add(meta.get("ref", "?"))
+        pooled["window_modes"].add(bands.get("window_mode", "wire-slope"))
         for k, v in bands["bands"].items():
             pooled["bands"][k] += v
+            pooled["band_reps"][k].append((v, bands.get("window_s") or 0.0))
         pooled["lss_attributed"] += bands["lss_attributed_samples"]
         pooled["total_exec"] += bands["total_exec_samples"]
         pooled["window_s"] += bands.get("window_s") or 0.0
@@ -85,6 +109,10 @@ def collect_arm(stamp_dir, arm):
             pooled["markers"][m]["total"] += rec["total"]
             for th, n in rec.get("by_thread", {}).items():
                 pooled["markers"][m]["by_thread"][th] += n
+        for th, by_band in bands.get("thread_band_lss", {}).items():
+            for split in by_band.values():
+                pooled["thread_lss"][th][0] += split.get("lss", 0)
+                pooled["thread_lss"][th][1] += split.get("other", 0)
         for c, mb in bands.get("alloc_by_class_mb", {}).items():
             pooled["alloc_by_class_mb"][c] += mb
         pooled["alloc_total_mb"] += bands.get("alloc_total_mb") or 0.0
@@ -99,36 +127,367 @@ def collect_arm(stamp_dir, arm):
             pooled["is_backfill"] = True
             pooled["deposited"] += walk.get("deposited") or 0
             pooled["walk_seconds"] += walk.get("walk_seconds") or 0
-    if pooled["is_backfill"] and pooled["columns"] == 0:
-        # Backfill runs are client-less: the per-column denominator is deposits.
-        pooled["columns"] = pooled["deposited"]
+    if pooled["reps"] == 0:
+        die(f"{stamp_dir}/{arm}: every rep was skipped (skip_reps too high?)")
+    if len(pooled["window_modes"]) > 1:
+        die(f"{stamp_dir}/{arm}: mixed analysis windows {sorted(pooled['window_modes'])} — "
+            f"re-run analyze_profile_jfr.py with one --window mode before pooling")
+    if pooled["is_backfill"]:
+        if pooled["walk_seconds"] <= 0:
+            die(f"{stamp_dir}/{arm}: backfill arm pooled 0 completed-walk seconds — "
+                f"no rep finished its walk; raise the duration and re-run")
+        if pooled["columns"] == 0:
+            # Backfill runs are client-less: the per-column denominator is deposits.
+            pooled["columns"] = pooled["deposited"]
     return pooled
 
 
 def cut_ci(a, b):
-    """(cut_pct, lo_pct, hi_pct) for pooled Poisson counts base=a, change=b; None = n/a."""
-    if a <= 0 or b <= 0:
+    """(cut_pct, lo_pct, hi_pct) for pooled Poisson counts base=a, change=b.
+
+    b==0: +100% cut with a rule-of-three lower bound (upper 95% CI of a Poisson
+    observation of 0 is ~3, so ratio_hi = 3/a). a==0: no ratio exists -> None.
+    """
+    if a <= 0:
         return None
+    if b == 0:
+        return (100.0, 100.0 * (1 - 3.0 / a), 100.0)
     r = b / a
     se = math.sqrt(1.0 / a + 1.0 / b)
     lo_r, hi_r = r * math.exp(-1.96 * se), r * math.exp(1.96 * se)
     return (100 * (1 - r), 100 * (1 - hi_r), 100 * (1 - lo_r))
 
 
-def fmt_cut(a, b):
+def significant(a, b):
+    """True when the 95% CI on the cut excludes 0 (drift/effect detectable)."""
     c = cut_ci(a, b)
     if c is None:
-        return "n/a"
+        # base 0: an appearance is significant by rule-of-three symmetry when b >= 4.
+        return b >= 4
+    _, lo, hi = c
+    return lo > 0 or hi < 0
+
+
+# Two-sided 95% t critical values by dof (capped table; >10 -> ~z).
+T_CRIT = {1: 12.71, 2: 4.30, 3: 3.18, 4: 2.78, 5: 2.57, 6: 2.45, 7: 2.36,
+          8: 2.31, 9: 2.26, 10: 2.23}
+
+
+def rep_level_significant(reps_a, reps_b):
+    """Dispersion-aware significance on per-rep RATES (count / window seconds).
+
+    The b0-aa-control A/A showed the save/probe-correlated bands (serialize-live,
+    nbt-other, zip) are BURSTY — 5-20x over-dispersed vs Poisson on code-identical
+    arms — so a pooled-count Poisson CI fires false tripwires there. A pooled t-test
+    on rep rates carries the observed dispersion instead. Falls back to the Poisson
+    judgement when either arm has < 2 reps.
+    """
+    if len(reps_a) < 2 or len(reps_b) < 2:
+        return significant(sum(c for c, _ in reps_a), sum(c for c, _ in reps_b))
+    ra = [c / w for c, w in reps_a if w > 0]
+    rb = [c / w for c, w in reps_b if w > 0]
+    if len(ra) < 2 or len(rb) < 2:
+        return significant(sum(c for c, _ in reps_a), sum(c for c, _ in reps_b))
+    ma, mb = sum(ra) / len(ra), sum(rb) / len(rb)
+    va = sum((x - ma) ** 2 for x in ra) / (len(ra) - 1)
+    vb = sum((x - mb) ** 2 for x in rb) / (len(rb) - 1)
+    dof = len(ra) + len(rb) - 2
+    sp2 = ((len(ra) - 1) * va + (len(rb) - 1) * vb) / dof
+    if sp2 == 0:
+        return ma != mb
+    t = abs(ma - mb) / math.sqrt(sp2 * (1 / len(ra) + 1 / len(rb)))
+    return t > T_CRIT.get(dof, 1.96)
+
+
+def fmt_cut(a, b):
+    if a == 0 and b == 0:
+        return "n/a (0/0)"
+    if a == 0:
+        return f"appeared (0 -> {b})"
+    c = cut_ci(a, b)
     cut, lo, hi = c
     return f"{cut:+6.1f}% [{lo:+.1f}, {hi:+.1f}]"
 
 
+def compare(base, change):
+    """Print the full comparison; returns nothing (pure reporting)."""
+    print(f"# compare_profile: base={base['arm']} ({base['reps']} reps, refs "
+          f"{sorted(base['refs'])}) vs change={change['arm']} ({change['reps']} reps, "
+          f"refs {sorted(change['refs'])})")
+    skipped = base["skipped"] + change["skipped"]
+    if skipped:
+        print(f"(skipped {skipped} warm-up rep(s) via --skip-reps)")
+    else:
+        print("(--skip-reps 0: pooling ALL reps including any warm-up rep)")
+    if base["reps"] != change["reps"]:
+        print(f"WARNING: unbalanced reps ({base['reps']} vs {change['reps']}) — "
+              f"pooled counts are still valid, but check why an arm lost a rep")
+    if base["window_modes"] != change["window_modes"]:
+        die(f"window modes differ between arms: {sorted(base['window_modes'])} vs "
+            f"{sorted(change['window_modes'])} — re-analyze with one --window mode")
+    window_mode = next(iter(base["window_modes"]))
+    print(f"pooled window ({window_mode}): base {base['window_s']:.0f}s, "
+          f"change {change['window_s']:.0f}s"
+          f" | columns: base {base['columns']}, change {change['columns']}")
+    if base["columns"] and change["columns"] and not base["is_backfill"]:
+        parity = 100.0 * abs(base["columns"] - change["columns"]) / base["columns"]
+        marker = "WARNING" if parity > COLUMN_PARITY_WARN_PCT else "ok"
+        print(f"column parity: {parity:.2f}% delta ({marker}; the plan's guard is "
+              f"±{COLUMN_PARITY_WARN_PCT:.0f}% — beyond it, count cuts are diluted by "
+              f"throughput change, biasing toward false FAILs)")
+    print()
+
+    print("## Pooled bands (samples; cut = 1 - change/base, Poisson 95% CI)")
+    band_names = sorted(set(base["bands"]) | set(change["bands"]),
+                        key=lambda k: -base["bands"].get(k, 0))
+    for name in band_names:
+        a, b = base["bands"].get(name, 0), change["bands"].get(name, 0)
+        trip = "   <- TRIPWIRE" if name in TRIPWIRE_BANDS else ""
+        print(f"- {name:<16} {a:>7} -> {b:<7} cut {fmt_cut(a, b)}{trip}")
+    a, b = base["lss_attributed"], change["lss_attributed"]
+    print(f"- {'lss_attributed':<16} {a:>7} -> {b:<7} cut {fmt_cut(a, b)}")
+    for n in TRIPWIRE_BANDS:
+        ta, tb = base["bands"].get(n, 0), change["bands"].get(n, 0)
+        if ta == 0 and tb == 0:
+            print(f"WARNING: tripwire band {n} is 0 in both arms — classifier drift is "
+                  f"UNDETECTABLE here (normal for backfill windows; note it in the verdict)")
+        elif rep_level_significant(base["band_reps"].get(n, []),
+                                   change["band_reps"].get(n, [])):
+            spread_a = [c for c, _ in base["band_reps"].get(n, [])]
+            spread_b = [c for c, _ in change["band_reps"].get(n, [])]
+            print(f"WARNING: tripwire band {n} moved beyond its rep-level dispersion "
+                  f"({ta} -> {tb}; per-rep {spread_a} -> {spread_b}) — the CLASSIFIER "
+                  f"moved, not the code; do not trust the other cuts")
+    print()
+
+    print("## Pooled per-thread LSS-frame samples (Phase 3 gate: lss cut + vanilla residual)")
+    threads = sorted(set(base["thread_lss"]) | set(change["thread_lss"]),
+                     key=lambda th: -base["thread_lss"].get(th, [0, 0])[0])
+    for th in threads[:10]:
+        la, oa = base["thread_lss"].get(th, [0, 0])
+        lb, ob = change["thread_lss"].get(th, [0, 0])
+        if la == 0 and lb == 0 and oa == 0 and ob == 0:
+            continue
+        print(f"- {th:<24} lss {la:>6} -> {lb:<6} cut {fmt_cut(la, lb)}"
+              f" | other(residual) {oa} -> {ob}")
+    print()
+
+    print("## Pooled markers (any-frame counters; the phase-gate numbers)")
+    for m in sorted(set(base["markers"]) | set(change["markers"])):
+        a = base["markers"][m]["total"] if m in base["markers"] else 0
+        b = change["markers"][m]["total"] if m in change["markers"] else 0
+        if a == 0 and b == 0:
+            continue
+        print(f"- {m}")
+        print(f"    total {a:>7} -> {b:<7} cut {fmt_cut(a, b)}")
+        by_a = base["markers"].get(m, {}).get("by_thread", {})
+        by_b = change["markers"].get(m, {}).get("by_thread", {})
+        for th in sorted(set(by_a) | set(by_b), key=lambda t: -by_a.get(t, 0)):
+            ta, tb = by_a.get(th, 0), by_b.get(th, 0)
+            print(f"    {th:<24} {ta:>7} -> {tb:<7} cut {fmt_cut(ta, tb)}")
+    print()
+
+    if base["columns"] > 0 and change["columns"] > 0:
+        print("## Per-column metrics (µs/col caveat: native sampled @20ms vs Java @10ms —"
+              " absolutes understate native, cuts are fair)")
+        for rec in (base, change):
+            us_col = rec["lss_attributed"] * SAMPLE_PERIOD_MS * 1000.0 / rec["columns"]
+            alloc_col = rec["alloc_total_mb"] * 1e6 / rec["columns"]
+            print(f"- {rec['role']:<8} lss µs/col {us_col:8.1f} | alloc/col {alloc_col:9.0f} B"
+                  f" | columns {rec['columns']}")
+        base_us = base["lss_attributed"] * SAMPLE_PERIOD_MS * 1000.0 / base["columns"]
+        change_us = change["lss_attributed"] * SAMPLE_PERIOD_MS * 1000.0 / change["columns"]
+        if base_us > 0:
+            print(f"- µs/col cut: {100 * (1 - change_us / base_us):+.1f}%"
+                  f" (count CI applies: {fmt_cut(base['lss_attributed'], change['lss_attributed'])}"
+                  f" before the column normalization)")
+        print("- top allocation movers (per-column bytes, change - base):")
+        movers = []
+        for c in set(base["alloc_by_class_mb"]) | set(change["alloc_by_class_mb"]):
+            pa = base["alloc_by_class_mb"].get(c, 0.0) * 1e6 / base["columns"]
+            pb = change["alloc_by_class_mb"].get(c, 0.0) * 1e6 / change["columns"]
+            movers.append((pb - pa, c, pa, pb))
+        movers.sort(key=lambda t: -abs(t[0]))
+        for delta, cls, pa, pb in movers[:8]:
+            print(f"    {delta:+10.0f} B/col  {cls}  ({pa:.0f} -> {pb:.0f})")
+        print()
+    else:
+        print("## Per-column metrics: SKIPPED — an arm has 0 columns (no client.json "
+              "and no completed walk); never divide by a fabricated denominator")
+        print()
+
+    if base["is_backfill"] or change["is_backfill"]:
+        print("## Backfill walk (deposits/s = the Phase 2 gate metric)")
+        for rec in (base, change):
+            if rec["walk_seconds"] > 0:
+                print(f"- {rec['role']:<8} deposited {rec['deposited']} in {rec['walk_seconds']:.0f}s"
+                      f" = {rec['deposited'] / rec['walk_seconds']:.1f}/s")
+        print()
+
+    if base["disk_read"] or change["disk_read"]:
+        print(f"## hibw ceiling (pooled sources.disk_read / pooled {window_mode}-window seconds)")
+        for rec in (base, change):
+            if rec["window_s"] > 0:
+                print(f"- {rec['role']:<8} {rec['disk_read']} disk-read serves / {rec['window_s']:.0f}s"
+                      f" = {rec['disk_read'] / rec['window_s']:.1f} col/s")
+        print()
+
+
+# ---- selftest --------------------------------------------------------------------------
+
+def selftest():
+    import contextlib
+    import io
+    import tempfile
+    failures = []
+    ran = [0]
+
+    def check(name, cond):
+        ran[0] += 1
+        if cond:
+            print(f"  ok  {name}")
+        else:
+            failures.append(name)
+            print(f"FAIL  {name}")
+
+    # cut_ci arithmetic + endpoint ordering
+    c = cut_ci(300, 150)
+    check("cut_ci midpoint", c is not None and abs(c[0] - 50.0) < 1e-9)
+    check("cut_ci ordering lo<cut<hi", c[1] < c[0] < c[2])
+    check("cut_ci zero-change rule-of-three", cut_ci(30, 0) == (100.0, 100.0 * (1 - 0.1), 100.0))
+    check("cut_ci zero-base is None", cut_ci(0, 5) is None)
+    check("fmt 0/0", fmt_cut(0, 0) == "n/a (0/0)")
+    check("fmt appeared", fmt_cut(0, 7) == "appeared (0 -> 7)")
+    check("fmt full-elimination has 100%", "+100.0%" in fmt_cut(30, 0))
+    # significance: 1->0 must NOT be significant; 10->0 must; 0->4 must (symmetry)
+    check("sig 1->0 no", not significant(1, 0))
+    check("sig 10->0 yes", significant(10, 0))
+    check("sig 0->4 yes", significant(0, 4))
+    check("sig 0->3 no", not significant(0, 3))
+    check("sig equal no", not significant(200, 200))
+    # Dispersion-aware tripwire: the REAL b0-aa-control serialize-live rep data —
+    # 6..164 across code-identical arms — must NOT fire (the Poisson CI did).
+    aa_base = [(18, 83.0), (88, 82.0), (6, 79.0)]
+    aa_change = [(164, 86.0), (48, 83.0), (52, 80.0)]
+    check("rep-level: A/A burst not significant", not rep_level_significant(aa_base, aa_change))
+    tight_base = [(100, 80.0), (98, 80.0), (102, 80.0)]
+    tight_change = [(10, 80.0), (12, 80.0), (9, 80.0)]
+    check("rep-level: tight real drift fires", rep_level_significant(tight_base, tight_change))
+    check("rep-level: identical rates quiet",
+          not rep_level_significant(tight_base, tight_base))
+    check("rep-level: 1-rep falls back to Poisson",
+          rep_level_significant([(300, 80.0)], [(150, 80.0)]))
+
+    def write_run(root, arm, rep, *, valid=True, walk=None, columns=1000,
+                  window_mode="wire-slope", bands_extra=None):
+        d = os.path.join(root, f"{arm}-rep{rep}")
+        os.makedirs(d, exist_ok=True)
+        meta = {"arm": arm, "rep": rep, "ref": "abc123", "arm_valid": valid}
+        if walk is not None:
+            meta["walk"] = walk
+        with open(os.path.join(d, "meta.json"), "w") as f:
+            json.dump(meta, f)
+        bands = {"window_mode": window_mode, "window_s": 60.0,
+                 "total_exec_samples": 1000,
+                 "bands": {"nbt": 100, "nbt-other": 10, "serialize-live": 5},
+                 "lss_attributed_samples": 100,
+                 "thread_band_lss": {"IO-Worker": {"nbt": {"lss": 90, "other": 4}}},
+                 "markers": {"m.X": {"total": 50, "by_thread": {"IO-Worker": 50}}},
+                 "alloc_total_mb": 10.0, "alloc_by_class_mb": {"byte[]": 8.0}}
+        if bands_extra:
+            bands.update(bands_extra)
+        with open(os.path.join(d, "bands.json"), "w") as f:
+            json.dump(bands, f)
+        if columns is not None:
+            with open(os.path.join(d, "client.json"), "w") as f:
+                json.dump({"columns_received": columns}, f)
+        with open(os.path.join(d, "server.json"), "w") as f:
+            json.dump({"sources": {"disk_read": 900}}, f)
+
+    def expect_die(name, fn):
+        try:
+            with contextlib.redirect_stderr(io.StringIO()):
+                fn()
+        except SystemExit as e:
+            check(name, e.code == 2)
+        else:
+            check(name, False)
+
+    with tempfile.TemporaryDirectory() as td:
+        write_run(td, "base", 1)
+        write_run(td, "base", 2)
+        write_run(td, "change", 1)
+        write_run(td, "change", 2)
+        rec = collect_arm(td, "base", "base")
+        check("pool reps", rec["reps"] == 2 and rec["bands"]["nbt"] == 200)
+        check("pool thread_lss", rec["thread_lss"]["IO-Worker"] == [180, 8])
+        rec1 = collect_arm(td, "base", "base", skip_reps=1)
+        check("skip-reps drops rep1", rec1["reps"] == 1 and rec1["skipped"] == 1)
+        out = io.StringIO()
+        with contextlib.redirect_stdout(out):
+            compare(collect_arm(td, "base", "base"), collect_arm(td, "change", "change"))
+        text = out.getvalue()
+        check("A/A tripwires quiet", "moved significantly" not in text)
+        check("thread section present", "Pooled per-thread LSS-frame" in text)
+        check("role labels", "- base " in text and "- change " in text)
+
+    with tempfile.TemporaryDirectory() as td:
+        write_run(td, "base", 1, valid=False)
+        expect_die("invalid arm dies", lambda: collect_arm(td, "base", "base"))
+
+    with tempfile.TemporaryDirectory() as td:
+        write_run(td, "base", 1)
+        write_run(td, "base", 2, window_mode="full")
+        expect_die("mixed window modes die", lambda: collect_arm(td, "base", "base"))
+
+    with tempfile.TemporaryDirectory() as td:
+        walk = {"complete": True, "deposited": 5000, "walk_seconds": 50}
+        write_run(td, "backfill", 1, walk=walk, columns=None, window_mode="walk")
+        rec = collect_arm(td, "backfill", "base")
+        check("backfill deposits become columns", rec["columns"] == 5000)
+
+    with tempfile.TemporaryDirectory() as td:
+        walk = {"complete": False, "deposited": 0, "walk_seconds": 0}
+        write_run(td, "backfill", 1, walk=walk, columns=None, window_mode="walk")
+        expect_die("0-walk-seconds backfill dies", lambda: collect_arm(td, "backfill", "base"))
+
+    with tempfile.TemporaryDirectory() as td:
+        write_run(td, "base", 1)
+        write_run(td, "change", 1)
+        write_run(td, "change", 2)
+        out = io.StringIO()
+        with contextlib.redirect_stdout(out):
+            compare(collect_arm(td, "base", "base"), collect_arm(td, "change", "change"))
+        check("unbalanced reps warns", "unbalanced reps" in out.getvalue())
+
+    with tempfile.TemporaryDirectory() as td:
+        write_run(td, "base", 1, bands_extra={"bands": {"nbt": 100, "nbt-other": 0,
+                                                        "serialize-live": 0}})
+        write_run(td, "change", 1, bands_extra={"bands": {"nbt": 90, "nbt-other": 0,
+                                                          "serialize-live": 0}})
+        out = io.StringIO()
+        with contextlib.redirect_stdout(out):
+            compare(collect_arm(td, "base", "base"), collect_arm(td, "change", "change"))
+        check("0/0 tripwire says undetectable", "UNDETECTABLE" in out.getvalue())
+
+    print(f"[compare-profile] selftest: {ran[0]} cases, {len(failures)} failures — "
+          f"{'PASS' if not failures else 'FAIL: ' + ', '.join(failures)}")
+    sys.exit(1 if failures else 0)
+
+
 def main():
     args = [a for a in sys.argv[1:]]
-    arms_arg = None
+    if "--selftest" in args:
+        selftest()
+        return
+    arms_arg, skip_reps = None, 0
     if "--arms" in args:
         i = args.index("--arms")
         arms_arg = args[i + 1]
+        del args[i:i + 2]
+    if "--skip-reps" in args:
+        i = args.index("--skip-reps")
+        skip_reps = int(args[i + 1])
         del args[i:i + 2]
     if not args:
         sys.exit(__doc__)
@@ -153,93 +512,8 @@ def main():
     if base_dir == change_dir and arm_a == arm_b:
         die("one stamp dir needs two distinct arms (or pass two stamp dirs)")
 
-    base = collect_arm(base_dir, arm_a)
-    change = collect_arm(change_dir, arm_b)
-
-    print(f"# compare_profile: base={arm_a} ({base['reps']} reps, refs {sorted(base['refs'])})"
-          f" vs change={arm_b} ({change['reps']} reps, refs {sorted(change['refs'])})")
-    if base["reps"] != change["reps"]:
-        print(f"WARNING: unbalanced reps ({base['reps']} vs {change['reps']}) — "
-              f"pooled counts are still valid, but check why an arm lost a rep")
-    print(f"pooled window: base {base['window_s']:.0f}s, change {change['window_s']:.0f}s"
-          f" | columns: base {base['columns']}, change {change['columns']}")
-    print()
-
-    print("## Pooled bands (samples; cut = 1 - change/base, Poisson 95% CI)")
-    band_names = sorted(set(base["bands"]) | set(change["bands"]),
-                        key=lambda k: -base["bands"].get(k, 0))
-    for name in band_names:
-        a, b = base["bands"].get(name, 0), change["bands"].get(name, 0)
-        trip = "   <- TRIPWIRE (classifier drift if CI excludes 0)" if name in TRIPWIRE_BANDS else ""
-        print(f"- {name:<16} {a:>7} -> {b:<7} cut {fmt_cut(a, b)}{trip}")
-    a, b = base["lss_attributed"], change["lss_attributed"]
-    print(f"- {'lss_attributed':<16} {a:>7} -> {b:<7} cut {fmt_cut(a, b)}")
-    tripped = [n for n in TRIPWIRE_BANDS
-               if (c := cut_ci(base["bands"].get(n, 0), change["bands"].get(n, 0)))
-               and (c[1] > 0 or c[2] < 0)]
-    if tripped:
-        print(f"WARNING: tripwire bands moved significantly: {', '.join(tripped)} — "
-              f"the CLASSIFIER moved, not the code; do not trust the other cuts")
-    print()
-
-    print("## Pooled markers (any-frame counters; the phase-gate numbers)")
-    for m in sorted(set(base["markers"]) | set(change["markers"])):
-        a = base["markers"].get(m, {}).get("total", 0) if m in base["markers"] else 0
-        b = change["markers"].get(m, {}).get("total", 0) if m in change["markers"] else 0
-        if a == 0 and b == 0:
-            continue
-        print(f"- {m}")
-        print(f"    total {a:>7} -> {b:<7} cut {fmt_cut(a, b)}")
-        threads = sorted(set(base["markers"].get(m, {}).get("by_thread", {}))
-                         | set(change["markers"].get(m, {}).get("by_thread", {})),
-                         key=lambda th: -(base["markers"].get(m, {}).get("by_thread", {}).get(th, 0)))
-        for th in threads:
-            ta = base["markers"].get(m, {}).get("by_thread", {}).get(th, 0)
-            tb = change["markers"].get(m, {}).get("by_thread", {}).get(th, 0)
-            print(f"    {th:<24} {ta:>7} -> {tb:<7} cut {fmt_cut(ta, tb)}")
-    print()
-
-    print("## Per-column metrics (µs/col caveat: native sampled @20ms vs Java @10ms —"
-          " absolutes understate native, cuts are fair)")
-    for rec in (base, change):
-        cols = rec["columns"] or 1
-        us_col = rec["lss_attributed"] * SAMPLE_PERIOD_MS * 1000.0 / cols
-        alloc_col = rec["alloc_total_mb"] * 1e6 / cols
-        print(f"- {rec['arm']:<8} lss µs/col {us_col:8.1f} | alloc/col {alloc_col:9.0f} B"
-              f" | columns {rec['columns']}")
-    if base["columns"] and change["columns"]:
-        base_us = base["lss_attributed"] * SAMPLE_PERIOD_MS * 1000.0 / base["columns"]
-        change_us = change["lss_attributed"] * SAMPLE_PERIOD_MS * 1000.0 / change["columns"]
-        if base_us > 0:
-            print(f"- µs/col cut: {100 * (1 - change_us / base_us):+.1f}%"
-                  f" (count CI applies: {fmt_cut(base['lss_attributed'], change['lss_attributed'])}"
-                  f" before the column normalization)")
-        print("- top allocation movers (per-column bytes, change - base):")
-        movers = []
-        for c in set(base["alloc_by_class_mb"]) | set(change["alloc_by_class_mb"]):
-            pa = base["alloc_by_class_mb"].get(c, 0.0) * 1e6 / base["columns"]
-            pb = change["alloc_by_class_mb"].get(c, 0.0) * 1e6 / change["columns"]
-            movers.append((pb - pa, c, pa, pb))
-        movers.sort(key=lambda t: -abs(t[0]))
-        for delta, cls, pa, pb in movers[:8]:
-            print(f"    {delta:+10.0f} B/col  {cls}  ({pa:.0f} -> {pb:.0f})")
-    print()
-
-    if base["is_backfill"] or change["is_backfill"]:
-        print("## Backfill walk (deposits/s = the Phase 2 gate metric)")
-        for rec in (base, change):
-            if rec["walk_seconds"] > 0:
-                print(f"- {rec['arm']:<8} deposited {rec['deposited']} in {rec['walk_seconds']:.0f}s"
-                      f" = {rec['deposited'] / rec['walk_seconds']:.1f}/s")
-        print()
-
-    if base["disk_read"] or change["disk_read"]:
-        print("## hibw ceiling (pooled sources.disk_read / pooled window seconds)")
-        for rec in (base, change):
-            if rec["window_s"] > 0:
-                print(f"- {rec['arm']:<8} {rec['disk_read']} disk-read serves / {rec['window_s']:.0f}s"
-                      f" = {rec['disk_read'] / rec['window_s']:.1f} col/s")
-        print()
+    compare(collect_arm(base_dir, arm_a, "base", skip_reps),
+            collect_arm(change_dir, arm_b, "change", skip_reps))
 
 
 if __name__ == "__main__":

--- a/scripts/compare_profile.py
+++ b/scripts/compare_profile.py
@@ -1,0 +1,246 @@
+#!/usr/bin/env python3
+"""Pooled base/change cuts over profile harness runs (PERF Phase 0 item 5).
+
+This is the arithmetic every phase gate states, computed ONE way instead of ad hoc:
+pooled band counts, pooled per-marker counters (with per-thread splits), per-column
+allocation weight, LSS-attributed µs/col, Poisson CIs on every cut, and the hibw
+ceiling metric (pooled sources.disk_read ÷ pooled window seconds).
+
+Usage:
+  compare_profile.py <stamp-dir> [--arms A,B]        # both arms in one stamp dir
+  compare_profile.py <base-stamp> <change-stamp>     # arms in separate stamp dirs
+
+Default arms: base,change when present, else vanilla,c2me (profile_disk_read.sh's two
+modes), else backfill,backfill (a backfill A/B across two stamp dirs). Every run dir
+needs bands.json — run `analyze_profile_jfr.py compare <stamp-dir>` (with --window walk
+for backfill stamps) first; this script is a pure aggregator and never shells out.
+
+Reading the output:
+  - cut% = 1 - change/base pooled counts; CI is a log-normal Poisson approximation
+    (se = sqrt(1/a + 1/b)). A gate "≥30% cut with the CI lower bound above 0" means
+    cut_lo > 0 and cut >= 30.
+  - CLASSIFIER TRIPWIRE: nbt-other and serialize-live are vanilla/probe work no phase
+    touches — a cut whose CI excludes 0 there means the classifier moved, not the code.
+  - µs/col = lss_attributed_samples × 10 ms ÷ columns. profile.jfc samples Java @10 ms
+    but native @20 ms, so native-heavy bands (zip) are under-weighted ~2x in ABSOLUTE
+    terms; cuts are unaffected when both arms have similar native mix (the F5 caveat).
+
+Exit: 0 on success, 2 when any pooled run is arm-invalid or artifacts are missing.
+"""
+
+import json
+import math
+import os
+import sys
+from collections import Counter, defaultdict
+from glob import glob
+
+SAMPLE_PERIOD_MS = 10.0          # profile.jfc Java exec-sample period
+TRIPWIRE_BANDS = ("nbt-other", "serialize-live")
+
+
+def die(msg):
+    print(f"[compare-profile] ERROR: {msg}", file=sys.stderr)
+    sys.exit(2)
+
+
+def load_json(path):
+    try:
+        with open(path) as f:
+            return json.load(f)
+    except FileNotFoundError:
+        return None
+
+
+def collect_arm(stamp_dir, arm):
+    """Pool all <arm>-rep* run dirs into one record."""
+    run_dirs = sorted(glob(os.path.join(stamp_dir, f"{arm}-rep*")))
+    run_dirs = [d for d in run_dirs if os.path.isdir(d)]
+    if not run_dirs:
+        die(f"no {arm}-rep* run dirs in {stamp_dir}")
+    pooled = {
+        "arm": arm, "reps": 0, "refs": set(), "bands": Counter(),
+        "lss_attributed": 0, "total_exec": 0, "window_s": 0.0,
+        "markers": defaultdict(lambda: {"total": 0, "by_thread": Counter()}),
+        "alloc_by_class_mb": Counter(), "alloc_total_mb": 0.0,
+        "columns": 0, "disk_read": 0, "deposited": 0, "walk_seconds": 0.0,
+        "is_backfill": False,
+    }
+    for d in run_dirs:
+        meta = load_json(os.path.join(d, "meta.json")) or {}
+        if meta.get("arm_valid") is not True:
+            die(f"{d}: arm_valid is not true — an invalid arm must never be pooled "
+                f"(echo='{meta.get('config_echo', '')}')")
+        bands = load_json(os.path.join(d, "bands.json"))
+        if bands is None:
+            die(f"{d}: no bands.json — run analyze_profile_jfr.py compare first")
+        pooled["reps"] += 1
+        pooled["refs"].add(meta.get("ref", "?"))
+        for k, v in bands["bands"].items():
+            pooled["bands"][k] += v
+        pooled["lss_attributed"] += bands["lss_attributed_samples"]
+        pooled["total_exec"] += bands["total_exec_samples"]
+        pooled["window_s"] += bands.get("window_s") or 0.0
+        for m, rec in bands.get("markers", {}).items():
+            pooled["markers"][m]["total"] += rec["total"]
+            for th, n in rec.get("by_thread", {}).items():
+                pooled["markers"][m]["by_thread"][th] += n
+        for c, mb in bands.get("alloc_by_class_mb", {}).items():
+            pooled["alloc_by_class_mb"][c] += mb
+        pooled["alloc_total_mb"] += bands.get("alloc_total_mb") or 0.0
+        client = load_json(os.path.join(d, "client.json"))
+        if client:
+            pooled["columns"] += client.get("columns_received") or 0
+        server = load_json(os.path.join(d, "server.json"))
+        if server:
+            pooled["disk_read"] += (server.get("sources") or {}).get("disk_read") or 0
+        walk = meta.get("walk")
+        if walk:
+            pooled["is_backfill"] = True
+            pooled["deposited"] += walk.get("deposited") or 0
+            pooled["walk_seconds"] += walk.get("walk_seconds") or 0
+    if pooled["is_backfill"] and pooled["columns"] == 0:
+        # Backfill runs are client-less: the per-column denominator is deposits.
+        pooled["columns"] = pooled["deposited"]
+    return pooled
+
+
+def cut_ci(a, b):
+    """(cut_pct, lo_pct, hi_pct) for pooled Poisson counts base=a, change=b; None = n/a."""
+    if a <= 0 or b <= 0:
+        return None
+    r = b / a
+    se = math.sqrt(1.0 / a + 1.0 / b)
+    lo_r, hi_r = r * math.exp(-1.96 * se), r * math.exp(1.96 * se)
+    return (100 * (1 - r), 100 * (1 - hi_r), 100 * (1 - lo_r))
+
+
+def fmt_cut(a, b):
+    c = cut_ci(a, b)
+    if c is None:
+        return "n/a"
+    cut, lo, hi = c
+    return f"{cut:+6.1f}% [{lo:+.1f}, {hi:+.1f}]"
+
+
+def main():
+    args = [a for a in sys.argv[1:]]
+    arms_arg = None
+    if "--arms" in args:
+        i = args.index("--arms")
+        arms_arg = args[i + 1]
+        del args[i:i + 2]
+    if not args:
+        sys.exit(__doc__)
+    if len(args) == 1:
+        base_dir = change_dir = args[0]
+    else:
+        base_dir, change_dir = args[0], args[1]
+
+    if arms_arg:
+        arm_a, arm_b = arms_arg.split(",")
+    else:
+        def has(d, arm):
+            return bool(glob(os.path.join(d, f"{arm}-rep*")))
+        if has(base_dir, "base") and has(change_dir, "change"):
+            arm_a, arm_b = "base", "change"
+        elif has(base_dir, "vanilla") and has(change_dir, "c2me"):
+            arm_a, arm_b = "vanilla", "c2me"
+        elif has(base_dir, "backfill") and has(change_dir, "backfill"):
+            arm_a = arm_b = "backfill"
+        else:
+            die(f"cannot auto-detect arms in {base_dir} / {change_dir} — pass --arms A,B")
+    if base_dir == change_dir and arm_a == arm_b:
+        die("one stamp dir needs two distinct arms (or pass two stamp dirs)")
+
+    base = collect_arm(base_dir, arm_a)
+    change = collect_arm(change_dir, arm_b)
+
+    print(f"# compare_profile: base={arm_a} ({base['reps']} reps, refs {sorted(base['refs'])})"
+          f" vs change={arm_b} ({change['reps']} reps, refs {sorted(change['refs'])})")
+    if base["reps"] != change["reps"]:
+        print(f"WARNING: unbalanced reps ({base['reps']} vs {change['reps']}) — "
+              f"pooled counts are still valid, but check why an arm lost a rep")
+    print(f"pooled window: base {base['window_s']:.0f}s, change {change['window_s']:.0f}s"
+          f" | columns: base {base['columns']}, change {change['columns']}")
+    print()
+
+    print("## Pooled bands (samples; cut = 1 - change/base, Poisson 95% CI)")
+    band_names = sorted(set(base["bands"]) | set(change["bands"]),
+                        key=lambda k: -base["bands"].get(k, 0))
+    for name in band_names:
+        a, b = base["bands"].get(name, 0), change["bands"].get(name, 0)
+        trip = "   <- TRIPWIRE (classifier drift if CI excludes 0)" if name in TRIPWIRE_BANDS else ""
+        print(f"- {name:<16} {a:>7} -> {b:<7} cut {fmt_cut(a, b)}{trip}")
+    a, b = base["lss_attributed"], change["lss_attributed"]
+    print(f"- {'lss_attributed':<16} {a:>7} -> {b:<7} cut {fmt_cut(a, b)}")
+    tripped = [n for n in TRIPWIRE_BANDS
+               if (c := cut_ci(base["bands"].get(n, 0), change["bands"].get(n, 0)))
+               and (c[1] > 0 or c[2] < 0)]
+    if tripped:
+        print(f"WARNING: tripwire bands moved significantly: {', '.join(tripped)} — "
+              f"the CLASSIFIER moved, not the code; do not trust the other cuts")
+    print()
+
+    print("## Pooled markers (any-frame counters; the phase-gate numbers)")
+    for m in sorted(set(base["markers"]) | set(change["markers"])):
+        a = base["markers"].get(m, {}).get("total", 0) if m in base["markers"] else 0
+        b = change["markers"].get(m, {}).get("total", 0) if m in change["markers"] else 0
+        if a == 0 and b == 0:
+            continue
+        print(f"- {m}")
+        print(f"    total {a:>7} -> {b:<7} cut {fmt_cut(a, b)}")
+        threads = sorted(set(base["markers"].get(m, {}).get("by_thread", {}))
+                         | set(change["markers"].get(m, {}).get("by_thread", {})),
+                         key=lambda th: -(base["markers"].get(m, {}).get("by_thread", {}).get(th, 0)))
+        for th in threads:
+            ta = base["markers"].get(m, {}).get("by_thread", {}).get(th, 0)
+            tb = change["markers"].get(m, {}).get("by_thread", {}).get(th, 0)
+            print(f"    {th:<24} {ta:>7} -> {tb:<7} cut {fmt_cut(ta, tb)}")
+    print()
+
+    print("## Per-column metrics (µs/col caveat: native sampled @20ms vs Java @10ms —"
+          " absolutes understate native, cuts are fair)")
+    for rec in (base, change):
+        cols = rec["columns"] or 1
+        us_col = rec["lss_attributed"] * SAMPLE_PERIOD_MS * 1000.0 / cols
+        alloc_col = rec["alloc_total_mb"] * 1e6 / cols
+        print(f"- {rec['arm']:<8} lss µs/col {us_col:8.1f} | alloc/col {alloc_col:9.0f} B"
+              f" | columns {rec['columns']}")
+    if base["columns"] and change["columns"]:
+        base_us = base["lss_attributed"] * SAMPLE_PERIOD_MS * 1000.0 / base["columns"]
+        change_us = change["lss_attributed"] * SAMPLE_PERIOD_MS * 1000.0 / change["columns"]
+        if base_us > 0:
+            print(f"- µs/col cut: {100 * (1 - change_us / base_us):+.1f}%"
+                  f" (count CI applies: {fmt_cut(base['lss_attributed'], change['lss_attributed'])}"
+                  f" before the column normalization)")
+        print("- top allocation movers (per-column bytes, change - base):")
+        movers = []
+        for c in set(base["alloc_by_class_mb"]) | set(change["alloc_by_class_mb"]):
+            pa = base["alloc_by_class_mb"].get(c, 0.0) * 1e6 / base["columns"]
+            pb = change["alloc_by_class_mb"].get(c, 0.0) * 1e6 / change["columns"]
+            movers.append((pb - pa, c, pa, pb))
+        movers.sort(key=lambda t: -abs(t[0]))
+        for delta, cls, pa, pb in movers[:8]:
+            print(f"    {delta:+10.0f} B/col  {cls}  ({pa:.0f} -> {pb:.0f})")
+    print()
+
+    if base["is_backfill"] or change["is_backfill"]:
+        print("## Backfill walk (deposits/s = the Phase 2 gate metric)")
+        for rec in (base, change):
+            if rec["walk_seconds"] > 0:
+                print(f"- {rec['arm']:<8} deposited {rec['deposited']} in {rec['walk_seconds']:.0f}s"
+                      f" = {rec['deposited'] / rec['walk_seconds']:.1f}/s")
+        print()
+
+    if base["disk_read"] or change["disk_read"]:
+        print("## hibw ceiling (pooled sources.disk_read / pooled window seconds)")
+        for rec in (base, change):
+            if rec["window_s"] > 0:
+                print(f"- {rec['arm']:<8} {rec['disk_read']} disk-read serves / {rec['window_s']:.0f}s"
+                      f" = {rec['disk_read'] / rec['window_s']:.1f} col/s")
+        print()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/compress_gate.sh
+++ b/scripts/compress_gate.sh
@@ -81,16 +81,35 @@ run_arm() { # <arm-label> <useCompressedColumns-value> <rep>
     rm -f "$RESULTS"/server*.json "$RESULTS"/client*.json "$RESULTS"/cpu*.jsonl \
           "$RESULTS"/*.jfr "$RESULTS"/warm-join-meta.json
     local rc=0
-    (cd "$PROJECT_ROOT" && ./scripts/benchmark.sh "$SCENARIO" "$DURATION") \
+    # BENCHMARK_CONFIG_STAGED: without it benchmark.sh's neutral-staging block (6856bcb,
+    # 2026-08-02) silently replaces the config staged above and the useCompressedColumns
+    # arm variable is INERT — PERF Phase 0 item 1 (found by the post-review blast-radius
+    # audit; this script's archived runs predate the block, so the recorded protocol-19
+    # evidence is clean).
+    (export BENCHMARK_CONFIG_STAGED=1; cd "$PROJECT_ROOT" && ./scripts/benchmark.sh "$SCENARIO" "$DURATION") \
         > "$OUT_ROOT/$STAMP/${arm}-rep${rep}.orchestrator.log" 2>&1 || rc=$?
     collect "$out"
+    # Effective-config assertion (Phase 0 item 1): the server ECHOES its effective knobs
+    # at service start (ServerConfigBase.effectiveConfigEcho, format-pinned). An ignored
+    # config key must FAIL the arm, not silently compare two identical arms. server.log
+    # is the MEASURED cycle's console (warm-join cycle A logs to server-populate.log);
+    # tail -1 keeps the latest echo if a log ever carries two boots.
+    local echo_line
+    echo_line="$(grep -o 'Effective config: .*' "$out/server.log" 2>/dev/null | tail -1 || true)"
+    local arm_valid=true
+    [[ "$echo_line" == *"useCompressedColumns=$value"* ]] || arm_valid=false
     cat > "$out/meta.json" <<EOF
 {"mode":"$MODE","arm":"$arm","useCompressedColumns":$value,"lodStore":"$STORE_MODE",
  "rep":$rep,"duration_s":$DURATION,
+ "config_echo":"$echo_line","arm_valid":$arm_valid,
  "ref":"$(git -C "$PROJECT_ROOT" rev-parse --short HEAD)","rc":$rc,"finished":"$(date -Is)"}
 EOF
     if [[ $rc -ne 0 ]]; then
         log "arm $arm rep$rep FAILED (rc=$rc)"
+        return 1
+    fi
+    if [[ "$arm_valid" != "true" ]]; then
+        log "arm $arm rep$rep INVALID: config echo '${echo_line:-<missing>}' does not carry useCompressedColumns=$value"
         return 1
     fi
 }

--- a/scripts/profile_disk_read.sh
+++ b/scripts/profile_disk_read.sh
@@ -122,7 +122,10 @@ cmd_run() {
         base|change)
             [[ -n "$BASE_REF" ]] || die "arm '$arm' needs PROFILE_BASE_REF (ref-vs-ref mode)"
             root="$(root_for_arm "$arm")"
-            [[ "$arm" == "change" || -d "$root" ]] || die "worktree $root missing — run setup first"
+            # ensure_base_worktree is idempotent and REPOINTS a leftover worktree from a
+            # previous session's ref — without this a standalone `run base` measures
+            # whatever the stale worktree happens to hold (B0 review N7).
+            [[ "$arm" == "change" ]] || ensure_base_worktree
             ;;
         *) die "unknown arm '$arm' (want vanilla | c2me | base | change)" ;;
     esac
@@ -245,6 +248,9 @@ cmd_matrix() {
         cmd_setup
     fi
     log "Matrix: ${reps} reps x {$arm_a, $arm_b} ABBA, duration=${duration}s, R=$lod_r -> $OUT_ROOT/$RUN_STAMP"
+    if (( reps % 2 != 0 )); then
+        log "NOTE: odd rep count leaves residual first-position bias after ABBA — prefer even reps"
+    fi
     for rep in $(seq 1 "$reps"); do
         # ABBA: odd reps run A,B; even reps run B,A — cancels first-position bias.
         local first="$arm_a" second="$arm_b"

--- a/scripts/profile_disk_read.sh
+++ b/scripts/profile_disk_read.sh
@@ -1,25 +1,39 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Disk-read serving profile harness: vanilla chunk IO vs C2ME (chunk-IO-overhaul fallback).
+# Disk-read serving profile harness. Two arm modes over benchmark.sh's no-cache scenario
+# (same pre-generated base world, generation disabled, cold client cache, server JFR via
+# runBenchmarkServer + the external 1 Hz CPU/wire sampler):
 #
-# Both arms run the SAME code and the SAME pre-generated base world through benchmark.sh's
-# no-cache scenario (generation disabled, cold client cache), with the server JFR recording
-# (wired into the runBenchmarkServer task) plus the external 1 Hz CPU/wire sampler. The only
-# variable is C2ME on the server runtime (-Pbenchmark.c2me=true via BENCHMARK_SERVER_GRADLE_ARGS):
-#   vanilla  LSS reads at IOWorker BACKGROUND priority (useBackgroundReadPriority path)
-#   c2me     C2ME's chunkio rewrite nulls the vanilla IOWorker -> LSS latches the
-#            incompatible fallback: chunkMap.read + AdaptiveReadThrottle
+#   IO-path A/B (default)     arm = vanilla | c2me — same tree, the only variable is C2ME
+#                             on the server runtime (-Pbenchmark.c2me=true):
+#                               vanilla  LSS reads at IOWorker BACKGROUND priority
+#                               c2me     C2ME nulls the vanilla IOWorker -> LSS latches the
+#                                        incompatible fallback: chunkMap.read + throttle
+#   Ref-vs-ref (PERF Phase 0) arm = base | change — set PROFILE_BASE_REF=<git-ref>:
+#                             `change` runs THIS tree, `base` runs a detached worktree at
+#                             the ref (benchmark_compare.sh pattern: worktree + prebuild +
+#                             rsync'd base world). Both refs must carry the effective-config
+#                             echo (>= the Phase 0 commit) or the arm fails its echo check.
+#
+# The matrix interleaves arms ABBA across reps (odd reps A,B; even reps B,A) — a fixed
+# order is a systematic first-position bias (page cache, JIT, gradle daemon warmth).
 #
 # Usage:
-#   profile_disk_read.sh run <arm> <rep> <duration> <R>   # arm = vanilla | c2me
-#   profile_disk_read.sh matrix <reps> <duration> <R>     # interleaved: vanilla,c2me per rep
+#   profile_disk_read.sh run <arm> <rep> <duration> <R>   # one arm run
+#   profile_disk_read.sh matrix <reps> <duration> <R>     # ABBA-interleaved matrix
+#   profile_disk_read.sh setup                            # ref mode: worktree + prebuild
 #
 # Results: profile-results/<stamp>/<arm>-rep<N>/{server.json,client.json,server-benchmark.jfr,
 #          client-benchmark.jfr,cpu.jsonl,orchestrator.log,server.log,meta.json}
 
 MAIN_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 OUT_ROOT="${OUT_ROOT:-$MAIN_ROOT/profile-results}"
+
+# Ref-vs-ref arm mode (PERF Phase 0 item 2). PROFILE_BASE_WT default deliberately
+# OUTSIDE the repo (a worktree inside would be swept into release_check globs).
+BASE_REF="${PROFILE_BASE_REF:-}"
+BASE_WT="${PROFILE_BASE_WT:-$(dirname "$MAIN_ROOT")/lss-profile-base}"
 
 log() { echo "[profile] $*"; }
 die() { echo "[profile] ERROR: $*" >&2; exit 1; }
@@ -66,13 +80,51 @@ stage_client_config() { # <path>
 EOF
 }
 
+root_for_arm() {
+    case "$1" in
+        base) echo "$BASE_WT" ;;
+        *)    echo "$MAIN_ROOT" ;;
+    esac
+}
+
+prebuild() { # <root>
+    log "Prebuilding $1 ..."
+    (cd "$1" && ./gradlew :fabric:build -x test -x runGameTest -x runClientGameTest --quiet)
+}
+
+ensure_base_worktree() {
+    [[ -n "$BASE_REF" ]] || die "arm base/change needs PROFILE_BASE_REF=<git-ref>"
+    local want
+    want="$(git -C "$MAIN_ROOT" rev-parse "${BASE_REF}^{commit}")" \
+        || die "PROFILE_BASE_REF '$BASE_REF' does not resolve"
+    if [[ ! -d "$BASE_WT" ]]; then
+        log "Creating worktree $BASE_WT @ $BASE_REF"
+        git -C "$MAIN_ROOT" worktree add --detach "$BASE_WT" "$BASE_REF"
+    elif [[ "$(git -C "$BASE_WT" rev-parse HEAD)" != "$want" ]]; then
+        log "Repointing worktree $BASE_WT -> $BASE_REF"
+        git -C "$BASE_WT" checkout --detach "$want"
+    fi
+}
+
+cmd_setup() {
+    ensure_base_worktree
+    prebuild "$MAIN_ROOT"
+    prebuild "$BASE_WT"
+    log "Setup complete: base=$BASE_WT@$BASE_REF change=$MAIN_ROOT (working tree)"
+}
+
 cmd_run() {
     local arm="${1:?arm}" rep="${2:?rep}" duration="${3:?duration}" LOD_R="${4:?lod-distance}"
-    local extra_args=""
+    local extra_args="" root="$MAIN_ROOT"
     case "$arm" in
         vanilla) ;;
         c2me) extra_args="-Pbenchmark.c2me=true" ;;
-        *) die "unknown arm '$arm' (want vanilla | c2me)" ;;
+        base|change)
+            [[ -n "$BASE_REF" ]] || die "arm '$arm' needs PROFILE_BASE_REF (ref-vs-ref mode)"
+            root="$(root_for_arm "$arm")"
+            [[ "$arm" == "change" || -d "$root" ]] || die "worktree $root missing — run setup first"
+            ;;
+        *) die "unknown arm '$arm' (want vanilla | c2me | base | change)" ;;
     esac
 
     [[ -d "$MAIN_ROOT/benchmark-worlds/base/world" ]] || die "no base world — build one first"
@@ -80,25 +132,32 @@ cmd_run() {
         die "port 25565 is in use — refusing to start (soak/benchmark conflict guard)"
     fi
 
+    # Identical base world for every arm: sync main's into the worktree.
+    if [[ "$root" != "$MAIN_ROOT" ]]; then
+        mkdir -p "$root/benchmark-worlds/base"
+        rsync -a --delete "$MAIN_ROOT/benchmark-worlds/base/world/" \
+            "$root/benchmark-worlds/base/world/"
+    fi
+
     RUN_OUT="$OUT_ROOT/$RUN_STAMP/${arm}-rep${rep}"
     mkdir -p "$RUN_OUT"
-    log "=== RUN $arm rep$rep (duration=${duration}s, R=$LOD_R) ==="
+    log "=== RUN $arm rep$rep (root=$root, duration=${duration}s, R=$LOD_R) ==="
 
     # Cold client cache every run + staged configs (gen OFF: pure disk-read + serialization).
-    local srv_cfg_dir="$MAIN_ROOT/fabric/build/run/benchmark-server/config"
-    local cli_cfg_dir="$MAIN_ROOT/fabric/build/run/benchmark-client/config"
+    local srv_cfg_dir="$root/fabric/build/run/benchmark-server/config"
+    local cli_cfg_dir="$root/fabric/build/run/benchmark-client/config"
     mkdir -p "$srv_cfg_dir" "$cli_cfg_dir"
     rm -rf "$cli_cfg_dir/lss/cache"
     stage_server_config "$srv_cfg_dir/lss-server-config.json"
     stage_client_config "$cli_cfg_dir/lss-client-config.json"
 
     # Stale-artifact guard: a crashed run must yield MISSING files, not the previous run's.
-    rm -f "$MAIN_ROOT/benchmark-results/server.json" "$MAIN_ROOT/benchmark-results/client.json" \
-          "$MAIN_ROOT/benchmark-results/"*.jfr \
-          "$MAIN_ROOT/fabric/build/run/benchmark-server/benchmark-results/server.json" \
-          "$MAIN_ROOT/fabric/build/run/benchmark-client/benchmark-results/client.json" \
-          "$MAIN_ROOT/fabric/build/run/benchmark-server/server-benchmark.jfr" \
-          "$MAIN_ROOT/fabric/build/run/benchmark-client/client-benchmark.jfr"
+    rm -f "$root/benchmark-results/server.json" "$root/benchmark-results/client.json" \
+          "$root/benchmark-results/"*.jfr \
+          "$root/fabric/build/run/benchmark-server/benchmark-results/server.json" \
+          "$root/fabric/build/run/benchmark-client/benchmark-results/client.json" \
+          "$root/fabric/build/run/benchmark-server/server-benchmark.jfr" \
+          "$root/fabric/build/run/benchmark-client/client-benchmark.jfr"
 
     "$MAIN_ROOT/scripts/lib/proc_sampler.sh" "$RUN_OUT/cpu.jsonl" $((duration + 420)) &
     local sampler_pid=$!
@@ -108,7 +167,7 @@ cmd_run() {
     # 2026-08-02) silently replaces the config staged above and every PROFILE_* knob is
     # inert — found 2026-08-06 (this round's F1 ran shipped defaults; see the findings
     # doc's erratum). store_gate.sh/benchmark_compare.sh always exported it.
-    (export BENCHMARK_CONFIG_STAGED=1; cd "$MAIN_ROOT" && BENCHMARK_SERVER_GRADLE_ARGS="$extra_args" \
+    (export BENCHMARK_CONFIG_STAGED=1; cd "$root" && BENCHMARK_SERVER_GRADLE_ARGS="$extra_args" \
         ./scripts/benchmark.sh no-cache "$duration") \
         > "$RUN_OUT/orchestrator.log" 2>&1 || rc=$?
 
@@ -117,30 +176,48 @@ cmd_run() {
 
     for f in server.json client.json server.log client.log \
              server-benchmark.jfr client-benchmark.jfr; do
-        [[ -f "$MAIN_ROOT/benchmark-results/$f" ]] && cp "$MAIN_ROOT/benchmark-results/$f" "$RUN_OUT/"
+        [[ -f "$root/benchmark-results/$f" ]] && cp "$root/benchmark-results/$f" "$RUN_OUT/"
     done
 
-    # A/B validity: the c2me arm must have latched the incompatible fallback (warn present),
-    # the vanilla arm must not. Recorded, and a mismatch fails the run.
+    # A/B validity 1 (io-path mode): the c2me arm must have latched the incompatible
+    # fallback (warn present), every other arm must not. Ref arms run vanilla IO.
     local warn="absent"
     if grep -q 'Background-priority disk reads unavailable' "$RUN_OUT/server.log" 2>/dev/null; then
         warn="present"
     fi
     local warn_ok=true
-    { [[ "$arm" == "c2me" && "$warn" == "absent" ]] || [[ "$arm" == "vanilla" && "$warn" == "present" ]]; } \
-        && warn_ok=false
+    if [[ "$arm" == "c2me" ]]; then
+        [[ "$warn" == "present" ]] || warn_ok=false
+    else
+        [[ "$warn" == "absent" ]] || warn_ok=false
+    fi
+
+    # A/B validity 2 (Phase 0 item 1): the server's effective-config echo must carry the
+    # staged knobs — an ignored key must FAIL the arm, not compare two identical arms.
+    # Requires both refs >= the echo commit in ref-vs-ref mode.
+    local echo_line
+    echo_line="$(grep -o 'Effective config: .*' "$RUN_OUT/server.log" 2>/dev/null | tail -1 || true)"
+    local echo_ok=true
+    [[ "$echo_line" == *"useNbtTranscode=${PROFILE_NBT_TRANSCODE:-true}"* ]] || echo_ok=false
+    [[ "$echo_line" == *"diskReaderThreads=5"* ]] || echo_ok=false
+
+    local arm_valid=true
+    { [[ "$warn_ok" == "true" ]] && [[ "$echo_ok" == "true" ]]; } || arm_valid=false
 
     cat > "$RUN_OUT/meta.json" <<EOF
 {
   "arm": "$arm",
   "rep": $rep,
-  "ref": "$(git -C "$MAIN_ROOT" rev-parse --short HEAD)",
+  "ref": "$(git -C "$root" rev-parse --short HEAD)",
+  "worktree_dirty": $(if [[ -n "$(git -C "$root" status --porcelain 2>/dev/null)" ]]; then echo true; else echo false; fi),
+  "base_ref": "${BASE_REF:-}",
   "duration_s": $duration,
   "lod_distance": $LOD_R,
   "bw_per_player": ${PROFILE_BW_PER_PLAYER:-20971520},
   "nbt_transcode": ${PROFILE_NBT_TRANSCODE:-true},
   "fallback_warn": "$warn",
-  "arm_valid": $warn_ok,
+  "config_echo": "$echo_line",
+  "arm_valid": $arm_valid,
   "orchestrator_rc": $rc,
   "finished": "$(date -Is)"
 }
@@ -153,14 +230,26 @@ EOF
         log "run $arm rep$rep INVALID ARM: fallback warn $warn for arm $arm"
         return 1
     fi
+    if [[ "$echo_ok" != "true" ]]; then
+        log "run $arm rep$rep INVALID ARM: config echo '${echo_line:-<missing>}' does not carry the staged knobs"
+        return 1
+    fi
     log "run $arm rep$rep done -> $RUN_OUT"
 }
 
 cmd_matrix() {
     local reps="${1:?reps}" duration="${2:?duration}" lod_r="${3:?lod-distance}"
-    log "Matrix: ${reps} reps x {vanilla, c2me}, duration=${duration}s, R=$lod_r -> $OUT_ROOT/$RUN_STAMP"
+    local arm_a="vanilla" arm_b="c2me"
+    if [[ -n "$BASE_REF" ]]; then
+        arm_a="base"; arm_b="change"
+        cmd_setup
+    fi
+    log "Matrix: ${reps} reps x {$arm_a, $arm_b} ABBA, duration=${duration}s, R=$lod_r -> $OUT_ROOT/$RUN_STAMP"
     for rep in $(seq 1 "$reps"); do
-        for arm in vanilla c2me; do
+        # ABBA: odd reps run A,B; even reps run B,A — cancels first-position bias.
+        local first="$arm_a" second="$arm_b"
+        if (( rep % 2 == 0 )); then first="$arm_b"; second="$arm_a"; fi
+        for arm in "$first" "$second"; do
             cmd_run "$arm" "$rep" "$duration" "$lod_r"
             sleep 15   # settle: gradle daemon / page cache quiesce between runs
         done
@@ -175,5 +264,6 @@ RUN_STAMP="${RUN_STAMP:-$(date +%Y%m%d-%H%M%S)}"
 case "$CMD" in
     run)    cmd_run "$@" ;;
     matrix) cmd_matrix "$@" ;;
-    *) sed -n '3,20p' "$0"; exit 1 ;;
+    setup)  cmd_setup ;;
+    *) sed -n '3,29p' "$0"; exit 1 ;;
 esac


### PR DESCRIPTION
Stage B0 of the v0.10.0 program (PERF round Phase 0, docs/planning/perf-round-2026-08-06-implementation-plan.md) — the measurement tooling every B-phase gate reads, plus the A/A control run gating B1.

### What lands

1. **Effective-config echo** — `ServerConfigBase.effectiveConfigEcho`, one INFO line at service start on both platforms echoing the RESOLVED knobs (`useNbtTranscode`, resolved `diskReaderThreads`, LIVE post-probe `useCompressedColumns`). Script-consumed contract: format exact-pinned in both config suites, call-site wiring source-regex-pinned in `ChannelAccessorContractTest`. `profile_disk_read.sh` / `compress_gate.sh` / `backfill_profile.sh` grep it into each run's `meta.json` and fail the arm when a staged knob doesn't appear — an ignored key can no longer silently compare two identical arms. `compress_gate.sh` also gains the missing `BENCHMARK_CONFIG_STAGED=1`.
2. **Ref-vs-ref arms** in `profile_disk_read.sh` AND `backfill_profile.sh` (`base`/`change` behind `PROFILE_BASE_REF`, worktree + prebuild + rsync'd base world, ABBA-interleaved matrix, stale-worktree repoint, `worktree_dirty` honesty flag).
3. **`backfill_profile.sh`** (new) — committed form of the ad-hoc F3 runner: server-only walk profiling, `StoreBackfill` start/terminal lines parsed into `meta.json` (walk seconds + deposit counts = the Phase 2 deposits/s gate); incomplete walks invalidate the arm. Both log-line shapes are now test-pinned (`StoreBackfillTest`).
4. **`analyze_profile_jfr.py`** — `--window full|walk|T0:T1`, per-thread×band×has-LSS-frame counters, per-marker×thread counters (`PROFILE_MARKERS` overridable), persisted alloc-by-class, `DISK_PATH_MARKERS` extended (verified no-op on all archived profiles — zero samples reclassify), stale-artifact unlink before re-analysis.
5. **`compare_profile.py`** (new) — pooled band/marker/per-thread-LSS cuts with Poisson CIs, µs/col + per-column allocation movers, hibw ceiling, backfill deposits/s, column-parity guard, window-mode homogeneity check, `--skip-reps`, 28-case `--selftest` wired into build.yml (alongside `check_move_trace.py --selftest`, which A1 left un-wired).

### Review + A/A

Single-Opus three-lens review (per program §6.2): 4 MAJORs + 11 minors, all fixed in the second commit — headline: the echo printed the *requested* compression value before the zstd probe (M1), and the classifier tripwire fired on code-identical arms because the save/probe-correlated bands are 5–20× over-dispersed vs Poisson (calibrated by the A/A; tripwire now t-tests per-rep rates, selftest-pinned with the real A/A data).

Validation: Tier 1 Fabric+Paper + Tier 2 green; backfill smoke reproduces F3 exactly (45,589 deposits in 55 s = 828.9/s); **A/A control PASS** (3+3×150 s ABBA, both arms @ 357782f — column parity 0.03%, hibw 555.6 vs 545.2 col/s, steady serve-path metrics quiet). Full numbers + the noise-floor calibration in the progress doc's measurement ledger.

Note: the Phase-0 `profile_disk_read.sh` staging fix itself pre-landed on PR #88 (recorded there and in the progress doc).

🤖 Generated with [Claude Code](https://claude.com/claude-code)