### PR TITLE
B2: R4 contentHash → CRC32C + interim store schema v4 (v0.10.0 stage B2)

### DIFF
--- a/common/src/main/java/dev/vox/lss/common/store/LodStoreService.java
+++ b/common/src/main/java/dev/vox/lss/common/store/LodStoreService.java
@@ -48,17 +48,31 @@ public interface LodStoreService {
      *  {@code usize == 0} = all-air ({@code frame} is empty). */
     record FrameHit(byte[] frame, int usize, long columnTimestamp) {}
 
-    /** The store's content hash (FNV-1a 64): {@code chash} over raw bytes, {@code fhash}
-     *  over the compressed frame. ONE canonical implementation — the frame-reuse deposit
-     *  computes both on the processing thread and the store validates against them, so
-     *  the function must be shared, not twinned. */
+    /** The store's content hash (CRC32C since schema v4, zero-extended into the 64-bit
+     *  hash columns): {@code chash} over raw bytes, {@code fhash} over the compressed
+     *  frame. ONE canonical implementation — the frame-reuse deposit computes both on
+     *  the processing thread and the store validates against them, so the function must
+     *  be shared, not twinned.
+     *
+     *  <p>CRC32C replaced FNV-1a 64 in the perf round (Phase 2 / R4): the serial byte
+     *  loop was ~28% of the SQLite batcher thread under deposit load, and CRC32C runs
+     *  as a hardware intrinsic. This is CORRUPTION DETECTION ONLY — never an
+     *  identity/dedup key, never crosses a jar boundary; detection strength drops
+     *  2^-64 to 2^-32 per corrupted row on DERIVED data whose worst case is one wrong
+     *  LOD column the purge ladder then deletes. {@code usize == 0} short-circuits
+     *  before any hash compare, so the CRC-of-empty degenerate value is never
+     *  consulted. ({@code DirtyContentFilter.fnv1a64} is a separate function with its
+     *  own 0-sentinel and stays FNV.)
+     *
+     *  <p><b>{@code new CRC32C()} per call — never a static field, never a
+     *  ThreadLocal:</b> the instance is mutable and non-thread-safe, and this is called
+     *  from three thread families (batcher, reader pool, processing thread); a shared
+     *  instance produces wrong hashes that drive the row-poison purge into deleting
+     *  good rows. The cost is the update intrinsic, not the allocation. */
     static long contentHash(byte[] data) {
-        long hash = 0xcbf29ce484222325L;
-        for (byte b : data) {
-            hash ^= (b & 0xFF);
-            hash *= 0x100000001b3L;
-        }
-        return hash;
+        var crc = new java.util.zip.CRC32C();
+        crc.update(data, 0, data.length);
+        return crc.getValue();
     }
 
     /** The mode this store was built for (memory tier only vs memory+disk). */

--- a/common/src/main/java/dev/vox/lss/common/store/LodStoreService.java
+++ b/common/src/main/java/dev/vox/lss/common/store/LodStoreService.java
@@ -75,6 +75,20 @@ public interface LodStoreService {
         return crc.getValue();
     }
 
+    /** FNV-1a 64 — the schema-3 / {@code wirefmt = 19} row validator, RENAMED AND KEPT
+     *  (mega plan R-1) rather than deleted: C4's lazy migration dispatches per-row hash
+     *  validation on the {@code wirefmt} column, and legacy rows validate against THIS
+     *  function. Not called between B2 and C4 (dev-window builds drop-and-rebuild via
+     *  the schema bump instead); deleting it "as dead" re-introduces it wrong at C4. */
+    static long legacyContentHashFnv(byte[] data) {
+        long hash = 0xcbf29ce484222325L;
+        for (byte b : data) {
+            hash ^= (b & 0xFF);
+            hash *= 0x100000001b3L;
+        }
+        return hash;
+    }
+
     /** The mode this store was built for (memory tier only vs memory+disk). */
     LodStoreMode mode();
 

--- a/common/src/main/java/dev/vox/lss/common/store/SqliteLodStore.java
+++ b/common/src/main/java/dev/vox/lss/common/store/SqliteLodStore.java
@@ -86,6 +86,9 @@ public final class SqliteLodStore implements LodStoreService {
     // Old rows would fail every validation under the new function, so the bump
     // drops-and-rebuilds; rollback is symmetric (metaMatches is an equality compare,
     // an old jar against a v4 store also rebuilds).
+    // Interim (mega plan R-1): C4 re-specifies schema 4 (wirefmt column + per-row hash
+    // dispatch against legacyContentHashFnv); a Phase-2-era store drops there via
+    // metaMatches (meta wire 19 != 20) — no shipped v0.9.x store ever sees this shape.
     static final int SCHEMA_VERSION = 4;
     private static final String DB_FILE = "store.db";
     private static final int PAGE_SIZE = 16384;

--- a/common/src/main/java/dev/vox/lss/common/store/SqliteLodStore.java
+++ b/common/src/main/java/dev/vox/lss/common/store/SqliteLodStore.java
@@ -78,10 +78,15 @@ public final class SqliteLodStore implements LodStoreService {
 
     // v2: auto_vacuum=INCREMENTAL (must be set before table creation; the bump
     // rebuilds every v1 store once — the legal migration for derived data).
-    // 3: the fhash column (FNV-1a of the compressed blob — frame-level integrity for
-    // protocol-19 verbatim frame serving, compressed-columns plan §0.1/§3). Derived
-    // data: the bump drops-and-rebuilds; the warm store re-warms from serves/backfill.
-    static final int SCHEMA_VERSION = 3;
+    // 3: the fhash column (frame-level integrity for protocol-19 verbatim frame
+    // serving, compressed-columns plan §0.1/§3). Derived data: the bump
+    // drops-and-rebuilds; the warm store re-warms from serves/backfill.
+    // 4: chash/fhash switch FNV-1a 64 -> CRC32C zero-extended (perf round Phase 2/R4 —
+    // the byte loop was ~28% of the batcher thread; see LodStoreService.contentHash).
+    // Old rows would fail every validation under the new function, so the bump
+    // drops-and-rebuilds; rollback is symmetric (metaMatches is an equality compare,
+    // an old jar against a v4 store also rebuilds).
+    static final int SCHEMA_VERSION = 4;
     private static final String DB_FILE = "store.db";
     private static final int PAGE_SIZE = 16384;
     private static final int WRITE_TXN_ROWS = 64;
@@ -473,7 +478,7 @@ public final class SqliteLodStore implements LodStoreService {
                 }
                 byte[] blob = rs.getBytes(4);
                 byte[] raw = this.codec.decompress(blob, usize);
-                if (raw.length != usize || fnv1a(raw) != chash) {
+                if (raw.length != usize || contentHash(raw) != chash) {
                     throw new IllegalStateException("row integrity failure at " + packed
                             + " (usize/chash mismatch)");
                 }
@@ -532,7 +537,7 @@ public final class SqliteLodStore implements LodStoreService {
                             + " (usize " + usize + " out of bounds)");
                 }
                 byte[] blob = rs.getBytes(4);
-                if (fnv1a(blob) != fhash
+                if (contentHash(blob) != fhash
                         || this.codec.declaredContentSize(blob) != usize) {
                     throw new IllegalStateException("row integrity failure at " + packed
                             + " (fhash/declared-size mismatch)");
@@ -1158,8 +1163,8 @@ public final class SqliteLodStore implements LodStoreService {
         } else {
             blob = dep.bytes().length == 0 ? EMPTY : this.codec.compress(dep.bytes());
             usize = dep.bytes().length;
-            chash = fnv1a(dep.bytes());
-            fhash = fnv1a(blob);
+            chash = contentHash(dep.bytes());
+            fhash = contentHash(blob);
         }
         // Latest-wins by STORED ts in ONE statement: the conditional upsert replaces the
         // old SELECT-then-INSERT pair (the cold-path gate measured per-deposit cost —
@@ -2044,7 +2049,7 @@ public final class SqliteLodStore implements LodStoreService {
 
     /** Delegates to the ONE canonical hash (LodStoreService.contentHash) — the
      *  frame-reuse deposit computes chash/fhash on the processing thread against it. */
-    private static long fnv1a(byte[] data) {
+    private static long contentHash(byte[] data) {
         return LodStoreService.contentHash(data);
     }
 }

--- a/docs/planning/v0.10.0-progress.md
+++ b/docs/planning/v0.10.0-progress.md
@@ -275,6 +275,25 @@ the mega plan at the overridden text — never a silent divergence.
   existing R1-review verification block below the delete loop throws on any
   surviving file; no change.
 
+- **2026-08-07 (B3 pre-implementation recon — 26.2 bytecode facts, verified via javap
+  + Vineflower on the merged-deobf jar)**: everything Phase 3's design assumes is
+  present as assumed. `RegionFileStorage.getRegionFile(ChunkPos)` private,
+  never-null-creates-on-demand (the `@Invoker` target). `RegionFile` private members
+  for the raw-read mixin to `@Shadow`: `getOffset(ChunkPos)`, `file` (FileChannel),
+  static `isExternalStreamChunk(byte)` / `getExternalChunkVersion(byte)`,
+  `getExternalChunkPath(ChunkPos)`; `getChunkDataInputStream` is `synchronized` (the
+  raw read must be too) and its shape decompiles exactly as the plan's three-branch
+  description: offset-0 → null, truncated header (<5) → null, length==0 → null,
+  external flag → `.mcc` via `createExternalChunkInputStream` (not-a-regular-file →
+  null), truncated/negative stream → null, else `createChunkInputStream` which
+  handles `VERSION_CUSTOM` (readUTF the id, log, null), `fromId==null` (log, null),
+  else `new DataInputStream(version.wrap(stream))`. **`RegionFileVersion` is fully
+  public incl. `fromId(int)` and `wrap(InputStream)` — the pool-side reconstruction
+  needs NO mixin**; only the two fetch-side mixins (storage invoker + RegionFile raw
+  read) are needed. Decompiled source cached at scratchpad `mc-region/out/` this
+  session (regenerate: unzip the class from the merged-deobf jar + Vineflower 1.12.0
+  from the gradle cache).
+
 ## Measurement ledger
 
 - **2026-08-07 — B2 (R4 CRC32C) gate session: ALL GATES PASS. Box exclusive**

--- a/docs/planning/v0.10.0-progress.md
+++ b/docs/planning/v0.10.0-progress.md
@@ -236,8 +236,8 @@ the mega plan at the overridden text — never a silent divergence.
   removed from DEFAULT_MARKERS (dead class). The F6/F7 gate-reading guidance did
   its job: the $Key term made the verdict unambiguous in one A/B.
 
-- **2026-08-07 (B2 implementation decisions, perf plan Phase 2 / R4)**: lands exactly
-  as specified — `LodStoreService.contentHash` FNV-1a→CRC32C (`new CRC32C()` per
+- **2026-08-07 (B2 implementation decisions, perf plan Phase 2 / R4)**: lands as
+  specified — `LodStoreService.contentHash` FNV-1a→CRC32C (`new CRC32C()` per
   call, never shared — the three-thread-family constraint is in the javadoc), zero-
   extended into the 64-bit columns, `SCHEMA_VERSION` 3→4 with the history line and
   rollback-symmetry note, the `fnv1a` wrapper renamed `contentHash` (4 call sites),
@@ -254,6 +254,26 @@ the mega plan at the overridden text — never a silent divergence.
   A1/A2 live restart is still pending on the expired panel token; if the token
   arrives after B2 merges, the restart is still safe (the staged jar is v0.9.1-era,
   pre-schema-4) but no NEW builds may be deployed.
+
+- **2026-08-07 (B2 review round, single grouped Opus reviewer — all three lenses)**:
+  0 MAJORs + 6 minors, all addressed same-day. **F1 was a caught governing-plan
+  divergence**: the first commit DELETED the FNV body while mega plan R-1 requires it
+  "renamed but kept" as C4's `wirefmt = 19` legacy-row validator — restored as
+  `legacyContentHashFnv` with the C4-pointer javadoc (the initial "exactly as
+  specified" decisions text was corrected; the reviewer's exhaustive verification of
+  the four-call-site audit, the untouched FNV domains, `CRC32C.getValue()` bytecode
+  unsignedness, and the chash+1 mismatch-by-range argument are in the review
+  record). **F5** closed the substantive pin gap: every prior hash assertion was
+  self-referential, so a silent revert to FNV that kept schema 4 would red nothing
+  while arming the C4 landmine — `contentHashIsCrc32cZeroExtended` now pins RFC 3720
+  B.4 vectors incl. the bit-31 zero-extension case, plus the legacy FNV offset
+  basis. **F4**: the schema-drift test now proves the rebuild fires ONCE (third
+  clean open keeps the v4 deposit). **F2**: the release-notes item carries the
+  REWRITE-AT-C4 marker (shipped upgrades migrate lazily; the rebuild text is
+  dev-window/drift-only). **F3**: the interim-schema line in the `4:` history
+  comment + the PR-body paragraph. **F6** (PLAUSIBLE): already implemented — the
+  existing R1-review verification block below the delete loop throws on any
+  surviving file; no change.
 
 ## Measurement ledger
 

--- a/docs/planning/v0.10.0-progress.md
+++ b/docs/planning/v0.10.0-progress.md
@@ -13,7 +13,7 @@ the mega plan at the overridden text — never a silent divergence.
 | A2 | Transport yield (default FALSE) + tracer `yielded` field + live deploy of inert build | MERGED 2026-08-07; inert build staged over the A1 jar (same pending restart) | #88 | 3-lens round: 0 correctness MAJORs, 2 discipline MAJORs + 2 pin-gap MAJORs fixed; T1 ~1236+360, T2 66/66, T3, both selftests green |
 | B0 | PERF measurement tooling + A/A control | MERGED 2026-08-07 | #89 | single-Opus review: 4 MAJORs + 11 minors all fixed; selftest 28 + T1 both platforms + T2 + CI green; backfill smoke reproduces F3; A/A PASS + burst-band noise-floor calibration (ledger) |
 | B1 | R3 structural-identity memo key | **GATES FAILED — REVERTED** 2026-08-07; MERGED (behavior suite + tooling fix + negative-result record) | #90 | 4+4×150 s ABBA: memo marker 249→286 backfill / 258→290 serve, Key walk = the walk it replaced; plan Phase 1 verdict block + ledger; CI green |
-| B2 | R4 CRC32C + interim schema bump (dev-window semantics per R-1) | pending | — | — |
+| B2 | R4 CRC32C + interim schema bump (dev-window semantics per R-1) | gates ALL PASS 2026-08-07; PR pending | — | contentHash marker 354→0 (+100% cut vs ≥80% gate); warm/cold/save-storm/3 soaks PASS; review 0 MAJORs + 6 minors fixed (F1: legacy FNV validator restored per R-1) |
 | B3 | R1 background-read split | pending | — | — |
 | B4 | R2 selective NBT parse | pending | — | — |
 | B5 | Round-acceptance closing A/B (merge gate for C1) | pending | — | — |
@@ -276,6 +276,30 @@ the mega plan at the overridden text — never a silent divergence.
   surviving file; no change.
 
 ## Measurement ledger
+
+- **2026-08-07 — B2 (R4 CRC32C) gate session: ALL GATES PASS. Box exclusive**
+  (`pgrep` clean before each block; tree frozen during the ref-vs-ref A/B).
+  **Backfill ref-vs-ref A/B** (`profile-results/b2-backfill`, 4+4 reps × 150 s ABBA,
+  base=`b43610d` change=`9abb75b`, all arms valid): **`LodStoreService.contentHash`
+  marker on the batcher thread 354 → 0, cut +100.0% [+99.2, +100.0]** vs the ≥80%
+  gate — total elimination below sampling resolution (the CRC32C intrinsic);
+  independently corroborated by the `store` band's +41.6% [+35.0, +47.4] cut.
+  Deposits/s flat (844.2 → 840.4, −0.5%): the walk is pace/IO-bound, the freed CPU
+  shows in the band — the non-regression leg holds. Tripwires quiet. (The A/B ran
+  against `9abb75b`; the review-fix commit `4ecd501` adds only an uncalled legacy
+  method + tests + comments — measured-path-identical, the B0-A/A precedent.)
+  **store_gate warm** (`b2-warm`, 2 reps): GATE PASS — hit ratio 0.99, addressable
+  cut ~100%, LSS-band cut 82.5% (floor 50), §0-as-written 70% floor passed at 82.5%.
+  **store_gate cold**: first run at n=2 FAILED the per-rep majority (median +8.7%
+  inside the 10% ceiling, reps +6.0%/+11.5%) — re-run at n=4 on `4ecd501`:
+  **GATE PASS, median +6.3%, 4/4 reps within ceiling** (the n=2 red was the
+  majority-rule artifact at a tight margin, not a regression; R4 does not touch the
+  cold gate's comparison — both arms run the change ref). **store_save_storm.sh**:
+  PASS — storm-window CPU off 4.88 s → on 5.24 s (delta +0.36 s, bound +1.22 s),
+  cadence held 50.00 ms both arms. **Store soaks** (all on `4ecd501`):
+  store-second-join PASS, store-save-storm scenario PASS (+ its off arm), and
+  store_offline_edit's three chained phases PASS — 0 violations, 0 warnings across
+  every run. VERDICT: Phase 2 accepted; CRC32C + interim schema v4 sound.
 
 (one entry per A/B session: date, box-state confirmation (§2 exclusivity +
 `pgrep` clean), arms/refs, pooled numbers, verdict)

--- a/docs/planning/v0.10.0-progress.md
+++ b/docs/planning/v0.10.0-progress.md
@@ -12,7 +12,7 @@ the mega plan at the overridden text — never a silent divergence.
 | A1 | Probe-snapshot refactor + move-desync tracer + `LSS_MOVE_TRACE` rig knob + live deploy | MERGED 2026-08-07; live deploy staged, restart pending (expired panel token — see live-deploy log) | #87 | 3-lens Opus round complete, all findings fixed; T1 Fabric+Paper, T2 66/66, T3, validator selftest 34 — all green pre-PR |
 | A2 | Transport yield (default FALSE) + tracer `yielded` field + live deploy of inert build | MERGED 2026-08-07; inert build staged over the A1 jar (same pending restart) | #88 | 3-lens round: 0 correctness MAJORs, 2 discipline MAJORs + 2 pin-gap MAJORs fixed; T1 ~1236+360, T2 66/66, T3, both selftests green |
 | B0 | PERF measurement tooling + A/A control | MERGED 2026-08-07 | #89 | single-Opus review: 4 MAJORs + 11 minors all fixed; selftest 28 + T1 both platforms + T2 + CI green; backfill smoke reproduces F3; A/A PASS + burst-band noise-floor calibration (ledger) |
-| B1 | R3 structural-identity memo key | **GATES FAILED — REVERTED** 2026-08-07 (negative result; behavior suite + tooling fix land instead) | pending | 4+4×150 s ABBA: memo marker 249→286 backfill / 258→290 serve, Key walk = the walk it replaced; plan Phase 1 verdict block + ledger |
+| B1 | R3 structural-identity memo key | **GATES FAILED — REVERTED** 2026-08-07; MERGED (behavior suite + tooling fix + negative-result record) | #90 | 4+4×150 s ABBA: memo marker 249→286 backfill / 258→290 serve, Key walk = the walk it replaced; plan Phase 1 verdict block + ledger; CI green |
 | B2 | R4 CRC32C + interim schema bump (dev-window semantics per R-1) | pending | — | — |
 | B3 | R1 background-read split | pending | — | — |
 | B4 | R2 selective NBT parse | pending | — | — |
@@ -235,6 +235,25 @@ the mega plan at the overridden text — never a silent divergence.
   `base-`/`change-` — decided by meta content now), and the $Key marker lines
   removed from DEFAULT_MARKERS (dead class). The F6/F7 gate-reading guidance did
   its job: the $Key term made the verdict unambiguous in one A/B.
+
+- **2026-08-07 (B2 implementation decisions, perf plan Phase 2 / R4)**: lands exactly
+  as specified — `LodStoreService.contentHash` FNV-1a→CRC32C (`new CRC32C()` per
+  call, never shared — the three-thread-family constraint is in the javadoc), zero-
+  extended into the 64-bit columns, `SCHEMA_VERSION` 3→4 with the history line and
+  rollback-symmetry note, the `fnv1a` wrapper renamed `contentHash` (4 call sites),
+  `DirtyContentFilter.fnv1a64` and `RegistryFingerprint.fnvOver` and the soak
+  exporter's probe hash deliberately untouched (separate domains). New
+  `schemaVersionDriftDropsAndRebuildsTheStore` pin: an out-of-band meta downgrade to
+  `SCHEMA_VERSION - 1` is byte-for-byte the old-store-under-new-jar case since
+  `metaMatches` is an equality compare (first attempt failed on the meta table's
+  actual `k`/`v` column names — the corruption-test's SQLite pattern reused).
+  Release-note obligation discharged: `docs/planning/v0.10.0-release-notes-draft.md`
+  created (the established draft pattern) seeded with the R4 item + the shipped
+  A1/A2 features. **The R-1 deploy hold begins when this stage MERGES** (no live
+  Modrinth deploys until C4's final schema-4 shape lands) — noted here because the
+  A1/A2 live restart is still pending on the expired panel token; if the token
+  arrives after B2 merges, the restart is still safe (the staged jar is v0.9.1-era,
+  pre-schema-4) but no NEW builds may be deployed.
 
 ## Measurement ledger
 

--- a/docs/planning/v0.10.0-release-notes-draft.md
+++ b/docs/planning/v0.10.0-release-notes-draft.md
@@ -1,0 +1,31 @@
+# v0.10.0 release notes — DRAFT (accumulating; D1 consolidates, D2 preps the tag text)
+
+Items append here as stages merge (the established draft pattern —
+`v0.9.1-release-notes-draft.md`). Write for server admins and mod users; present
+tense; platform qualifier only when platform-specific; Folia items must mention the
+experimental status.
+
+### Performance
+
+- **Faster LOD store deposits (CRC32C integrity hashes)** — The LOD store's row
+  integrity hashes now use hardware-accelerated CRC32C instead of a byte-at-a-time
+  FNV-1a loop, which was measured at ~28% of the store's write thread during heavy
+  deposit load (backfill, fresh generation). One-time effect on upgrade: the store's
+  schema version bumps and the existing `lss-lod` store is rebuilt from scratch —
+  LOD data re-warms automatically from serves (and the background backfill where
+  enabled; a 10 GB store re-backfills in roughly 25 minutes at the default
+  500 columns/second). World data is never touched; the store is derived data.
+
+### New Features
+
+- **Movement-desync tracer (server-side, off by default)** — A diagnostic recorder
+  for the three vanilla movement-rejection paths ("moved too quickly", "moved
+  wrongly", and the silent creative-flight rejection) plus per-flight telemetry.
+  Fabric only; fully inert unless armed with `-Dlss.moveTrace=true` or the marker
+  file `config/lss-move-trace.enable`; output rotates in `logs/lss-move-trace.jsonl`.
+  `/lsslod diag` shows a `MoveTrace:` line while active.
+- **Transport yield (off by default)** — `lodYieldsToVanillaTransport`: when enabled,
+  LOD traffic pauses whenever a player's connection is backed up, so vanilla chunk
+  packets are never queued behind LOD data. Ships disabled while live evidence
+  accumulates; a starvation floor guarantees at least one LOD payload every 5 seconds
+  on a congested link.

--- a/docs/planning/v0.10.0-release-notes-draft.md
+++ b/docs/planning/v0.10.0-release-notes-draft.md
@@ -15,6 +15,9 @@ experimental status.
   LOD data re-warms automatically from serves (and the background backfill where
   enabled; a 10 GB store re-backfills in roughly 25 minutes at the default
   500 columns/second). World data is never touched; the store is derived data.
+  <!-- REWRITE AT C4 per mega plan R-1: shipped v0.9.x -> v0.10.0 upgrades migrate
+       LAZILY (ALTER + background walk) and do NOT rebuild; the rebuild text applies
+       only to dev-window builds and fingerprint/codec drift. B2 review F2. -->
 
 ### New Features
 

--- a/fabric/src/test/java/dev/vox/lss/common/store/SqliteLodStoreTest.java
+++ b/fabric/src/test/java/dev/vox/lss/common/store/SqliteLodStoreTest.java
@@ -326,6 +326,40 @@ class SqliteLodStoreTest {
         reopened.deposit(OW, p, bytes(8, 400), 200);
         assertNotNull(awaitHit(reopened, OW, p), "rebuilt store must accept deposits");
         reopened.shutdown();
+
+        // Fires ONCE (review F4): a third clean open must keep the v4 deposit — a bug
+        // that rebuilds on every open would pass everything above. (The freshness
+        // sweep keeps the row: the region header stamp is older than its src_stamp.)
+        SqliteLodStore third = open(defaultEnv());
+        assertNotNull(third.get(OW, p),
+                "the v4 deposit must survive a clean reopen — the rebuild fires exactly once");
+        third.shutdown();
+    }
+
+    /**
+     * Known-answer vectors (review F5 — RFC 3720 B.4 + the Castagnoli check value):
+     * nothing else pins that the function IS CRC32C — every other hash assertion is
+     * self-referential, so a silent revert to FNV that kept SCHEMA_VERSION = 4 would
+     * red zero tests while arming the C4 landmine (schema-4 rows stamped with FNV
+     * hashes, which C4's per-row dispatch would then purge row by row — the lazy
+     * migration silently degrading to a slow drop). The 0xC1D04330 vector has bit 31
+     * set, pinning ZERO-extension over sign-extension.
+     */
+    @Test
+    void contentHashIsCrc32cZeroExtended() {
+        assertEquals(0xE3069283L, LodStoreService.contentHash(
+                "123456789".getBytes(java.nio.charset.StandardCharsets.US_ASCII)));
+        assertEquals(0x8A9136AAL, LodStoreService.contentHash(new byte[32]));
+        byte[] ff = new byte[32];
+        java.util.Arrays.fill(ff, (byte) 0xFF);
+        assertEquals(0x62A8AB43L, LodStoreService.contentHash(ff));
+        assertEquals(0xC1D04330L, LodStoreService.contentHash(new byte[]{'a'}));
+        // Degenerate empty value — stored for all-air raw deposits, never consulted
+        // (usize == 0 short-circuits both read rungs before any hash compare).
+        assertEquals(0L, LodStoreService.contentHash(new byte[0]));
+        // The kept legacy validator (C4's wirefmt=19 dispatch) stays FNV-1a 64:
+        // FNV of empty input is the 64-bit offset basis.
+        assertEquals(0xcbf29ce484222325L, LodStoreService.legacyContentHashFnv(new byte[0]));
     }
 
     @Test

--- a/fabric/src/test/java/dev/vox/lss/common/store/SqliteLodStoreTest.java
+++ b/fabric/src/test/java/dev/vox/lss/common/store/SqliteLodStoreTest.java
@@ -296,6 +296,38 @@ class SqliteLodStoreTest {
         shifted.shutdown();
     }
 
+    /** The v3->v4 bump (R4: chash/fhash FNV-1a -> CRC32C): a store stamped with the
+     *  PREVIOUS schema version must drop-and-rebuild exactly once — old rows' hashes
+     *  would fail every validation under the new function. metaMatches is an equality
+     *  compare, so this out-of-band downgrade is byte-for-byte the "old store under a
+     *  new jar" upgrade case (and pins rollback symmetry: any mismatch rebuilds). */
+    @Test
+    void schemaVersionDriftDropsAndRebuildsTheStore() throws Exception {
+        long p = PositionUtil.packPosition(0, 2);
+        writeRegion(OW, 0, 0, Map.of(p, (int) (nowSec() - 1000)));
+        SqliteLodStore store = open(defaultEnv());
+        store.deposit(OW, p, bytes(7, 400), 100);
+        assertNotNull(awaitHit(store, OW, p));
+        store.shutdown();
+
+        var ds = new org.sqlite.SQLiteDataSource();
+        ds.setUrl("jdbc:sqlite:" + storeDir().resolve("store.db"));
+        try (Connection c = ds.getConnection(); Statement st = c.createStatement()) {
+            st.execute("PRAGMA busy_timeout=3000");
+            st.execute("UPDATE meta SET v='" + (SqliteLodStore.SCHEMA_VERSION - 1)
+                    + "' WHERE k='schema_version'");
+        }
+
+        SqliteLodStore reopened = open(defaultEnv());
+        assertNull(reopened.get(OW, p),
+                "rows hashed under the old schema must not survive the version bump");
+        assertEquals(0, reopened.diagnostics().getErrors(), "drop-and-rebuild is not an error");
+        // ...and the rebuilt store is fully functional under the new hash.
+        reopened.deposit(OW, p, bytes(8, 400), 200);
+        assertNotNull(awaitHit(reopened, OW, p), "rebuilt store must accept deposits");
+        reopened.shutdown();
+    }
+
     @Test
     void corruptDbFileIsDroppedAndRecreated() throws Exception {
         Files.createDirectories(storeDir());


### PR DESCRIPTION
Stage B2 of the v0.10.0 program (PERF round Phase 2 / R4): the LOD store's row-integrity hashes (`chash`/`fhash`) switch from a byte-at-a-time FNV-1a loop — measured at ~28% of the SQLite batcher thread under deposit load — to hardware-intrinsic CRC32C, zero-extended into the existing 64-bit columns. `SCHEMA_VERSION` bumps 3→4 (drop-and-rebuild, the derived-data policy; rollback symmetric via `metaMatches` equality).

**Interim-schema note (mega plan R-1, required in this PR text):** this schema 4 is a *dev-window interim* — C4 re-specifies schema 4 with the `wirefmt` column and per-row hash dispatch (legacy rows validating against the kept `legacyContentHashFnv`), and a Phase-2-era store correctly drops there via `metaMatches` (meta wire 19 ≠ 20). No shipped v0.9.x store ever sees this interim shape; shipped upgrades get C4's lazy migration, not a rebuild. **The R-1 live-deploy hold starts at this merge**: no Modrinth deploys until C4's final schema-4 shape lands.

### Gate results (all PASS — full numbers in the progress doc ledger)

- **Backfill ref-vs-ref A/B** (4+4×150 s ABBA): `contentHash` marker on the batcher thread **354 → 0, cut +100.0% [+99.2, +100.0]** vs the ≥80% gate; `store` band +41.6% corroborates; deposits/s flat (the walk is pace-bound — non-regression leg holds).
- **store_gate warm**: PASS (band cut 82.5%). **store_gate cold**: PASS at n=4 (median +6.3%, 4/4 within the 10% ceiling; the initial n=2 red was the per-rep majority rule at a tight margin — median was inside the ceiling both times).
- **store_save_storm**: PASS (+0.36 s vs +1.22 s bound, cadence held both arms).
- **Store soaks**: store-second-join, store-save-storm (+off arm), and store_offline_edit's three chained phases — 0 violations, 0 warnings.

### Review (single grouped Opus, three lenses): 0 MAJORs + 6 minors, all fixed

Headline F1: the first commit deleted the FNV body, diverging from mega-plan R-1's "renamed but kept" (C4's legacy-row validator) — restored as `legacyContentHashFnv`. F5 closed the real pin gap: all prior hash assertions were self-referential, so a silent FNV revert keeping schema 4 would red nothing while arming the C4 landmine; `contentHashIsCrc32cZeroExtended` pins RFC 3720 B.4 vectors including the bit-31 zero-extension case. Also: rebuild-fires-once leg, REWRITE-AT-C4 marker on the release-notes item, interim-schema history comment. The reviewer's exhaustive audit (four call sites exactly; `DirtyContentFilter`/`RegistryFingerprint`/soak-exporter FNVs untouched and domain-separate; `CRC32C.getValue()` unsignedness from bytecode) is in the review record.

Validation: full T1 both platforms + T2 green; `schemaVersionDriftDropsAndRebuildsTheStore` covers the v3→v4 path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)