### PR TITLE
feat(xver): C0 — IdentityCodec, registry identity tables, WireSectionCursor + settling measurement

### DIFF
--- a/common/src/main/java/dev/vox/lss/common/wire/IdentityCodec.java
+++ b/common/src/main/java/dev/vox/lss/common/wire/IdentityCodec.java
@@ -44,6 +44,11 @@ public final class IdentityCodec {
             var sb = new StringBuilder(name).append('[');
             boolean first = true;
             for (var e : sorted.entrySet()) {
+                if (e.getKey() == null || e.getValue() == null) {
+                    // StringBuilder would render a null as the literal "null", which
+                    // then VALIDATES — a silent-corruption path in a fail-loud class.
+                    throw new IllegalArgumentException("null property key/value for " + name);
+                }
                 if (!first) {
                     sb.append(',');
                 }

--- a/common/src/main/java/dev/vox/lss/common/wire/IdentityCodec.java
+++ b/common/src/main/java/dev/vox/lss/common/wire/IdentityCodec.java
@@ -1,0 +1,145 @@
+package dev.vox.lss.common.wire;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+
+/**
+ * The protocol-20 canonical identity form (cross-version-identity-encoding-plan §2.1):
+ * {@code namespace:path[k1=v1,k2=v2]} — ALL properties, sorted by property name, no
+ * spaces; bare {@code namespace:path} when the state has none. Biomes are bare
+ * identifiers. This is a NEW strict wire form — deliberately NOT
+ * {@code BlockState.toString()} (which {@code RegistryFingerprint} uses and persists
+ * in store meta; that stringifier stays untouched).
+ *
+ * <p><b>Charset safety is validated, not assumed</b> (the plan's pin): Minecraft's
+ * identifier charset ({@code [a-z0-9_.-]} namespace, {@code [a-z0-9_./-]} path) and
+ * serialized property names/values cannot contain the four structural characters
+ * {@code [ ] , =} or spaces, so the form needs no escaping. {@link #validate} enforces
+ * the full grammar; the platform-side table generators run every registry entry
+ * through it, so an out-of-charset modded value fails loudly at table build, never as
+ * silent wire corruption.
+ *
+ * <p>{@link #parse} accepts ONLY the canonical form (strictly ascending property
+ * names, no duplicates) — a decoder that tolerated non-canonical spellings would
+ * make two wire dictionaries encode one state, breaking dictionary determinism.
+ */
+public final class IdentityCodec {
+    private IdentityCodec() {}
+
+    /** A parsed identity: {@code name} is {@code namespace:path}; properties sorted. */
+    public record ParsedIdentity(String name, List<Map.Entry<String, String>> properties) {}
+
+    /**
+     * Builds the canonical form from a registry name ({@code namespace:path}) and a
+     * property map (any iteration order — sorted here). Validates the result.
+     */
+    public static String canonical(String name, Map<String, String> properties) {
+        String identity;
+        if (properties == null || properties.isEmpty()) {
+            identity = name;
+        } else {
+            var sorted = new TreeMap<>(properties);
+            var sb = new StringBuilder(name).append('[');
+            boolean first = true;
+            for (var e : sorted.entrySet()) {
+                if (!first) {
+                    sb.append(',');
+                }
+                first = false;
+                sb.append(e.getKey()).append('=').append(e.getValue());
+            }
+            identity = sb.append(']').toString();
+        }
+        validate(identity);
+        return identity;
+    }
+
+    /** Throws {@link IllegalArgumentException} unless {@code identity} is canonical. */
+    public static void validate(String identity) {
+        parse(identity);
+    }
+
+    /**
+     * Strict parse of the canonical form. Rejects: missing/multiple {@code :},
+     * empty segments, out-of-charset characters, an empty {@code []}, unsorted or
+     * duplicate property names, and any structural malformation.
+     */
+    public static ParsedIdentity parse(String identity) {
+        if (identity == null || identity.isEmpty()) {
+            throw new IllegalArgumentException("empty identity");
+        }
+        int bracket = identity.indexOf('[');
+        String name = bracket < 0 ? identity : identity.substring(0, bracket);
+
+        int colon = name.indexOf(':');
+        if (colon <= 0 || colon != name.lastIndexOf(':') || colon == name.length() - 1) {
+            throw new IllegalArgumentException("identity name needs exactly one interior ':': " + identity);
+        }
+        checkCharset(name, 0, colon, NAMESPACE_CHARS, "namespace", identity);
+        checkCharset(name, colon + 1, name.length(), PATH_CHARS, "path", identity);
+
+        if (bracket < 0) {
+            return new ParsedIdentity(name, List.of());
+        }
+        if (identity.charAt(identity.length() - 1) != ']') {
+            throw new IllegalArgumentException("unterminated property list: " + identity);
+        }
+        String body = identity.substring(bracket + 1, identity.length() - 1);
+        if (body.isEmpty()) {
+            throw new IllegalArgumentException("empty property list must be the bare form: " + identity);
+        }
+        var props = new ArrayList<Map.Entry<String, String>>();
+        String previousKey = null;
+        for (String pair : body.split(",", -1)) {
+            int eq = pair.indexOf('=');
+            if (eq <= 0 || eq != pair.lastIndexOf('=') || eq == pair.length() - 1) {
+                throw new IllegalArgumentException("malformed property '" + pair + "' in: " + identity);
+            }
+            String key = pair.substring(0, eq);
+            String value = pair.substring(eq + 1);
+            checkCharset(key, 0, key.length(), PROP_NAME_CHARS, "property name", identity);
+            checkCharset(value, 0, value.length(), PROP_VALUE_CHARS, "property value", identity);
+            if (previousKey != null && previousKey.compareTo(key) >= 0) {
+                throw new IllegalArgumentException("property names not strictly ascending at '"
+                        + key + "' in: " + identity);
+            }
+            previousKey = key;
+            props.add(Map.entry(key, value));
+        }
+        return new ParsedIdentity(name, List.copyOf(props));
+    }
+
+    // Charsets: namespace/path follow Minecraft's Identifier rules; property names are
+    // Minecraft's lowercase serialized names, values their getName(T) output (booleans,
+    // non-negative ints, lowercase enum names — '+' '.' '-' allowed defensively for
+    // modded numeric-ish values). None admit '[' ']' ',' '=' or whitespace — the
+    // no-escaping premise, enforced here and pinned by IdentityCodecTest.
+    private static final boolean[] NAMESPACE_CHARS = charset("abcdefghijklmnopqrstuvwxyz0123456789_.-");
+    private static final boolean[] PATH_CHARS = charset("abcdefghijklmnopqrstuvwxyz0123456789_./-");
+    private static final boolean[] PROP_NAME_CHARS = charset("abcdefghijklmnopqrstuvwxyz0123456789_");
+    private static final boolean[] PROP_VALUE_CHARS = charset("abcdefghijklmnopqrstuvwxyz0123456789_.+-");
+
+    private static boolean[] charset(String allowed) {
+        var table = new boolean[128];
+        for (int i = 0; i < allowed.length(); i++) {
+            table[allowed.charAt(i)] = true;
+        }
+        return table;
+    }
+
+    private static void checkCharset(String s, int from, int to, boolean[] allowed,
+                                     String what, String identity) {
+        if (from >= to) {
+            throw new IllegalArgumentException("empty " + what + " in: " + identity);
+        }
+        for (int i = from; i < to; i++) {
+            char c = s.charAt(i);
+            if (c >= 128 || !allowed[c]) {
+                throw new IllegalArgumentException("illegal character '" + c + "' in "
+                        + what + " of: " + identity);
+            }
+        }
+    }
+}

--- a/common/src/main/java/dev/vox/lss/common/wire/IdentityDictionary.java
+++ b/common/src/main/java/dev/vox/lss/common/wire/IdentityDictionary.java
@@ -1,0 +1,43 @@
+package dev.vox.lss.common.wire;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+
+/**
+ * The v20 column dictionary: one entry per distinct canonical identity, indexed in
+ * FIRST-SEEN order (deterministic given section walk order — pinned by goldens).
+ * Blocks and biomes share one table; context (which palette references an index)
+ * disambiguates. A clear column never touches the dictionary, so it emits empty —
+ * the {@code dictCount==0 ⇔ sectionCount==0} ghost-clear invariant costs nothing here
+ * and is enforced at the emitters.
+ *
+ * <p>Every identity is {@link IdentityCodec#validate validated} on first insertion:
+ * the dictionary is the last common choke point before strings hit the wire (or a
+ * migrated store row), so an out-of-charset identity fails loudly here rather than
+ * shipping unparseable.
+ */
+public final class IdentityDictionary {
+    private final LinkedHashMap<String, Integer> indices = new LinkedHashMap<>();
+
+    /** Returns the identity's dictionary index, assigning the next one on first sight. */
+    public int indexOf(String identity) {
+        Integer existing = indices.get(identity);
+        if (existing != null) {
+            return existing;
+        }
+        IdentityCodec.validate(identity);
+        int index = indices.size();
+        indices.put(identity, index);
+        return index;
+    }
+
+    public int size() {
+        return indices.size();
+    }
+
+    /** Entries in index order (index {@code i} is {@code entries().get(i)}). */
+    public List<String> entries() {
+        return new ArrayList<>(indices.keySet());
+    }
+}

--- a/common/src/main/java/dev/vox/lss/common/wire/NativeToV20Translator.java
+++ b/common/src/main/java/dev/vox/lss/common/wire/NativeToV20Translator.java
@@ -73,21 +73,17 @@ public final class NativeToV20Translator {
         // DIRECT: synthesize a palette from the packed ids (the ViaVersion
         // PaletteType1_18.readValues maneuver), then repack at the v20 width.
         int[] ids = WireSectionCursor.unpack(c.data(), c.bits(), entries);
-        var seen = new java.util.LinkedHashMap<Integer, Integer>();
+        // Box-free first-seen remap (thousands of these run per store-migration row —
+        // a Map<Integer,Integer> boxes one Integer per voxel lookup).
+        var seen = new IntFirstSeen(entries);
         int[] remapped = new int[entries];
         for (int i = 0; i < entries; i++) {
-            Integer position = seen.get(ids[i]);
-            if (position == null) {
-                position = seen.size();
-                seen.put(ids[i], position);
-            }
-            remapped[i] = position;
+            remapped[i] = seen.indexOf(ids[i]);
         }
         int n = seen.size();
         int[] palette = new int[n];
-        int p = 0;
-        for (int id : seen.keySet()) {
-            palette[p++] = dict.indexOf(identityFor(identity, id, isBlocks));
+        for (int p = 0; p < n; p++) {
+            palette[p] = dict.indexOf(identityFor(identity, seen.idAt(p), isBlocks));
         }
         int bits = v20Bits(n, isBlocks);
         long[] data = bits == 0 ? new long[0] : WireSectionCursor.pack(remapped, bits);
@@ -110,5 +106,76 @@ public final class NativeToV20Translator {
         }
         int ceillog2 = 32 - Integer.numberOfLeadingZeros(paletteSize - 1);
         return isBlocks ? Math.max(4, Math.min(12, ceillog2)) : ceillog2;
+    }
+
+    /**
+     * Open-addressed {@code int -> first-seen index} map (power-of-two linear probe,
+     * {@code -1} = empty) — insertion order retrievable via {@link #idAt}. Ids are
+     * non-negative (unpack masks them), so {@code -1} is a safe sentinel.
+     */
+    private static final class IntFirstSeen {
+        private int[] keys;
+        private int[] values;
+        private int[] order;
+        private int size;
+
+        IntFirstSeen(int expectedEntries) {
+            int cap = Integer.highestOneBit(Math.max(16, expectedEntries / 4) - 1) << 1;
+            this.keys = new int[cap];
+            this.values = new int[cap];
+            this.order = new int[16];
+            java.util.Arrays.fill(this.keys, -1);
+        }
+
+        int indexOf(int id) {
+            int mask = keys.length - 1;
+            int slot = (id * 0x9E3779B9) >>> 16 & mask;
+            while (true) {
+                int k = keys[slot];
+                if (k == id) {
+                    return values[slot];
+                }
+                if (k == -1) {
+                    if (size * 2 >= keys.length) {
+                        grow();
+                        return indexOf(id);
+                    }
+                    keys[slot] = id;
+                    values[slot] = size;
+                    if (size == order.length) {
+                        order = java.util.Arrays.copyOf(order, size * 2);
+                    }
+                    order[size] = id;
+                    return size++;
+                }
+                slot = (slot + 1) & mask;
+            }
+        }
+
+        private void grow() {
+            int[] oldKeys = keys, oldValues = values;
+            keys = new int[oldKeys.length * 2];
+            values = new int[oldKeys.length * 2];
+            java.util.Arrays.fill(keys, -1);
+            int mask = keys.length - 1;
+            for (int i = 0; i < oldKeys.length; i++) {
+                if (oldKeys[i] != -1) {
+                    int slot = (oldKeys[i] * 0x9E3779B9) >>> 16 & mask;
+                    while (keys[slot] != -1) {
+                        slot = (slot + 1) & mask;
+                    }
+                    keys[slot] = oldKeys[i];
+                    values[slot] = oldValues[i];
+                }
+            }
+        }
+
+        int size() {
+            return size;
+        }
+
+        int idAt(int firstSeenIndex) {
+            return order[firstSeenIndex];
+        }
     }
 }

--- a/common/src/main/java/dev/vox/lss/common/wire/NativeToV20Translator.java
+++ b/common/src/main/java/dev/vox/lss/common/wire/NativeToV20Translator.java
@@ -1,0 +1,114 @@
+package dev.vox.lss.common.wire;
+
+import java.util.ArrayList;
+import java.util.function.IntFunction;
+
+/**
+ * Byte-domain native → v20 section-array translation (the encode direction of the
+ * §4.2 translator family): rewrite palettes, never voxels. Consumers: the Phase-0
+ * settling measurement (real-encoder frame diff) and the schema-4 store migration
+ * walk (a migrated row must byte-equal a fresh v20 encode); the v20→native
+ * direction (legacy egress) is the Phase-2 sibling.
+ *
+ * <p>Identity lookups are injected ({@code globalId -> canonical identity}) so this
+ * stays MC-free; the platform registry tables supply them. Rules (§2.1):
+ * <ul>
+ * <li>Natively-INDEXED containers ship their packed longs verbatim (widths already
+ *     vanilla-shaped = inside the v20 sets); only the palette values are rewritten
+ *     to dictionary indices.</li>
+ * <li>DIRECT containers are re-palettized: enumerate distinct ids from the longs in
+ *     first-seen scan order, repack at the v20 width — blocks
+ *     {@code n==1 -> 0, else clamp(ceillog2(n), 4, 12)}, biomes
+ *     {@code ceillog2(n)} (0-6).</li>
+ * <li>The two count shorts and the light layers pass through verbatim (pinned
+ *     version-neutral wire fields — recomputation is the live v20 EMITTER's concern,
+ *     not the translator's).</li>
+ * <li>Dictionary indices are assigned first-seen across the section walk (sections
+ *     in order; blocks then biomes within each; palette order within each container)
+ *     — deterministic, golden-pinned. A clear column (0 sections) translates to the
+ *     empty-dictionary clear frame.</li>
+ * </ul>
+ */
+public final class NativeToV20Translator {
+    private NativeToV20Translator() {}
+
+    /**
+     * Translates a NATIVE section-array body to the v20 layout.
+     *
+     * @param blockIdentity global block-state id → canonical identity (strict form;
+     *                      validated at dictionary insertion)
+     * @param biomeIdentity biome registry id → bare identity
+     * @throws WireFormatException on malformed input
+     * @throws IllegalArgumentException if a lookup yields a non-canonical identity
+     */
+    public static byte[] translate(byte[] nativeBody,
+                                   IntFunction<String> blockIdentity,
+                                   IntFunction<String> biomeIdentity) {
+        var column = WireSectionCursor.parse(nativeBody, WireSectionCursor.Layout.NATIVE);
+        var dict = new IdentityDictionary();
+        var sections = new ArrayList<WireSectionCursor.WireSection>(column.sections().size());
+        for (var s : column.sections()) {
+            var blocks = convert(s.blocks(), WireSectionCursor.BLOCK_ENTRIES, true, dict, blockIdentity);
+            var biomes = convert(s.biomes(), WireSectionCursor.BIOME_ENTRIES, false, dict, biomeIdentity);
+            sections.add(new WireSectionCursor.WireSection(s.sectionY(), s.nonEmptyBlockCount(),
+                    s.fluidCount(), blocks, biomes, s.blockLight(), s.skyLight()));
+        }
+        return WireSectionCursor.emit(
+                new WireSectionCursor.WireColumn(dict.entries(), sections),
+                WireSectionCursor.Layout.V20);
+    }
+
+    private static WireSectionCursor.WireContainer convert(WireSectionCursor.WireContainer c,
+                                                           int entries, boolean isBlocks,
+                                                           IdentityDictionary dict,
+                                                           IntFunction<String> identity) {
+        if (!c.isDirect()) {
+            // Indexed (single-value included): palette ids -> dict indices, longs verbatim.
+            int[] palette = new int[c.palette().length];
+            for (int i = 0; i < palette.length; i++) {
+                palette[i] = dict.indexOf(identityFor(identity, c.palette()[i], isBlocks));
+            }
+            return new WireSectionCursor.WireContainer(c.bits(), palette, c.data());
+        }
+        // DIRECT: synthesize a palette from the packed ids (the ViaVersion
+        // PaletteType1_18.readValues maneuver), then repack at the v20 width.
+        int[] ids = WireSectionCursor.unpack(c.data(), c.bits(), entries);
+        var seen = new java.util.LinkedHashMap<Integer, Integer>();
+        int[] remapped = new int[entries];
+        for (int i = 0; i < entries; i++) {
+            Integer position = seen.get(ids[i]);
+            if (position == null) {
+                position = seen.size();
+                seen.put(ids[i], position);
+            }
+            remapped[i] = position;
+        }
+        int n = seen.size();
+        int[] palette = new int[n];
+        int p = 0;
+        for (int id : seen.keySet()) {
+            palette[p++] = dict.indexOf(identityFor(identity, id, isBlocks));
+        }
+        int bits = v20Bits(n, isBlocks);
+        long[] data = bits == 0 ? new long[0] : WireSectionCursor.pack(remapped, bits);
+        return new WireSectionCursor.WireContainer(bits, palette, data);
+    }
+
+    private static String identityFor(IntFunction<String> lookup, int id, boolean isBlocks) {
+        String identity = lookup.apply(id);
+        if (identity == null) {
+            throw new IllegalArgumentException("no identity for "
+                    + (isBlocks ? "block-state" : "biome") + " id " + id);
+        }
+        return identity;
+    }
+
+    /** §2.1 widths: blocks {@code n==1 -> 0 else clamp(ceillog2(n), 4, 12)}; biomes {@code ceillog2(n)}. */
+    static int v20Bits(int paletteSize, boolean isBlocks) {
+        if (paletteSize <= 1) {
+            return 0;
+        }
+        int ceillog2 = 32 - Integer.numberOfLeadingZeros(paletteSize - 1);
+        return isBlocks ? Math.max(4, Math.min(12, ceillog2)) : ceillog2;
+    }
+}

--- a/common/src/main/java/dev/vox/lss/common/wire/WireBytes.java
+++ b/common/src/main/java/dev/vox/lss/common/wire/WireBytes.java
@@ -1,0 +1,214 @@
+package dev.vox.lss.common.wire;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+
+/**
+ * Minecraft-wire-format primitives over plain {@code byte[]} — the {@code common/}
+ * module has no Minecraft dependency, so the VarInt and big-endian scalar codecs are
+ * hand-rolled here to be BIT-IDENTICAL to {@code FriendlyByteBuf}'s
+ * ({@code writeVarInt}/{@code readVarInt}, netty big-endian shorts/longs, and the
+ * {@code writeUtf} shape of VarInt byte-length + UTF-8). Equivalence is pinned by a
+ * Fabric-side parity test against the real {@code FriendlyByteBuf}, which common
+ * cannot reference.
+ *
+ * <p>{@link Reader} is a bounds-checked cursor: every violation throws
+ * {@link WireFormatException}; it never throws {@code ArrayIndexOutOfBoundsException}
+ * and never allocates from an unvalidated wire-claimed count (callers bound-check
+ * counts against {@link Reader#remaining()} before sizing anything).
+ * {@link Writer} is a growable buffer with the matching write shapes.
+ */
+public final class WireBytes {
+    private WireBytes() {}
+
+    /** Maximum encoded VarInt width (Minecraft rejects a 6th continuation byte). */
+    public static final int MAX_VARINT_BYTES = 5;
+
+    /** Encoded width of {@code value} as a Minecraft VarInt (1-5 bytes; negatives are 5). */
+    public static int varIntSize(int value) {
+        int size = 1;
+        while ((value & ~0x7F) != 0) {
+            size++;
+            value >>>= 7;
+        }
+        return size;
+    }
+
+    public static final class Reader {
+        private final byte[] buf;
+        private int pos;
+        private final int limit;
+
+        public Reader(byte[] buf) {
+            this(buf, 0, buf.length);
+        }
+
+        public Reader(byte[] buf, int offset, int limit) {
+            if (offset < 0 || limit > buf.length || offset > limit) {
+                throw new WireFormatException("reader window [" + offset + ", " + limit
+                        + ") outside buffer of " + buf.length);
+            }
+            this.buf = buf;
+            this.pos = offset;
+            this.limit = limit;
+        }
+
+        public int position() {
+            return pos;
+        }
+
+        public int remaining() {
+            return limit - pos;
+        }
+
+        private void need(int n, String what) {
+            if (limit - pos < n) {
+                throw new WireFormatException("truncated " + what + ": need " + n
+                        + " bytes, have " + (limit - pos));
+            }
+        }
+
+        public int readByte() {
+            need(1, "byte");
+            return buf[pos++];
+        }
+
+        public int readUnsignedByte() {
+            return readByte() & 0xFF;
+        }
+
+        /** Big-endian signed short, the netty {@code readShort} shape. */
+        public int readShort() {
+            need(2, "short");
+            int v = ((buf[pos] & 0xFF) << 8) | (buf[pos + 1] & 0xFF);
+            pos += 2;
+            return (short) v;
+        }
+
+        /** Big-endian long, the netty {@code readLong} shape. */
+        public long readLong() {
+            need(8, "long");
+            long v = 0;
+            for (int i = 0; i < 8; i++) {
+                v = (v << 8) | (buf[pos + i] & 0xFFL);
+            }
+            pos += 8;
+            return v;
+        }
+
+        /** Minecraft VarInt: 7-bit groups little-endian-first, at most 5 bytes. */
+        public int readVarInt() {
+            int value = 0;
+            for (int i = 0; i < MAX_VARINT_BYTES; i++) {
+                need(1, "VarInt");
+                int b = buf[pos++] & 0xFF;
+                value |= (b & 0x7F) << (7 * i);
+                if ((b & 0x80) == 0) {
+                    return value;
+                }
+            }
+            throw new WireFormatException("VarInt wider than " + MAX_VARINT_BYTES + " bytes");
+        }
+
+        /** A VarInt that must be non-negative (counts, lengths). */
+        public int readVarIntCount(String what) {
+            int v = readVarInt();
+            if (v < 0) {
+                throw new WireFormatException("negative " + what + ": " + v);
+            }
+            return v;
+        }
+
+        public byte[] readBytes(int n) {
+            need(n, n + " raw bytes");
+            byte[] out = Arrays.copyOfRange(buf, pos, pos + n);
+            pos += n;
+            return out;
+        }
+
+        public void skip(int n, String what) {
+            need(n, what);
+            pos += n;
+        }
+
+        /** VarInt byte-length + UTF-8 bytes — the {@code writeUtf} shape. */
+        public String readUtf(int maxBytes) {
+            int len = readVarIntCount("string length");
+            if (len > maxBytes) {
+                throw new WireFormatException("string of " + len + " bytes exceeds cap " + maxBytes);
+            }
+            need(len, "string body");
+            String s = new String(buf, pos, len, StandardCharsets.UTF_8);
+            pos += len;
+            return s;
+        }
+    }
+
+    public static final class Writer {
+        private byte[] buf;
+        private int pos;
+
+        public Writer(int initialCapacity) {
+            this.buf = new byte[Math.max(16, initialCapacity)];
+        }
+
+        private void ensure(int n) {
+            if (pos + n > buf.length) {
+                buf = Arrays.copyOf(buf, Math.max(buf.length * 2, pos + n));
+            }
+        }
+
+        public int size() {
+            return pos;
+        }
+
+        public Writer writeByte(int v) {
+            ensure(1);
+            buf[pos++] = (byte) v;
+            return this;
+        }
+
+        public Writer writeShort(int v) {
+            ensure(2);
+            buf[pos++] = (byte) (v >>> 8);
+            buf[pos++] = (byte) v;
+            return this;
+        }
+
+        public Writer writeLong(long v) {
+            ensure(8);
+            for (int i = 7; i >= 0; i--) {
+                buf[pos++] = (byte) (v >>> (8 * i));
+            }
+            return this;
+        }
+
+        public Writer writeVarInt(int value) {
+            ensure(MAX_VARINT_BYTES);
+            while ((value & ~0x7F) != 0) {
+                buf[pos++] = (byte) ((value & 0x7F) | 0x80);
+                value >>>= 7;
+            }
+            buf[pos++] = (byte) value;
+            return this;
+        }
+
+        public Writer writeBytes(byte[] src) {
+            ensure(src.length);
+            System.arraycopy(src, 0, buf, pos, src.length);
+            pos += src.length;
+            return this;
+        }
+
+        /** VarInt byte-length + UTF-8 bytes — the {@code writeUtf} shape. */
+        public Writer writeUtf(String s) {
+            byte[] body = s.getBytes(StandardCharsets.UTF_8);
+            writeVarInt(body.length);
+            return writeBytes(body);
+        }
+
+        public byte[] toByteArray() {
+            return Arrays.copyOf(buf, pos);
+        }
+    }
+}

--- a/common/src/main/java/dev/vox/lss/common/wire/WireFormatException.java
+++ b/common/src/main/java/dev/vox/lss/common/wire/WireFormatException.java
@@ -1,0 +1,15 @@
+package dev.vox.lss.common.wire;
+
+/**
+ * Structural violation while reading or writing a wire-format byte body (truncation,
+ * negative or over-bounds counts, oversized VarInts, layout-rule violations). Unchecked
+ * so byte-domain helpers compose without checked-exception plumbing; every hostile-input
+ * path in {@link WireSectionCursor} is pinned to throw THIS (never
+ * {@code ArrayIndexOutOfBoundsException}, never {@code NegativeArraySizeException},
+ * never {@code OutOfMemoryError} from a wire-claimed allocation).
+ */
+public final class WireFormatException extends RuntimeException {
+    public WireFormatException(String message) {
+        super(message);
+    }
+}

--- a/common/src/main/java/dev/vox/lss/common/wire/WireSectionCursor.java
+++ b/common/src/main/java/dev/vox/lss/common/wire/WireSectionCursor.java
@@ -1,0 +1,292 @@
+package dev.vox.lss.common.wire;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Structural walker for the column SECTION-ARRAY body in both wire layouts — the
+ * transcoder's layout knowledge factored out (cross-version-identity-encoding-plan
+ * §4.2) so the settling measurement, the legacy egress translators, and the store
+ * migration walk all share one parser/emitter instead of three.
+ *
+ * <p><b>NATIVE layout</b> (protocol ≤19 section bytes, what `SectionSerializer` /
+ * `NbtSectionSerializer` emit today):
+ * <pre>
+ * VarInt sectionCount
+ * repeat: byte sectionY; short nonEmptyBlockCount; short fluidCount;
+ *         blocks container(4096 entries); biomes container(64 entries);
+ *         bool hasBlockLight [+2048 B]; bool hasSkyLight [+2048 B]
+ * container: byte bits;
+ *   bits==0            -> VarInt single palette value, no data words
+ *   0&lt;bits&lt;=threshold  -> VarInt paletteCount + paletteCount VarInt values, then data
+ *   bits&gt;threshold     -> DIRECT: NO palette list, data holds registry ids
+ * data: ceil(entries / (64/bits)) raw big-endian longs, NO length prefix
+ * thresholds: blocks 8, biomes 3 (vanilla's width→shape strategy tables)
+ * </pre>
+ *
+ * <p><b>V20 layout</b> (§2.1): a leading shared identity dictionary, then the same
+ * section shape with palettes of VarInt DICTIONARY INDICES and NO DIRECT mode:
+ * <pre>
+ * VarInt dictCount; repeat: VarInt len + UTF-8 canonical identity
+ * VarInt sectionCount; sections as above, but every bits&gt;0 container carries a
+ * palette list (widths: blocks 4-12, biomes 1-6; bits==0 single index)
+ * </pre>
+ *
+ * <p>Hostile-input containment (the plan's hostile-allocation pin, held here for
+ * every consumer at once): all failures throw {@link WireFormatException}; no
+ * wire-claimed count sizes an allocation before it is bounded — palette counts are
+ * capped by the container's entry count, dictionary and light reads are bounded by
+ * bytes actually remaining. {@code parse -> emit} is byte-identity on well-formed
+ * input (both layouts, corpus-pinned); VarInts are canonical on emit, so only a
+ * non-minimally-encoded (hence non-native) input can re-emit differently.
+ */
+public final class WireSectionCursor {
+    private WireSectionCursor() {}
+
+    public enum Layout { NATIVE, V20 }
+
+    static final int BLOCK_ENTRIES = 4096;
+    static final int BIOME_ENTRIES = 64;
+    static final int NATIVE_BLOCK_PALETTE_MAX_BITS = 8;
+    static final int NATIVE_BIOME_PALETTE_MAX_BITS = 3;
+    /** v20 palette width ceilings (§2.1); parse-enforced so a hostile width cannot
+     *  claim absurd data lengths, emit-enforced so we never produce one. */
+    static final int V20_BLOCK_MAX_BITS = 12;
+    static final int V20_BIOME_MAX_BITS = 6;
+    private static final int LIGHT_BYTES = 2048;
+    /** Identity strings are short (~20-40 B measured); 4 KiB tolerates absurd modded
+     *  names while bounding a hostile length claim. */
+    private static final int MAX_IDENTITY_BYTES = 4096;
+
+    /**
+     * One palette container. {@code palette == null} means DIRECT (native layout
+     * only): the data words hold registry ids at {@code bits} width. A single-value
+     * container is {@code bits == 0}, one palette entry, empty data.
+     */
+    public record WireContainer(int bits, int[] palette, long[] data) {
+        public boolean isDirect() {
+            return palette == null;
+        }
+    }
+
+    /** {@code blockLight}/{@code skyLight} are 2048 bytes when present, else null. */
+    public record WireSection(int sectionY, int nonEmptyBlockCount, int fluidCount,
+                              WireContainer blocks, WireContainer biomes,
+                              byte[] blockLight, byte[] skyLight) {}
+
+    /** {@code dictionary} is empty for the NATIVE layout. */
+    public record WireColumn(List<String> dictionary, List<WireSection> sections) {}
+
+    // ---- parse ----------------------------------------------------------------
+
+    public static WireColumn parse(byte[] body, Layout layout) {
+        var in = new WireBytes.Reader(body);
+        WireColumn column = readColumn(in, layout);
+        if (in.remaining() != 0) {
+            throw new WireFormatException(in.remaining() + " trailing bytes after section array");
+        }
+        return column;
+    }
+
+    /**
+     * Walks one column body without retaining it, returning the consumed byte count
+     * (the skip primitive: same validations as {@link #parse}, no per-section
+     * allocations kept).
+     */
+    public static int scan(byte[] body, int offset, Layout layout) {
+        var in = new WireBytes.Reader(body, offset, body.length);
+        readColumn(in, layout);
+        return in.position() - offset;
+    }
+
+    private static WireColumn readColumn(WireBytes.Reader in, Layout layout) {
+        List<String> dictionary = List.of();
+        if (layout == Layout.V20) {
+            int dictCount = in.readVarIntCount("dictCount");
+            if (dictCount > in.remaining()) {  // every entry is >= 1 byte
+                throw new WireFormatException("dictCount " + dictCount + " exceeds remaining bytes");
+            }
+            var dict = new ArrayList<String>(dictCount);
+            for (int i = 0; i < dictCount; i++) {
+                dict.add(in.readUtf(MAX_IDENTITY_BYTES));
+            }
+            dictionary = dict;
+        }
+        int sectionCount = in.readVarIntCount("sectionCount");
+        if (layout == Layout.V20 && (sectionCount == 0) != dictionary.isEmpty()) {
+            throw new WireFormatException("clear-column invariant violated: dictCount="
+                    + dictionary.size() + " sectionCount=" + sectionCount);
+        }
+        // Sections accumulate dynamically, bounded by buffer exhaustion — the claimed
+        // count never sizes anything (each section is >= 8 bytes on the wire).
+        if (sectionCount > in.remaining()) {
+            throw new WireFormatException("sectionCount " + sectionCount + " exceeds remaining bytes");
+        }
+        var sections = new ArrayList<WireSection>();
+        for (int i = 0; i < sectionCount; i++) {
+            int sectionY = in.readByte();
+            int nonEmpty = in.readShort();
+            int fluid = in.readShort();
+            WireContainer blocks = readContainer(in, layout, BLOCK_ENTRIES, true);
+            WireContainer biomes = readContainer(in, layout, BIOME_ENTRIES, false);
+            byte[] blockLight = in.readByte() != 0 ? in.readBytes(LIGHT_BYTES) : null;
+            byte[] skyLight = in.readByte() != 0 ? in.readBytes(LIGHT_BYTES) : null;
+            sections.add(new WireSection(sectionY, nonEmpty, fluid, blocks, biomes,
+                    blockLight, skyLight));
+        }
+        return new WireColumn(dictionary, sections);
+    }
+
+    private static WireContainer readContainer(WireBytes.Reader in, Layout layout,
+                                               int entries, boolean isBlocks) {
+        int bits = in.readUnsignedByte();
+        int maxBits = layout == Layout.V20
+                ? (isBlocks ? V20_BLOCK_MAX_BITS : V20_BIOME_MAX_BITS)
+                : 31;  // native DIRECT width is registry-derived; cap only for sanity
+        if (bits > maxBits) {
+            throw new WireFormatException((isBlocks ? "block" : "biome")
+                    + " container width " + bits + " exceeds " + layout + " max " + maxBits);
+        }
+        if (bits == 0) {
+            return new WireContainer(0, new int[] { in.readVarInt() }, EMPTY_DATA);
+        }
+        int[] palette = null;
+        int paletteThreshold = isBlocks ? NATIVE_BLOCK_PALETTE_MAX_BITS : NATIVE_BIOME_PALETTE_MAX_BITS;
+        if (layout == Layout.V20 || bits <= paletteThreshold) {
+            int count = in.readVarIntCount("paletteCount");
+            if (count == 0 || count > entries) {
+                throw new WireFormatException("palette count " + count + " outside [1, " + entries + "]");
+            }
+            palette = new int[count];
+            for (int i = 0; i < count; i++) {
+                palette[i] = in.readVarInt();
+            }
+        }
+        int valuesPerLong = 64 / bits;
+        int longCount = (entries + valuesPerLong - 1) / valuesPerLong;
+        long[] data = new long[longCount];
+        for (int i = 0; i < longCount; i++) {
+            data[i] = in.readLong();
+        }
+        return new WireContainer(bits, palette, data);
+    }
+
+    private static final long[] EMPTY_DATA = new long[0];
+
+    // ---- emit -----------------------------------------------------------------
+
+    public static byte[] emit(WireColumn column, Layout layout) {
+        var out = new WireBytes.Writer(1024);
+        if (layout == Layout.V20) {
+            if (column.sections().isEmpty() != column.dictionary().isEmpty()) {
+                throw new WireFormatException("refusing to emit a clear-column-invariant violation: dict="
+                        + column.dictionary().size() + " sections=" + column.sections().size());
+            }
+            out.writeVarInt(column.dictionary().size());
+            for (String identity : column.dictionary()) {
+                out.writeUtf(identity);
+            }
+        } else if (!column.dictionary().isEmpty()) {
+            throw new WireFormatException("NATIVE layout has no dictionary");
+        }
+        out.writeVarInt(column.sections().size());
+        for (WireSection s : column.sections()) {
+            out.writeByte(s.sectionY());
+            out.writeShort(s.nonEmptyBlockCount());
+            out.writeShort(s.fluidCount());
+            writeContainer(out, s.blocks(), layout, BLOCK_ENTRIES, true);
+            writeContainer(out, s.biomes(), layout, BIOME_ENTRIES, false);
+            writeLight(out, s.blockLight());
+            writeLight(out, s.skyLight());
+        }
+        return out.toByteArray();
+    }
+
+    private static void writeContainer(WireBytes.Writer out, WireContainer c, Layout layout,
+                                       int entries, boolean isBlocks) {
+        int bits = c.bits();
+        if (layout == Layout.V20 && c.isDirect()) {
+            throw new WireFormatException("v20 has no DIRECT mode");
+        }
+        if (layout == Layout.V20 && bits > (isBlocks ? V20_BLOCK_MAX_BITS : V20_BIOME_MAX_BITS)) {
+            throw new WireFormatException("v20 " + (isBlocks ? "block" : "biome")
+                    + " width " + bits + " out of range");
+        }
+        out.writeByte(bits);
+        if (bits == 0) {
+            if (c.isDirect() || c.palette().length != 1 || c.data().length != 0) {
+                throw new WireFormatException("malformed single-value container");
+            }
+            out.writeVarInt(c.palette()[0]);
+            return;
+        }
+        if (!c.isDirect()) {
+            out.writeVarInt(c.palette().length);
+            for (int v : c.palette()) {
+                out.writeVarInt(v);
+            }
+        }
+        int valuesPerLong = 64 / bits;
+        int expected = (entries + valuesPerLong - 1) / valuesPerLong;
+        if (c.data().length != expected) {
+            throw new WireFormatException("container data has " + c.data().length
+                    + " longs, layout implies " + expected);
+        }
+        for (long l : c.data()) {
+            out.writeLong(l);
+        }
+    }
+
+    private static void writeLight(WireBytes.Writer out, byte[] light) {
+        if (light == null) {
+            out.writeByte(0);
+            return;
+        }
+        if (light.length != LIGHT_BYTES) {
+            throw new WireFormatException("light layer of " + light.length + " bytes");
+        }
+        out.writeByte(1);
+        out.writeBytes(light);
+    }
+
+    // ---- packed-array helpers (SimpleBitStorage semantics) ---------------------
+
+    /**
+     * Unpacks {@code entries} values at {@code bits} width: LSB-first within each
+     * long, no value crosses a long boundary — vanilla {@code SimpleBitStorage} /
+     * the transcoder's histogram walk.
+     */
+    public static int[] unpack(long[] data, int bits, int entries) {
+        if (bits <= 0 || bits > 32) {
+            throw new WireFormatException("unpack width " + bits);
+        }
+        int valuesPerLong = 64 / bits;
+        int expected = (entries + valuesPerLong - 1) / valuesPerLong;
+        if (data.length != expected) {
+            throw new WireFormatException("unpack over " + data.length + " longs, expected " + expected);
+        }
+        long mask = (1L << bits) - 1;
+        int[] out = new int[entries];
+        for (int i = 0; i < entries; i++) {
+            out[i] = (int) ((data[i / valuesPerLong] >>> ((i % valuesPerLong) * bits)) & mask);
+        }
+        return out;
+    }
+
+    /** Inverse of {@link #unpack}; values must fit {@code bits}. */
+    public static long[] pack(int[] values, int bits) {
+        if (bits <= 0 || bits > 32) {
+            throw new WireFormatException("pack width " + bits);
+        }
+        int valuesPerLong = 64 / bits;
+        long[] out = new long[(values.length + valuesPerLong - 1) / valuesPerLong];
+        for (int i = 0; i < values.length; i++) {
+            int v = values[i];
+            if (v < 0 || (bits < 32 && v >= (1 << bits))) {
+                throw new WireFormatException("value " + v + " does not fit " + bits + " bits");
+            }
+            out[i / valuesPerLong] |= ((long) v) << ((i % valuesPerLong) * bits);
+        }
+        return out;
+    }
+}

--- a/common/src/main/java/dev/vox/lss/common/wire/WireSectionCursor.java
+++ b/common/src/main/java/dev/vox/lss/common/wire/WireSectionCursor.java
@@ -1,5 +1,6 @@
 package dev.vox.lss.common.wire;
 
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -23,22 +24,40 @@ import java.util.List;
  * data: ceil(entries / (64/bits)) raw big-endian longs, NO length prefix
  * thresholds: blocks 8, biomes 3 (vanilla's width→shape strategy tables)
  * </pre>
+ * Vanilla's width→shape tables also make some widths ILLEGAL on the wire even
+ * below the threshold: an indexed BLOCK container is only ever emitted at bits
+ * 4-8 (1-3 map to the 4-bit linear shape, so a bits-1..3 frame desyncs a real
+ * {@code section.read} — 26.2 {@code Strategy$1} disassembly). The cursor
+ * enforces that on BOTH parse and emit, so "the cursor accepted it" implies
+ * "vanilla can read it". Biomes have no such gap (1/2/3-bit linear shapes exist).
  *
  * <p><b>V20 layout</b> (§2.1): a leading shared identity dictionary, then the same
  * section shape with palettes of VarInt DICTIONARY INDICES and NO DIRECT mode:
  * <pre>
  * VarInt dictCount; repeat: VarInt len + UTF-8 canonical identity
  * VarInt sectionCount; sections as above, but every bits&gt;0 container carries a
- * palette list (widths: blocks 4-12, biomes 1-6; bits==0 single index)
+ * palette list (widths: blocks 0 or 4-12, biomes 0-6; bits==0 single index)
  * </pre>
+ * The §2.1 block width FLOOR (4) is enforced along with the ceilings, and every
+ * palette value is range-checked against the dictionary — referential integrity
+ * is the cursor's job, not each consumer's.
  *
  * <p>Hostile-input containment (the plan's hostile-allocation pin, held here for
  * every consumer at once): all failures throw {@link WireFormatException}; no
  * wire-claimed count sizes an allocation before it is bounded — palette counts are
- * capped by the container's entry count, dictionary and light reads are bounded by
- * bytes actually remaining. {@code parse -> emit} is byte-identity on well-formed
- * input (both layouts, corpus-pinned); VarInts are canonical on emit, so only a
- * non-minimally-encoded (hence non-native) input can re-emit differently.
+ * capped by the container's entry count, dictionary entries and light reads are
+ * bounded by bytes actually remaining, and the dictionary list grows dynamically
+ * (dictCount never pre-sizes anything). {@code parse -> emit} is byte-identity on
+ * well-formed input (both layouts, corpus-pinned); VarInts are canonical on emit,
+ * so only a non-minimally-encoded (hence non-native) input can re-emit differently.
+ *
+ * <p>The records expose their backing arrays WITHOUT defensive copies — the
+ * translator's verbatim-longs pass-through depends on it. Consumers must treat
+ * {@code palette()}/{@code data()}/light arrays as immutable; mutating one corrupts
+ * whatever shares it. Dictionary entries are deliberately NOT
+ * {@code IdentityCodec}-validated at parse: an unknown-but-well-formed identity
+ * from a newer peer must reach the §3 fallback ladder, not die here — do not
+ * "fix" this into a validating parse.
  */
 public final class WireSectionCursor {
     private WireSectionCursor() {}
@@ -49,14 +68,18 @@ public final class WireSectionCursor {
     static final int BIOME_ENTRIES = 64;
     static final int NATIVE_BLOCK_PALETTE_MAX_BITS = 8;
     static final int NATIVE_BIOME_PALETTE_MAX_BITS = 3;
+    /** Indexed block containers exist only at 4-8 bits in vanilla's shape table —
+     *  1-3 desync a real {@code section.read} (blocks only; biome linear shapes
+     *  cover 1-3). Shared by both layouts: v20 keeps the same floor (§2.1). */
+    static final int BLOCK_MIN_INDEXED_BITS = 4;
     /** v20 palette width ceilings (§2.1); parse-enforced so a hostile width cannot
      *  claim absurd data lengths, emit-enforced so we never produce one. */
     static final int V20_BLOCK_MAX_BITS = 12;
     static final int V20_BIOME_MAX_BITS = 6;
     private static final int LIGHT_BYTES = 2048;
     /** Identity strings are short (~20-40 B measured); 4 KiB tolerates absurd modded
-     *  names while bounding a hostile length claim. */
-    private static final int MAX_IDENTITY_BYTES = 4096;
+     *  names while bounding a hostile length claim. Enforced on parse AND emit. */
+    static final int MAX_IDENTITY_BYTES = 4096;
 
     /**
      * One palette container. {@code palette == null} means DIRECT (native layout
@@ -90,11 +113,16 @@ public final class WireSectionCursor {
 
     /**
      * Walks one column body without retaining it, returning the consumed byte count
-     * (the skip primitive: same validations as {@link #parse}, no per-section
-     * allocations kept).
+     * (the skip primitive: same validations as {@link #parse}, allocations are
+     * transient). The {@code limit} overload walks a body embedded in a larger
+     * buffer with a known end.
      */
     public static int scan(byte[] body, int offset, Layout layout) {
-        var in = new WireBytes.Reader(body, offset, body.length);
+        return scan(body, offset, body.length, layout);
+    }
+
+    public static int scan(byte[] body, int offset, int limit, Layout layout) {
+        var in = new WireBytes.Reader(body, offset, limit);
         readColumn(in, layout);
         return in.position() - offset;
     }
@@ -106,7 +134,9 @@ public final class WireSectionCursor {
             if (dictCount > in.remaining()) {  // every entry is >= 1 byte
                 throw new WireFormatException("dictCount " + dictCount + " exceeds remaining bytes");
             }
-            var dict = new ArrayList<String>(dictCount);
+            // Grows dynamically — the wire-claimed count must never pre-size an
+            // allocation (§2.3's hostile-allocation pin, dictCount included).
+            var dict = new ArrayList<String>();
             for (int i = 0; i < dictCount; i++) {
                 dict.add(in.readUtf(MAX_IDENTITY_BYTES));
             }
@@ -122,13 +152,14 @@ public final class WireSectionCursor {
         if (sectionCount > in.remaining()) {
             throw new WireFormatException("sectionCount " + sectionCount + " exceeds remaining bytes");
         }
+        int dictSize = dictionary.size();
         var sections = new ArrayList<WireSection>();
         for (int i = 0; i < sectionCount; i++) {
             int sectionY = in.readByte();
             int nonEmpty = in.readShort();
             int fluid = in.readShort();
-            WireContainer blocks = readContainer(in, layout, BLOCK_ENTRIES, true);
-            WireContainer biomes = readContainer(in, layout, BIOME_ENTRIES, false);
+            WireContainer blocks = readContainer(in, layout, BLOCK_ENTRIES, true, dictSize);
+            WireContainer biomes = readContainer(in, layout, BIOME_ENTRIES, false, dictSize);
             byte[] blockLight = in.readByte() != 0 ? in.readBytes(LIGHT_BYTES) : null;
             byte[] skyLight = in.readByte() != 0 ? in.readBytes(LIGHT_BYTES) : null;
             sections.add(new WireSection(sectionY, nonEmpty, fluid, blocks, biomes,
@@ -138,17 +169,12 @@ public final class WireSectionCursor {
     }
 
     private static WireContainer readContainer(WireBytes.Reader in, Layout layout,
-                                               int entries, boolean isBlocks) {
+                                               int entries, boolean isBlocks, int dictSize) {
         int bits = in.readUnsignedByte();
-        int maxBits = layout == Layout.V20
-                ? (isBlocks ? V20_BLOCK_MAX_BITS : V20_BIOME_MAX_BITS)
-                : 31;  // native DIRECT width is registry-derived; cap only for sanity
-        if (bits > maxBits) {
-            throw new WireFormatException((isBlocks ? "block" : "biome")
-                    + " container width " + bits + " exceeds " + layout + " max " + maxBits);
-        }
+        checkWidth(bits, layout, isBlocks);
         if (bits == 0) {
-            return new WireContainer(0, new int[] { in.readVarInt() }, EMPTY_DATA);
+            return new WireContainer(0,
+                    new int[] { readPaletteValue(in, layout, isBlocks, dictSize) }, EMPTY_DATA);
         }
         int[] palette = null;
         int paletteThreshold = isBlocks ? NATIVE_BLOCK_PALETTE_MAX_BITS : NATIVE_BIOME_PALETTE_MAX_BITS;
@@ -159,7 +185,7 @@ public final class WireSectionCursor {
             }
             palette = new int[count];
             for (int i = 0; i < count; i++) {
-                palette[i] = in.readVarInt();
+                palette[i] = readPaletteValue(in, layout, isBlocks, dictSize);
             }
         }
         int valuesPerLong = 64 / bits;
@@ -171,59 +197,99 @@ public final class WireSectionCursor {
         return new WireContainer(bits, palette, data);
     }
 
+    /** Palette values are registry ids (native) or dictionary indices (v20) — never
+     *  negative, and v20 indices must reference the dictionary that precedes them. */
+    private static int readPaletteValue(WireBytes.Reader in, Layout layout,
+                                        boolean isBlocks, int dictSize) {
+        int v = in.readVarIntCount((isBlocks ? "block" : "biome") + " palette value");
+        if (layout == Layout.V20 && v >= dictSize) {
+            throw new WireFormatException("palette index " + v + " outside dictionary of " + dictSize);
+        }
+        return v;
+    }
+
+    /** The width/shape legality shared by parse and emit (see class javadoc). */
+    private static void checkWidth(int bits, Layout layout, boolean isBlocks) {
+        int maxBits = layout == Layout.V20
+                ? (isBlocks ? V20_BLOCK_MAX_BITS : V20_BIOME_MAX_BITS)
+                : 31;  // native DIRECT width is registry-derived; cap only for sanity
+        if (bits > maxBits) {
+            throw new WireFormatException((isBlocks ? "block" : "biome")
+                    + " container width " + bits + " exceeds " + layout + " max " + maxBits);
+        }
+        if (isBlocks && bits >= 1 && bits < BLOCK_MIN_INDEXED_BITS) {
+            throw new WireFormatException("block container width " + bits
+                    + " has no vanilla shape (indexed blocks are 4-8"
+                    + (layout == Layout.V20 ? "; v20 floor is 4" : "") + ")");
+        }
+    }
+
     private static final long[] EMPTY_DATA = new long[0];
 
     // ---- emit -----------------------------------------------------------------
 
     public static byte[] emit(WireColumn column, Layout layout) {
-        var out = new WireBytes.Writer(1024);
+        var out = new WireBytes.Writer(estimateSize(column));
+        int dictSize = column.dictionary().size();
         if (layout == Layout.V20) {
             if (column.sections().isEmpty() != column.dictionary().isEmpty()) {
                 throw new WireFormatException("refusing to emit a clear-column-invariant violation: dict="
-                        + column.dictionary().size() + " sections=" + column.sections().size());
+                        + dictSize + " sections=" + column.sections().size());
             }
-            out.writeVarInt(column.dictionary().size());
+            out.writeVarInt(dictSize);
             for (String identity : column.dictionary()) {
+                if (identity.getBytes(StandardCharsets.UTF_8).length > MAX_IDENTITY_BYTES) {
+                    throw new WireFormatException("dictionary entry exceeds " + MAX_IDENTITY_BYTES
+                            + " UTF-8 bytes — our own parse would reject it");
+                }
                 out.writeUtf(identity);
             }
-        } else if (!column.dictionary().isEmpty()) {
+        } else if (dictSize != 0) {
             throw new WireFormatException("NATIVE layout has no dictionary");
         }
         out.writeVarInt(column.sections().size());
         for (WireSection s : column.sections()) {
+            if (s.sectionY() < Byte.MIN_VALUE || s.sectionY() > Byte.MAX_VALUE) {
+                throw new WireFormatException("sectionY " + s.sectionY() + " outside byte range");
+            }
+            checkShortRange(s.nonEmptyBlockCount(), "nonEmptyBlockCount");
+            checkShortRange(s.fluidCount(), "fluidCount");
             out.writeByte(s.sectionY());
             out.writeShort(s.nonEmptyBlockCount());
             out.writeShort(s.fluidCount());
-            writeContainer(out, s.blocks(), layout, BLOCK_ENTRIES, true);
-            writeContainer(out, s.biomes(), layout, BIOME_ENTRIES, false);
+            writeContainer(out, s.blocks(), layout, BLOCK_ENTRIES, true, dictSize);
+            writeContainer(out, s.biomes(), layout, BIOME_ENTRIES, false, dictSize);
             writeLight(out, s.blockLight());
             writeLight(out, s.skyLight());
         }
         return out.toByteArray();
     }
 
+    private static void checkShortRange(int v, String what) {
+        if (v < Short.MIN_VALUE || v > Short.MAX_VALUE) {
+            throw new WireFormatException(what + " " + v + " outside short range");
+        }
+    }
+
     private static void writeContainer(WireBytes.Writer out, WireContainer c, Layout layout,
-                                       int entries, boolean isBlocks) {
+                                       int entries, boolean isBlocks, int dictSize) {
         int bits = c.bits();
         if (layout == Layout.V20 && c.isDirect()) {
             throw new WireFormatException("v20 has no DIRECT mode");
         }
-        if (layout == Layout.V20 && bits > (isBlocks ? V20_BLOCK_MAX_BITS : V20_BIOME_MAX_BITS)) {
-            throw new WireFormatException("v20 " + (isBlocks ? "block" : "biome")
-                    + " width " + bits + " out of range");
-        }
+        checkWidth(bits, layout, isBlocks);
         out.writeByte(bits);
         if (bits == 0) {
             if (c.isDirect() || c.palette().length != 1 || c.data().length != 0) {
                 throw new WireFormatException("malformed single-value container");
             }
-            out.writeVarInt(c.palette()[0]);
+            out.writeVarInt(checkPaletteValue(c.palette()[0], layout, isBlocks, dictSize));
             return;
         }
         if (!c.isDirect()) {
             out.writeVarInt(c.palette().length);
             for (int v : c.palette()) {
-                out.writeVarInt(v);
+                out.writeVarInt(checkPaletteValue(v, layout, isBlocks, dictSize));
             }
         }
         int valuesPerLong = 64 / bits;
@@ -237,6 +303,14 @@ public final class WireSectionCursor {
         }
     }
 
+    private static int checkPaletteValue(int v, Layout layout, boolean isBlocks, int dictSize) {
+        if (v < 0 || (layout == Layout.V20 && v >= dictSize)) {
+            throw new WireFormatException((isBlocks ? "block" : "biome") + " palette value " + v
+                    + (layout == Layout.V20 ? " outside dictionary of " + dictSize : " is negative"));
+        }
+        return v;
+    }
+
     private static void writeLight(WireBytes.Writer out, byte[] light) {
         if (light == null) {
             out.writeByte(0);
@@ -247,6 +321,23 @@ public final class WireSectionCursor {
         }
         out.writeByte(1);
         out.writeBytes(light);
+    }
+
+    /** Close-enough writer pre-size so a real column pays no growth copies. */
+    private static int estimateSize(WireColumn column) {
+        int size = 16;
+        for (String identity : column.dictionary()) {
+            size += 5 + identity.length() * 2;
+        }
+        for (WireSection s : column.sections()) {
+            size += 7 + 2 * (1 + LIGHT_BYTES)
+                    + containerEstimate(s.blocks()) + containerEstimate(s.biomes());
+        }
+        return size;
+    }
+
+    private static int containerEstimate(WireContainer c) {
+        return 1 + 5 + (c.isDirect() ? 0 : c.palette().length * 3) + c.data().length * 8;
     }
 
     // ---- packed-array helpers (SimpleBitStorage semantics) ---------------------

--- a/docs/planning/cross-version-identity-encoding-plan.md
+++ b/docs/planning/cross-version-identity-encoding-plan.md
@@ -223,13 +223,26 @@ negligible next to zstd + serialization.
   `Block.BLOCK_STATE_REGISTRY` iteration order — the same enumeration
   `RegistryFingerprint` already uses). DIRECT sections re-palettize here.
 - **NBT transcode path** (`NbtSectionSerializer.transcodeSection:408` + Paper twin):
-  the disk palette ALREADY stores name+properties NBT — canonicalize straight to
-  identity strings, **no registry resolution needed for the wire**. The
-  `MemoizedNbtCodec` id resolve survives only for what still needs ids: the two
-  shorts (air/fluid classification) and the x-ray mask pre-gate
-  (`mask.containsId`, `:497-508`). The >256-palette object-path fallback can be
-  RETIRED for encoding (v20 has no DIRECT limit; a >256 disk palette transcodes
-  fine) but stays for malformed shapes.
+  **AMENDED at C0 (2026-08-07 review MAJOR 6 — the original "canonicalize straight
+  from the disk NBT, no registry resolution needed" is RETRACTED).** The pinned
+  rule: **identities on the wire are always the identity of a state that RESOLVED
+  in the emitting server's registry** — the transcode path canonicalizes from the
+  `MemoizedNbtCodec`-resolved state (via its global id through the identity
+  table, one array index per palette entry — the memo already resolves every
+  entry for the two shorts and the mask pre-gate, so this costs nothing new;
+  R-5's "memo stays hot" holds). Canonicalizing raw disk spellings instead would
+  (a) break disk/live byte parity the moment the codec's leniency fires (a
+  hard-error entry substitutes AIR in place, a partial property set fills
+  defaults — the raw spelling and the resolved state's canonical form are then
+  different strings, different dictionaries, different bytes: red
+  `SerializerParityGameTests`, per-path `DirtyContentFilter` hashes), and
+  (b) void §4.2's "exact and lossless on the same MC version" egress premise
+  (a raw spelling absent from the registry has no id for the v19 translator).
+  The `MemoizedNbtCodec` id resolve therefore survives for the wire identity as
+  well as the two shorts and the x-ray mask pre-gate (`mask.containsId`,
+  `:497-508`). The >256-palette object-path fallback can be RETIRED for encoding
+  (v20 has no DIRECT limit; a >256 disk palette transcodes fine) but stays for
+  malformed shapes.
 - **X-ray masking** stays upstream of encoding, in the object/descriptor domain
   (`XrayMaskFilter.mask` on `LevelChunkSection` before `write`; transcode pre-gate
   unchanged) — every serve path and the `DirtyContentFilter` hash keep seeing

--- a/docs/planning/v0.10.0-progress.md
+++ b/docs/planning/v0.10.0-progress.md
@@ -17,7 +17,7 @@ the mega plan at the overridden text — never a silent divergence.
 | B3 | R1 background-read split | MERGED 2026-08-07 | #92 | IO-Worker LSS-frames +99.4%/+99.1%/+99.0% cut (serve/hibw/backfill) vs ≥75%/≥50% gates; hibw ceiling +3.8%; walk flat; A7 triage exonerated; review 1 BLOCKER + 2 MAJORs + 17 minors fixed |
 | B4 | R2 selective NBT parse | MERGED 2026-08-07 | #93 | kill-switch A/B on `bae0952`: four-class alloc/col +50.0%/+48.1% cut (serve/backfill) vs ≥30%; nbt-minus-memo +50.2%/+58.6% vs ≥25%; parity 0.03%/exact; walk flat; 0 fallback warns; review 1 MAJOR (B4-1 skip-desync → exhaustion check) + 9 minors fixed |
 | B5 | Round-acceptance closing A/B (merge gate for C1) | ROUND ACCEPTED 2026-08-07 | — | base=`834e4d7` vs final: backfill 3-thread +21.3% vs ≥15%; alloc +49.2%/+52.4% vs ≥30%; hibw ceiling +10.7% (µs/col +5.9% cut there); store gate outright; serve-µs/col −4.3% n.s. = documented deviation (R1+10.3%×R2−10.5% composition); noise audit clean |
-| C0 | IdentityCodec + registry tables + WireSectionCursor + settling measurement | pending | — | — |
+| C0 | IdentityCodec + registry tables + WireSectionCursor + settling measurement | implemented + gated 2026-08-07; review round pending | — | new common/wire package + platform tables, all INERT; corpus cross-check + whole-registry sweeps + every-prefix truncation fuzz green (T1 Fabric+Paper, T2); settling: raw +5.28%, zstd-1 frame **+9.70%** (above §8's 4–6% — size claims re-baselined, ledger) |
 | C1 | v20 encode + client decode + handshake + WireDialectTracker + `Dialects:` diag | pending | — | — |
 | C2 | Legacy egress translators + store-hit recompress + dialect-19 soak lever | pending | — | — |
 | C3 | Client ladder (20→19→16 discovery) | pending | — | — |
@@ -432,6 +432,73 @@ the mega plan at the overridden text — never a silent divergence.
   chain; 0xC0 0x00 verified genuinely invalid modified-UTF8; Tier 2 parity covers
   selective over a real DEFLATE region file).
 
+- **2026-08-07 (C0 pre-implementation recon — 26.2 API facts via javap on the loom
+  named jar + repo facts via a read-only sweep)**: MC surface for the identity
+  tables: `Block.BLOCK_STATE_REGISTRY` is `IdMapper<BlockState>` with BOTH
+  directions (`getId`/`byId`) plus `iterator()`/`size()` — the fingerprint's
+  "iteration order IS global-id order" doc carries over; `StateHolder.getProperties()`
+  returns `Collection<Property<?>>` and canonical values come from the abstract
+  `Property.getName(T)` stringifier (NOTE: 26.2's `getValues()` returns
+  `Stream<Property$Value<?>>`, not the old map — use getProperties+getValue);
+  `StateDefinition.getProperty(String)` exists for the decode rung; block names via
+  `BuiltInRegistries.BLOCK.getKey` → **`net.minecraft.resources.Identifier`** (26.2
+  renamed ResourceLocation — a D3 re-port catalogue item), with
+  `isValidNamespace/isValidPath` public for the charset pin; biomes are the dynamic
+  `Registries.BIOME` (per-`RegistryAccess`, platform-supplied — the
+  `RegistryFingerprint` pattern: platform extracts `Iterable<String>`, common stays
+  MC-free). Repo facts: `common/` has ZERO VarInt/wire primitives (the cursor
+  hand-rolls MC-format VarInt; a fabric-side cross-check vs `FriendlyByteBuf` pins
+  equivalence); the transcode emit shape is `TranscodedBody.writeContainer`
+  (`NbtSectionSerializer:311-324` — bits byte, bits==0 single VarInt else VarInt
+  count + entries, raw big-endian longs with NO length prefix, count implied by
+  bits: valuesPerLong=64/bits, entries 4096 blocks / 64 biomes); native
+  palette-vs-DIRECT thresholds blocks >8 bits / biomes >3 bits; the committed
+  `nbt-corpus` goldens are exactly the native section-array layout (VarInt count +
+  sections) — corpus-driven cursor walk checks live fabric-side where both the
+  corpus and FriendlyByteBuf are reachable; the settling-measurement template is
+  `CompressedColumnsExperimentTool` (self-skipping JUnit, plain
+  `Bootstrap.bootStrap()` + `VanillaRegistries.createLookup()` registries, direct
+  `.mca` reads, gradle property pass-through in fabric/build.gradle:92-100, real
+  zstd-1 frames); §8's corpus (`test-server/paper` world) is present on disk
+  (12 overworld .mca, 37 MB). Scope decision: the settling encoder IS the
+  byte-domain **`NativeToV20Translator`** (native wire → v20 wire over
+  WireSectionCursor with an injected id→identity lookup) — a production component
+  the C4 migration walk reuses, not throwaway harness code; the v20→native
+  direction (legacy egress) stays C2 per the landing order, so §9's bijection fuzz
+  lands there. C0 lands INERT to main (no serve-path wiring — that is C1, behind
+  the integration-branch constraint).
+
+- **2026-08-07 (C0 implementation decisions, XVER Phase 0)**: lands INERT to main —
+  no serve path consults any of it until C1. `common/wire/` is the new package:
+  `WireBytes` (hand-rolled MC-format VarInt/short/long/UTF over `byte[]`, bit-identity
+  pinned fabric-side against the real `FriendlyByteBuf`), `WireFormatException` (the
+  single pinned failure mode for hostile input — array errors and wire-claimed
+  allocations are test-pinned OUT), `IdentityCodec` (canonical
+  `namespace:path[k1=v1,…]` form, strict parse accepting ONLY canonical spellings —
+  a tolerant parser would let two dictionary spellings encode one state; charset
+  grammar excludes `[ ] , =` + whitespace, the no-escaping premise as code),
+  `IdentityDictionary` (first-seen indices, validates at insertion),
+  `WireSectionCursor` (both layouts parse/scan/emit; native palette-vs-DIRECT
+  thresholds blocks >8 / biomes >3 bits; implied long counts 64/bits; v20 width
+  ceilings 12/6 parse-enforced; the clear-column `dictCount==0 ⇔ sectionCount==0`
+  invariant enforced on BOTH parse and emit), and `NativeToV20Translator` (the §4.2
+  encode direction: indexed containers keep bits+longs VERBATIM with palettes
+  rewritten to dict indices; DIRECT re-palettizes first-seen and repacks at the
+  §2.1 widths — blocks n==1→0 else clamp(ceillog2,4,12), biomes ceillog2; count
+  shorts + light pass through verbatim). Platform `IdentityTables` +
+  `PaperIdentityTables` (textual twins): blocks from `Block.BLOCK_STATE_REGISTRY`
+  (ids via `getId`, not iteration position), biomes per-registry builders (callers
+  memoize at C1 wiring). Test posture: the corpus cross-check
+  (`WireSectionCursorCorpusTest`) walks all 14 committed nbt-corpus goldens —
+  scan-to-exact-length + parse→emit byte-identity, with a DIRECT-coverage guard so
+  the suite cannot silently lose its teeth; `IdentityTablesTest` +
+  Paper twin sweep the ENTIRE ~29k-state registry (canonical + strictly-parseable +
+  globally-unique + exact inverse-mirror), with character-identical spot-pin
+  literals as the cross-platform anchor; truncation containment fuzzes EVERY strict
+  prefix of both layouts. The settling tool (`V20SettlingExperimentTool`) mirrors
+  the experiment-tool contract (self-skipping, `-Dlss.store.experiment.regionDir`
+  pass-through — zero gradle changes).
+
 - **2026-08-07 (B5 round-acceptance deviation — the serve-arm µs/col gate, plan-text
   pair: the VERDICT block in the plan's Round acceptance section)**: the closing
   A/B's serve-arm lss-attributed µs/col came in at **−4.3% (a rise), n.s. vs zero
@@ -644,6 +711,24 @@ the mega plan at the overridden text — never a silent divergence.
   same-day; negative result recorded in the plan's Phase 1 verdict block; B5's
   closing A/B drops R3. Artifacts: `profile-results/b1-backfill`,
   `profile-results/b1-serve` (+ jfr-report.md each).
+
+- **2026-08-07 — C0 settling measurement (XVER §8's gate on published size claims):
+  REAL-ENCODER numbers land ABOVE the wire envelope — release notes must cite ~+10%
+  wire/store growth, not §8's +4–6%.** Method: the §8 corpus (`test-server/paper`
+  overworld, genuine played terrain), EVERY full column (2,684 — §8 sampled 400),
+  production `serializeChunkNbt` (native v19) vs `NativeToV20Translator` over the
+  real registry tables, actual zstd-1 frames, size-only (no box-exclusivity needed).
+  Results: **raw 35,829 → 37,719 B/col = +1,891 B/col (+5.28%)** — inside §8's
+  +3.5–6% raw envelope (upper half; this corpus is richer than §8's sample: 51 dict
+  entries/col vs 38, 11 served sections vs 9.6); **zstd-1 frame 5,785 → 6,346 B/col
+  = +561 B/col (+9.70%)** — §8's ≈+4–6% wire figure UNDERSTATED it, exactly the
+  cross-corpus/zlib-proxy bias §8 itself flagged (the proxy omitted index bytes and
+  the current palette's own compressed cost). Store rows grow with the wire figure
+  ⇒ plan on ~+10% store growth at C4 migration. Robustness receipts: 0 translate
+  failures, 0 reparse failures across all 2,684 columns (the cursor + tables +
+  translator handled every real column); p95 frame delta +860 B, max +1,432 B —
+  no pathological outliers. Artifacts: `profile-results/v20-settling/settling.json`;
+  tool `V20SettlingExperimentTool` (re-runnable on any corpus).
 
 ## Live-deploy log
 

--- a/docs/planning/v0.10.0-progress.md
+++ b/docs/planning/v0.10.0-progress.md
@@ -499,6 +499,44 @@ the mega plan at the overridden text — never a silent divergence.
   the experiment-tool contract (self-skipping, `-Dlss.store.experiment.regionDir`
   pass-through — zero gradle changes).
 
+- **2026-08-07 (C0 review round, single grouped Opus reviewer — all three lenses;
+  0 CRITICALs, 6 MAJORs + 11 minors + 7 notes, all addressed or explicitly
+  deferred)**: the cleared list is unusually strong — the reviewer verified the
+  layout model against 26.2 BYTECODE (disassembled `PalettedContainer$Data.write`,
+  `Strategy$1/$2` width→shape tables, `VarInt.read` truncation semantics,
+  `StateDefinition.NAME_PATTERN`) rather than trusting repo comments. **MAJOR 1**:
+  v20 palette indices now range-checked against the dictionary on BOTH parse and
+  emit (referential integrity is the cursor's job, not each consumer's).
+  **MAJOR 2**: native palette values read as non-negative + bounds-checked
+  `blockIdentityFor(int)`/`BiomeTable.identityFor(int)` accessors on both
+  platforms (a bare `table[id]` turned corrupt input into AIOOBE past the pinned
+  failure mode). **MAJOR 3**: `dictCount` no longer pre-sizes the dictionary list
+  (§2.3's hostile-allocation pin, dictCount included — the gross-case remaining
+  guard alone allowed ~20× amplification). **MAJOR 4 — the round's headline**:
+  vanilla's width→SHAPE tables make block bits 1-3 ILLEGAL on the native wire
+  (indexed blocks exist only at 4-8; a bits-2 frame desyncs a real `section.read`
+  by 128 longs) — the cursor now enforces the shape table on parse AND emit, so
+  cursor-accepted ⇒ vanilla-decodable is a real invariant before C2's egress
+  translator exists to violate it. **MAJOR 5**: the §2.1 v20 block width FLOOR
+  (4) enforced alongside the ceilings. **MAJOR 6 (spec hazard, plan-text pair)**:
+  §4.1's "canonicalize straight from disk NBT, no registry resolution" is
+  RETRACTED — amended in the XVER plan to the pinned rule "wire identities are
+  always the identity of a state RESOLVED in the emitting server's registry"
+  (the raw-spelling reading would break disk/live byte parity whenever codec
+  leniency fires, and void §4.2's lossless-egress premise; the memo resolves
+  every palette entry anyway, so the id→identity lookup is one array index).
+  Minors: emit-side identity-length cap + sectionY/count range checks (silent
+  truncation), settling tool now FAILS on excluded columns (self-invalidating
+  size gate), corpus-driven translator test (voxel-for-voxel over all 14 goldens
+  incl. duplicate-palette + masked), golden count pinned at 14, Paper biome-table
+  twin test, VarInt READ-parity on non-canonical forms (MC truncates the 5-byte
+  overflow form — verified identical), box-free first-seen remap (no
+  Integer-boxing per voxel on the C4 migration path), null-property loud failure
+  in `canonical`, biome null-key → throw at table build, `scan` limit overload,
+  writer pre-sizing, shared-array + deliberately-unvalidated-parse javadoc
+  notes. Deferred with rationale: split-package note (repo test convention),
+  parse-copy costs (C2's legacy-dialect benchmark arm owns that question, N20).
+
 - **2026-08-07 (B5 round-acceptance deviation — the serve-arm µs/col gate, plan-text
   pair: the VERDICT block in the plan's Round acceptance section)**: the closing
   A/B's serve-arm lss-attributed µs/col came in at **−4.3% (a rise), n.s. vs zero

--- a/fabric/src/main/java/dev/vox/lss/networking/server/IdentityTables.java
+++ b/fabric/src/main/java/dev/vox/lss/networking/server/IdentityTables.java
@@ -1,0 +1,113 @@
+package dev.vox.lss.networking.server;
+
+import dev.vox.lss.common.wire.IdentityCodec;
+import net.minecraft.core.Registry;
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.world.level.biome.Biome;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.block.state.properties.Property;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * The protocol-20 registry identity tables (XVER Phase 0): global id ↔ canonical
+ * identity string ({@link IdentityCodec} form), both directions.
+ *
+ * <p>Blocks enumerate {@code Block.BLOCK_STATE_REGISTRY} — the same enumeration
+ * {@code RegistryFingerprint} uses (its iteration order IS global-id order, but ids
+ * are taken from {@code getId} rather than assumed). Biomes are the dynamic
+ * per-{@code RegistryAccess} registry, so their table is built per registry instance
+ * by the caller ({@link #biomeTable}); the block table is JVM-global and lazy.
+ *
+ * <p>Every identity passes {@link IdentityCodec#canonical} validation at build — an
+ * out-of-charset modded property value fails the table build loudly (and its Tier-1
+ * whole-registry sweep), never as silent wire corruption. Phase 0 ships these tables
+ * INERT: no serve path consults them until the v20 encode lands (C1); the settling
+ * measurement and the translator tests are the only consumers today.
+ */
+public final class IdentityTables {
+    private IdentityTables() {}
+
+    private static volatile String[] blockIdentities;
+    private static volatile Map<String, Integer> blockIdsByIdentity;
+
+    /** Canonical identity for every block state, indexed by global id. */
+    public static String[] blockIdentities() {
+        String[] table = blockIdentities;
+        if (table == null) {
+            synchronized (IdentityTables.class) {
+                table = blockIdentities;
+                if (table == null) {
+                    blockIdentities = table = buildBlockIdentities();
+                }
+            }
+        }
+        return table;
+    }
+
+    /** The inverse direction (legacy egress / decode): canonical identity → global id. */
+    public static Map<String, Integer> blockIdsByIdentity() {
+        Map<String, Integer> map = blockIdsByIdentity;
+        if (map == null) {
+            synchronized (IdentityTables.class) {
+                map = blockIdsByIdentity;
+                if (map == null) {
+                    String[] table = blockIdentities();
+                    var built = new HashMap<String, Integer>(table.length * 2);
+                    for (int id = 0; id < table.length; id++) {
+                        if (table[id] != null) {
+                            built.put(table[id], id);
+                        }
+                    }
+                    blockIdsByIdentity = map = Map.copyOf(built);
+                }
+            }
+        }
+        return map;
+    }
+
+    private static String[] buildBlockIdentities() {
+        var registry = Block.BLOCK_STATE_REGISTRY;
+        var table = new String[registry.size()];
+        for (BlockState state : registry) {
+            table[registry.getId(state)] = canonicalOf(state);
+        }
+        return table;
+    }
+
+    /** The canonical identity of one block state — name + ALL properties, sorted. */
+    public static String canonicalOf(BlockState state) {
+        String name = BuiltInRegistries.BLOCK.getKey(state.getBlock()).toString();
+        var props = new HashMap<String, String>();
+        for (Property<?> property : state.getProperties()) {
+            props.put(property.getName(), valueName(state, property));
+        }
+        return IdentityCodec.canonical(name, props);
+    }
+
+    private static <T extends Comparable<T>> String valueName(BlockState state, Property<T> property) {
+        return property.getName(state.getValue(property));
+    }
+
+    /** Both directions for one biome registry (dynamic — per RegistryAccess). */
+    public record BiomeTable(String[] identities, Map<String, Integer> idsByIdentity) {}
+
+    public static BiomeTable biomeTable(Registry<Biome> biomes) {
+        var identities = new String[biomes.size()];
+        var inverse = new HashMap<String, Integer>(biomes.size() * 2);
+        for (Biome biome : biomes) {
+            int id = biomes.getId(biome);
+            var key = biomes.getKey(biome);
+            if (key == null) {
+                continue;  // unkeyed intrusive entry: left null, translator fails loudly on use
+            }
+            String identity = key.toString();
+            IdentityCodec.validate(identity);
+            identities[id] = identity;
+            inverse.put(identity, id);
+        }
+        return new BiomeTable(identities, Map.copyOf(inverse));
+    }
+}

--- a/fabric/src/main/java/dev/vox/lss/networking/server/IdentityTables.java
+++ b/fabric/src/main/java/dev/vox/lss/networking/server/IdentityTables.java
@@ -77,6 +77,18 @@ public final class IdentityTables {
         return table;
     }
 
+    /**
+     * Bounds-checked lookup for wire-derived ids — the shape every consumer should
+     * use (a bare {@code table[id]} turns a corrupt palette id into
+     * {@code ArrayIndexOutOfBoundsException} instead of the translator's pinned
+     * loud failure). Returns null for an unknown id; {@code NativeToV20Translator}
+     * converts null into {@code IllegalArgumentException}.
+     */
+    public static String blockIdentityFor(int globalId) {
+        String[] table = blockIdentities();
+        return globalId >= 0 && globalId < table.length ? table[globalId] : null;
+    }
+
     /** The canonical identity of one block state — name + ALL properties, sorted. */
     public static String canonicalOf(BlockState state) {
         String name = BuiltInRegistries.BLOCK.getKey(state.getBlock()).toString();
@@ -92,7 +104,12 @@ public final class IdentityTables {
     }
 
     /** Both directions for one biome registry (dynamic — per RegistryAccess). */
-    public record BiomeTable(String[] identities, Map<String, Integer> idsByIdentity) {}
+    public record BiomeTable(String[] identities, Map<String, Integer> idsByIdentity) {
+        /** Bounds-checked lookup for wire-derived ids (see {@code blockIdentityFor}). */
+        public String identityFor(int id) {
+            return id >= 0 && id < identities.length ? identities[id] : null;
+        }
+    }
 
     public static BiomeTable biomeTable(Registry<Biome> biomes) {
         var identities = new String[biomes.size()];
@@ -101,7 +118,10 @@ public final class IdentityTables {
             int id = biomes.getId(biome);
             var key = biomes.getKey(biome);
             if (key == null) {
-                continue;  // unkeyed intrusive entry: left null, translator fails loudly on use
+                // A registry-iterated value always has a key; a null here means the
+                // registry is broken — fail the table build loudly rather than leave
+                // a hole that surfaces as a per-serve exception later.
+                throw new IllegalStateException("biome id " + id + " has no registry key");
             }
             String identity = key.toString();
             IdentityCodec.validate(identity);

--- a/fabric/src/test/java/dev/vox/lss/common/wire/IdentityCodecTest.java
+++ b/fabric/src/test/java/dev/vox/lss/common/wire/IdentityCodecTest.java
@@ -1,0 +1,122 @@
+package dev.vox.lss.common.wire;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The canonical identity form (XVER §2.1): all properties, sorted by name, no spaces;
+ * bare form without properties; strict parse that accepts ONLY the canonical
+ * spelling; and the charset-safety pin — the grammar PROVES the four structural
+ * characters cannot occur inside any segment, which is the no-escaping premise.
+ */
+class IdentityCodecTest {
+
+    @Test
+    void bareFormForPropertylessStates() {
+        assertEquals("minecraft:stone", IdentityCodec.canonical("minecraft:stone", Map.of()));
+        assertEquals("minecraft:stone", IdentityCodec.canonical("minecraft:stone", null));
+    }
+
+    @Test
+    void propertiesAreSortedByNameRegardlessOfInputOrder() {
+        var props = new LinkedHashMap<String, String>();
+        props.put("waterlogged", "false");
+        props.put("facing", "north");
+        props.put("half", "top");
+        assertEquals("minecraft:oak_stairs[facing=north,half=top,waterlogged=false]",
+                IdentityCodec.canonical("minecraft:oak_stairs", props));
+    }
+
+    @Test
+    void roundTripThroughParse() {
+        String identity = "mod_pack:heavy/ore_block[age=25,lit=true]";
+        var parsed = IdentityCodec.parse(identity);
+        assertEquals("mod_pack:heavy/ore_block", parsed.name());
+        assertEquals(List.of(Map.entry("age", "25"), Map.entry("lit", "true")),
+                parsed.properties());
+        assertEquals(identity, IdentityCodec.canonical(parsed.name(),
+                Map.ofEntries(parsed.properties().toArray(Map.Entry[]::new))));
+    }
+
+    @Test
+    void biomeStyleBareIdentifiersValidate() {
+        IdentityCodec.validate("minecraft:windswept_gravelly_hills");
+        IdentityCodec.validate("terralith:skylands_autumn");
+    }
+
+    @Test
+    void malformedStringsAreRejected() {
+        for (String bad : new String[] {
+                "", "stone", ":stone", "minecraft:", "a:b:c",
+                "minecraft:stone[]",                       // empty list must be bare
+                "minecraft:stone[facing]",                 // no '='
+                "minecraft:stone[facing=]",                // empty value
+                "minecraft:stone[=north]",                 // empty name
+                "minecraft:stone[facing=north",            // unterminated
+                "minecraft:stone[b=1,a=2]",                // unsorted
+                "minecraft:stone[a=1,a=2]",                // duplicate
+                "minecraft:stone[a=1,,b=2]",               // empty pair
+                "minecraft:Stone",                         // uppercase path
+                "Minecraft:stone",                         // uppercase namespace
+                "minecraft:stone[Facing=north]",           // uppercase prop name
+                "minecraft:stone[facing=North]",           // uppercase prop value
+                "minecraft:sto ne", "minecraft:stone[a=1] ",
+        }) {
+            assertThrows(IllegalArgumentException.class, () -> IdentityCodec.validate(bad),
+                    "should have rejected: " + bad);
+        }
+    }
+
+    /**
+     * The no-escaping premise, pinned as grammar: every segment charset excludes
+     * '[' ']' ',' '=' and whitespace, so no legal identity can contain a structural
+     * character anywhere but its structural position.
+     */
+    @Test
+    void structuralCharactersCannotOccurInsideAnySegment() {
+        for (char c : new char[] { '[', ']', ',', '=', ' ', '\t' }) {
+            String inNamespace = "min" + c + "ecraft:stone";
+            String inPath = "minecraft:st" + c + "one";
+            String inPropName = "minecraft:stone[fa" + c + "cing=north]";
+            String inPropValue = "minecraft:stone[facing=no" + c + "rth]";
+            for (String bad : new String[] { inNamespace, inPath, inPropName, inPropValue }) {
+                assertThrows(IllegalArgumentException.class, () -> IdentityCodec.validate(bad),
+                        "structural char '" + c + "' must be rejected in: " + bad);
+            }
+        }
+    }
+
+    @Test
+    void canonicalValidatesItsOwnOutput() {
+        assertThrows(IllegalArgumentException.class,
+                () -> IdentityCodec.canonical("minecraft:stone", Map.of("bad key", "x")));
+        assertThrows(IllegalArgumentException.class,
+                () -> IdentityCodec.canonical("no-colon", Map.of()));
+    }
+
+    @Test
+    void dictionaryAssignsFirstSeenIndicesDeterministically() {
+        var dict = new IdentityDictionary();
+        assertEquals(0, dict.indexOf("minecraft:stone"));
+        assertEquals(1, dict.indexOf("minecraft:dirt"));
+        assertEquals(0, dict.indexOf("minecraft:stone"));   // repeat: stable
+        assertEquals(2, dict.indexOf("minecraft:plains"));  // biomes share the table
+        assertEquals(List.of("minecraft:stone", "minecraft:dirt", "minecraft:plains"),
+                dict.entries());
+        assertEquals(3, dict.size());
+    }
+
+    @Test
+    void dictionaryValidatesOnFirstInsertion() {
+        var dict = new IdentityDictionary();
+        assertThrows(IllegalArgumentException.class, () -> dict.indexOf("not an identity"));
+        assertTrue(dict.entries().isEmpty(), "rejected identity must not be retained");
+    }
+}

--- a/fabric/src/test/java/dev/vox/lss/common/wire/NativeToV20TranslatorTest.java
+++ b/fabric/src/test/java/dev/vox/lss/common/wire/NativeToV20TranslatorTest.java
@@ -1,0 +1,244 @@
+package dev.vox.lss.common.wire;
+
+import dev.vox.lss.common.wire.WireSectionCursor.Layout;
+import dev.vox.lss.common.wire.WireSectionCursor.WireColumn;
+import dev.vox.lss.common.wire.WireSectionCursor.WireContainer;
+import dev.vox.lss.common.wire.WireSectionCursor.WireSection;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Random;
+import java.util.function.IntFunction;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The native → v20 byte-domain translation (§4.2 encode direction): indexed
+ * containers keep bits + packed longs VERBATIM with palettes rewritten to
+ * dictionary indices; DIRECT containers re-palettize (first-seen scan order) and
+ * repack at the §2.1 v20 widths; count shorts and light pass through; the
+ * dictionary is shared, first-seen, and validated.
+ */
+class NativeToV20TranslatorTest {
+
+    private static final IntFunction<String> BLOCKS = id -> switch (id) {
+        case 0 -> "minecraft:air";
+        case 9 -> "minecraft:stone";
+        case 130 -> "minecraft:oak_stairs[facing=north,half=top,waterlogged=false]";
+        default -> "minecraft:generated_" + id;
+    };
+    private static final IntFunction<String> BIOMES = id -> switch (id) {
+        case 2 -> "minecraft:plains";
+        default -> "minecraft:biome_" + id;
+    };
+
+    private static byte[] nativeBody(WireSection... sections) {
+        return WireSectionCursor.emit(new WireColumn(List.of(), List.of(sections)), Layout.NATIVE);
+    }
+
+    private static long[] packed(int[] values, int bits) {
+        return WireSectionCursor.pack(values, bits);
+    }
+
+    @Test
+    void indexedSectionsShipLongsVerbatimWithDictIndexPalettes() {
+        var rng = new Random(7);
+        var blockValues = new int[4096];
+        for (int i = 0; i < 4096; i++) {
+            blockValues[i] = rng.nextInt(3);
+        }
+        var blocks = new WireContainer(4, new int[] { 0, 9, 130 }, packed(blockValues, 4));
+        var biomes = new WireContainer(0, new int[] { 2 }, new long[0]);
+        byte[] v20 = NativeToV20Translator.translate(
+                nativeBody(new WireSection(-4, 100, 5, blocks, biomes, null, null)),
+                BLOCKS, BIOMES);
+
+        var column = WireSectionCursor.parse(v20, Layout.V20);
+        assertEquals(List.of("minecraft:air", "minecraft:stone",
+                "minecraft:oak_stairs[facing=north,half=top,waterlogged=false]",
+                "minecraft:plains"), column.dictionary());
+        var s = column.sections().get(0);
+        assertEquals(-4, s.sectionY());
+        assertEquals(100, s.nonEmptyBlockCount());
+        assertEquals(5, s.fluidCount());
+        assertEquals(4, s.blocks().bits());
+        assertArrayEquals(new int[] { 0, 1, 2 }, s.blocks().palette());
+        assertArrayEquals(blocks.data(), s.blocks().data(), "packed longs must ship verbatim");
+        assertEquals(0, s.biomes().bits());
+        assertArrayEquals(new int[] { 3 }, s.biomes().palette());
+    }
+
+    @Test
+    void directBlocksArePalettizedInFirstSeenOrderAndRepacked() {
+        // A DIRECT container at width 15 holding three distinct ids.
+        var ids = new int[4096];
+        for (int i = 0; i < 4096; i++) {
+            ids[i] = (i % 3 == 0) ? 9 : (i % 3 == 1 ? 4242 : 130);
+        }
+        var direct = new WireContainer(15, null, packed(ids, 15));
+        var biomes = new WireContainer(0, new int[] { 2 }, new long[0]);
+        byte[] v20 = NativeToV20Translator.translate(
+                nativeBody(new WireSection(2, 4096, 0, direct, biomes, null, null)),
+                BLOCKS, BIOMES);
+
+        var s = WireSectionCursor.parse(v20, Layout.V20).sections().get(0);
+        // First-seen scan order: 9, 4242, 130 -> dict 0,1,2; blocks floor width 4.
+        assertEquals(4, s.blocks().bits());
+        assertArrayEquals(new int[] { 0, 1, 2 }, s.blocks().palette());
+        int[] repacked = WireSectionCursor.unpack(s.blocks().data(), 4, 4096);
+        for (int i = 0; i < 4096; i++) {
+            int expected = (i % 3 == 0) ? 0 : (i % 3 == 1 ? 1 : 2);
+            assertEquals(expected, repacked[i], "voxel " + i + " must be preserved");
+        }
+        assertEquals(List.of("minecraft:stone", "minecraft:generated_4242",
+                "minecraft:oak_stairs[facing=north,half=top,waterlogged=false]",
+                "minecraft:plains"),
+                WireSectionCursor.parse(v20, Layout.V20).dictionary());
+    }
+
+    @Test
+    void directBiomesRepackAtCeillog2IncludingTheSingleValueCollapse() {
+        var biomeIds = new int[64];
+        for (int i = 0; i < 64; i++) {
+            biomeIds[i] = (i < 32) ? 2 : 13;  // both fit the 4-bit DIRECT width
+        }
+        var directBiomes = new WireContainer(4, null, packed(biomeIds, 4));
+        var single = new WireContainer(0, new int[] { 9 }, new long[0]);
+        byte[] v20 = NativeToV20Translator.translate(
+                nativeBody(new WireSection(0, 1, 0, single, directBiomes, null, null)),
+                BLOCKS, BIOMES);
+        var s = WireSectionCursor.parse(v20, Layout.V20).sections().get(0);
+        assertEquals(1, s.biomes().bits(), "two entries -> ceillog2(2) = 1 (no block floor)");
+        int[] repacked = WireSectionCursor.unpack(s.biomes().data(), 1, 64);
+        for (int i = 0; i < 64; i++) {
+            assertEquals(i < 32 ? 0 : 1, repacked[i]);
+        }
+
+        // All-one-id DIRECT collapses to a single-value container (bits 0, no data).
+        var uniform = new WireContainer(4, null, packed(new int[64], 4)); // all id 0
+        byte[] v20b = NativeToV20Translator.translate(
+                nativeBody(new WireSection(0, 1, 0, single, uniform, null, null)),
+                BLOCKS, id -> "minecraft:the_void");
+        var sb = WireSectionCursor.parse(v20b, Layout.V20).sections().get(0);
+        assertEquals(0, sb.biomes().bits());
+        assertEquals(0, sb.biomes().data().length);
+    }
+
+    @Test
+    void dictionaryIsSharedAcrossSectionsAndKindsFirstSeen() {
+        var stoneSingle = new WireContainer(0, new int[] { 9 }, new long[0]);
+        var plainsSingle = new WireContainer(0, new int[] { 2 }, new long[0]);
+        var s1 = new WireSection(-4, 1, 0, stoneSingle, plainsSingle, null, null);
+        var s2 = new WireSection(-3, 1, 0, stoneSingle, plainsSingle, null, null);
+        byte[] v20 = NativeToV20Translator.translate(nativeBody(s1, s2), BLOCKS, BIOMES);
+        var column = WireSectionCursor.parse(v20, Layout.V20);
+        // stone first (section 1 blocks), plains second (section 1 biomes); section 2
+        // adds nothing — repeats resolve to the same indices.
+        assertEquals(List.of("minecraft:stone", "minecraft:plains"), column.dictionary());
+        assertArrayEquals(new int[] { 0 }, column.sections().get(1).blocks().palette());
+        assertArrayEquals(new int[] { 1 }, column.sections().get(1).biomes().palette());
+    }
+
+    @Test
+    void clearColumnTranslatesToTheEmptyDictionaryClearFrame() {
+        byte[] v20 = NativeToV20Translator.translate(nativeBody(), BLOCKS, BIOMES);
+        assertArrayEquals(new byte[] { 0, 0 }, v20);
+    }
+
+    @Test
+    void lightLayersAndCountShortsPassThroughVerbatim() {
+        var blLight = new byte[2048];
+        var skyLight = new byte[2048];
+        new Random(3).nextBytes(blLight);
+        new Random(4).nextBytes(skyLight);
+        var single = new WireContainer(0, new int[] { 9 }, new long[0]);
+        var biome = new WireContainer(0, new int[] { 2 }, new long[0]);
+        byte[] v20 = NativeToV20Translator.translate(
+                nativeBody(new WireSection(5, 1234, 77, single, biome, blLight, skyLight)),
+                BLOCKS, BIOMES);
+        var s = WireSectionCursor.parse(v20, Layout.V20).sections().get(0);
+        assertEquals(1234, s.nonEmptyBlockCount());
+        assertEquals(77, s.fluidCount());
+        assertArrayEquals(blLight, s.blockLight());
+        assertArrayEquals(skyLight, s.skyLight());
+    }
+
+    @Test
+    void missingOrInvalidIdentitiesFailLoudly() {
+        var single = new WireContainer(0, new int[] { 9 }, new long[0]);
+        var biome = new WireContainer(0, new int[] { 2 }, new long[0]);
+        byte[] body = nativeBody(new WireSection(0, 1, 0, single, biome, null, null));
+        assertThrows(IllegalArgumentException.class,
+                () -> NativeToV20Translator.translate(body, id -> null, BIOMES));
+        assertThrows(IllegalArgumentException.class,
+                () -> NativeToV20Translator.translate(body, id -> "Not Canonical", BIOMES));
+    }
+
+    @Test
+    void v20BitsMatchesTheSpecTable() {
+        assertEquals(0, NativeToV20Translator.v20Bits(1, true));
+        assertEquals(4, NativeToV20Translator.v20Bits(2, true));
+        assertEquals(4, NativeToV20Translator.v20Bits(16, true));
+        assertEquals(5, NativeToV20Translator.v20Bits(17, true));
+        assertEquals(8, NativeToV20Translator.v20Bits(256, true));
+        assertEquals(9, NativeToV20Translator.v20Bits(257, true));
+        assertEquals(12, NativeToV20Translator.v20Bits(4096, true));
+        assertEquals(0, NativeToV20Translator.v20Bits(1, false));
+        assertEquals(1, NativeToV20Translator.v20Bits(2, false));
+        assertEquals(3, NativeToV20Translator.v20Bits(8, false));
+        assertEquals(6, NativeToV20Translator.v20Bits(64, false));
+    }
+
+    /** Fuzz: random native columns translate to parseable v20 whose voxel content matches. */
+    @Test
+    void translationPreservesEveryVoxelUnderFuzz() {
+        var rng = new Random(20260807);
+        for (int round = 0; round < 40; round++) {
+            int paletteSize = 1 + rng.nextInt(20);
+            var palette = new int[paletteSize];
+            for (int i = 0; i < paletteSize; i++) {
+                palette[i] = rng.nextInt(30000);
+            }
+            var values = new int[4096];
+            for (int i = 0; i < 4096; i++) {
+                values[i] = rng.nextInt(paletteSize);
+            }
+            WireContainer blocks;
+            boolean direct = rng.nextBoolean();
+            if (direct) {
+                var ids = new int[4096];
+                for (int i = 0; i < 4096; i++) {
+                    ids[i] = palette[values[i]];
+                }
+                blocks = new WireContainer(15, null, packed(ids, 15));
+            } else {
+                int bits = Math.max(4, 32 - Integer.numberOfLeadingZeros(paletteSize - 1));
+                blocks = paletteSize == 1
+                        ? new WireContainer(0, palette, new long[0])
+                        : new WireContainer(bits, palette, packed(values, bits));
+            }
+            var biomes = new WireContainer(0, new int[] { rng.nextInt(60) }, new long[0]);
+            byte[] v20 = NativeToV20Translator.translate(
+                    nativeBody(new WireSection(0, 1, 0, blocks, biomes, null, null)),
+                    BLOCKS, BIOMES);
+            var s = WireSectionCursor.parse(v20, Layout.V20).sections().get(0);
+            var dict = WireSectionCursor.parse(v20, Layout.V20).dictionary();
+            assertNotNull(s.blocks().palette());
+            int[] decodedIdx = s.blocks().bits() == 0
+                    ? null
+                    : WireSectionCursor.unpack(s.blocks().data(), s.blocks().bits(), 4096);
+            for (int i = 0; i < 4096; i++) {
+                String expected = BLOCKS.apply(palette[values[i]]);
+                int dictIndex = decodedIdx == null
+                        ? s.blocks().palette()[0]
+                        : s.blocks().palette()[decodedIdx[i]];
+                assertEquals(expected, dict.get(dictIndex), "round " + round + " voxel " + i);
+            }
+            assertTrue(s.blocks().bits() == 0 || s.blocks().bits() >= 4);
+        }
+    }
+}

--- a/fabric/src/test/java/dev/vox/lss/common/wire/WireBytesParityTest.java
+++ b/fabric/src/test/java/dev/vox/lss/common/wire/WireBytesParityTest.java
@@ -41,6 +41,27 @@ class WireBytesParityTest {
         }
     }
 
+    /**
+     * Read-side parity on NON-canonical encodings (review MINOR 14): our writer never
+     * produces these, but a shared wire parser must agree with MC on every input it
+     * can receive — notably the 5-byte overflow form, whose high bits MC silently
+     * truncates via Java's int shift.
+     */
+    @Test
+    void varIntReadParityOnNonCanonicalEncodings() {
+        byte[][] forms = {
+                { (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, 0x7F },  // overflow-truncated
+                { (byte) 0x80, (byte) 0x80, (byte) 0x80, (byte) 0x80, 0x10 },  // high-bit-only 5th byte
+                { (byte) 0x80, 0x00 },                                          // non-minimal zero
+                { (byte) 0xFF, 0x00 },                                          // non-minimal 127
+        };
+        for (byte[] form : forms) {
+            var mc = new FriendlyByteBuf(Unpooled.wrappedBuffer(form));
+            assertEquals(mc.readVarInt(), new WireBytes.Reader(form).readVarInt(),
+                    "read of " + java.util.Arrays.toString(form));
+        }
+    }
+
     @Test
     void scalarAndUtfShapesMatchFriendlyByteBuf() {
         var mc = new FriendlyByteBuf(Unpooled.buffer());

--- a/fabric/src/test/java/dev/vox/lss/common/wire/WireBytesParityTest.java
+++ b/fabric/src/test/java/dev/vox/lss/common/wire/WireBytesParityTest.java
@@ -1,0 +1,84 @@
+package dev.vox.lss.common.wire;
+
+import io.netty.buffer.Unpooled;
+import net.minecraft.network.FriendlyByteBuf;
+import org.junit.jupiter.api.Test;
+
+import java.util.Random;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * {@code common/} has no Minecraft dependency, so {@link WireBytes} hand-rolls the
+ * VarInt / big-endian / UTF shapes — this suite pins BIT-IDENTITY against the real
+ * {@code FriendlyByteBuf}, which is the whole premise of the shared cursor. A drift
+ * here would mean the cursor parses a different wire than the game emits.
+ */
+class WireBytesParityTest {
+
+    private static final int[] EDGE_VALUES = {
+            0, 1, 2, 126, 127, 128, 129, 255, 256, 16383, 16384, 2097151, 2097152,
+            268435455, 268435456, Integer.MAX_VALUE, -1, Integer.MIN_VALUE,
+    };
+
+    @Test
+    void varIntEncodingMatchesFriendlyByteBufOnEdgesAndFuzz() {
+        var rng = new Random(1);
+        for (int round = 0; round < 2000 + EDGE_VALUES.length; round++) {
+            int value = round < EDGE_VALUES.length ? EDGE_VALUES[round] : rng.nextInt();
+            var mc = new FriendlyByteBuf(Unpooled.buffer());
+            mc.writeVarInt(value);
+            byte[] expected = new byte[mc.readableBytes()];
+            mc.readBytes(expected);
+
+            var ours = new WireBytes.Writer(8);
+            ours.writeVarInt(value);
+            assertArrayEquals(expected, ours.toByteArray(), "encode of " + value);
+            assertEquals(expected.length, WireBytes.varIntSize(value), "size of " + value);
+            assertEquals(value, new WireBytes.Reader(expected).readVarInt(), "decode of " + value);
+        }
+    }
+
+    @Test
+    void scalarAndUtfShapesMatchFriendlyByteBuf() {
+        var mc = new FriendlyByteBuf(Unpooled.buffer());
+        mc.writeByte(-4);
+        mc.writeShort(4096);
+        mc.writeShort(-1);
+        mc.writeLong(0x0123456789ABCDEFL);
+        mc.writeUtf("minecraft:oak_stairs[facing=north]");
+        byte[] expected = new byte[mc.readableBytes()];
+        mc.readBytes(expected);
+
+        var ours = new WireBytes.Writer(64);
+        ours.writeByte(-4).writeShort(4096).writeShort(-1)
+                .writeLong(0x0123456789ABCDEFL).writeUtf("minecraft:oak_stairs[facing=north]");
+        assertArrayEquals(expected, ours.toByteArray());
+
+        var in = new WireBytes.Reader(expected);
+        assertEquals(-4, in.readByte());
+        assertEquals(4096, in.readShort());
+        assertEquals(-1, in.readShort());
+        assertEquals(0x0123456789ABCDEFL, in.readLong());
+        assertEquals("minecraft:oak_stairs[facing=north]", in.readUtf(256));
+        assertEquals(0, in.remaining());
+    }
+
+    @Test
+    void readerContainmentIsWireFormatExceptionNotArrayErrors() {
+        assertThrows(WireFormatException.class, () -> new WireBytes.Reader(new byte[0]).readByte());
+        assertThrows(WireFormatException.class, () -> new WireBytes.Reader(new byte[1]).readShort());
+        assertThrows(WireFormatException.class, () -> new WireBytes.Reader(new byte[7]).readLong());
+        assertThrows(WireFormatException.class,
+                () -> new WireBytes.Reader(new byte[] { (byte) 0x80 }).readVarInt());
+        assertThrows(WireFormatException.class,
+                () -> new WireBytes.Reader(new byte[] { (byte) 0x80, (byte) 0x80, (byte) 0x80,
+                        (byte) 0x80, (byte) 0x80, 1 }).readVarInt());
+        var negativeLen = new WireBytes.Writer(8).writeVarInt(-5).toByteArray();
+        assertThrows(WireFormatException.class,
+                () -> new WireBytes.Reader(negativeLen).readUtf(256));
+        assertThrows(WireFormatException.class, () -> new WireBytes.Reader(new byte[4], 3, 1));
+    }
+}

--- a/fabric/src/test/java/dev/vox/lss/common/wire/WireSectionCursorCorpusTest.java
+++ b/fabric/src/test/java/dev/vox/lss/common/wire/WireSectionCursorCorpusTest.java
@@ -10,7 +10,6 @@ import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -42,7 +41,10 @@ class WireSectionCursorCorpusTest {
         try (Stream<Path> files = Files.list(corpusDir())) {
             List<Path> bins = files.filter(p -> p.getFileName().toString().endsWith(".bin"))
                     .sorted().toList();
-            assertFalse(bins.isEmpty(), "corpus dir has no .bin goldens");
+            // Count-pinned like the repo's other fixture suites: a vanished golden must
+            // red THIS suite, not silently shrink its coverage. Update alongside any
+            // corpus addition (the generator lives in NbtSectionSerializerTest).
+            assertEquals(14, bins.size(), "nbt-corpus golden count drifted: " + bins);
             return bins;
         }
     }
@@ -71,5 +73,55 @@ class WireSectionCursorCorpusTest {
         }
         assertTrue(sawDirect, "corpus must exercise at least one DIRECT container "
                 + "(global-palette / biome-global goldens) or this suite lost its teeth");
+    }
+
+    /**
+     * The translator against the real emitter's output (review MINOR 11): every
+     * corpus golden — duplicate palettes, DIRECT/global tiers, masked sections —
+     * translates under synthetic identity tables, reparses as legal v20, and matches
+     * VOXEL FOR VOXEL: the identity at every block/biome position must equal the
+     * identity of the native id at that position. Sections, counts, and light must
+     * survive untouched.
+     */
+    @Test
+    void everyCorpusGoldenTranslatesToV20VoxelForVoxel() throws IOException {
+        java.util.function.IntFunction<String> blockIdentity = id -> "syntheticblocks:state_" + id;
+        java.util.function.IntFunction<String> biomeIdentity = id -> "syntheticbiomes:biome_" + id;
+        for (Path bin : corpusFiles()) {
+            byte[] body = Files.readAllBytes(bin);
+            var nat = WireSectionCursor.parse(body, WireSectionCursor.Layout.NATIVE);
+            byte[] v20Bytes = NativeToV20Translator.translate(body, blockIdentity, biomeIdentity);
+            var v20 = WireSectionCursor.parse(v20Bytes, WireSectionCursor.Layout.V20);
+            assertEquals(nat.sections().size(), v20.sections().size(), bin.getFileName().toString());
+            for (int i = 0; i < nat.sections().size(); i++) {
+                var n = nat.sections().get(i);
+                var v = v20.sections().get(i);
+                String at = bin.getFileName() + " section " + i;
+                assertEquals(n.sectionY(), v.sectionY(), at);
+                assertEquals(n.nonEmptyBlockCount(), v.nonEmptyBlockCount(), at);
+                assertEquals(n.fluidCount(), v.fluidCount(), at);
+                assertArrayEquals(n.blockLight(), v.blockLight(), at);
+                assertArrayEquals(n.skyLight(), v.skyLight(), at);
+                assertVoxelsMatch(n.blocks(), v.blocks(), 4096, blockIdentity, v20.dictionary(), at + " blocks");
+                assertVoxelsMatch(n.biomes(), v.biomes(), 64, biomeIdentity, v20.dictionary(), at + " biomes");
+            }
+        }
+    }
+
+    private static void assertVoxelsMatch(WireSectionCursor.WireContainer nat,
+                                          WireSectionCursor.WireContainer v20,
+                                          int entries,
+                                          java.util.function.IntFunction<String> identity,
+                                          List<String> dict, String at) {
+        int[] natValues = nat.bits() == 0 ? null
+                : WireSectionCursor.unpack(nat.data(), nat.bits(), entries);
+        int[] v20Values = v20.bits() == 0 ? null
+                : WireSectionCursor.unpack(v20.data(), v20.bits(), entries);
+        for (int i = 0; i < entries; i++) {
+            int natId = natValues == null ? nat.palette()[0]
+                    : (nat.isDirect() ? natValues[i] : nat.palette()[natValues[i]]);
+            int dictIndex = v20Values == null ? v20.palette()[0] : v20.palette()[v20Values[i]];
+            assertEquals(identity.apply(natId), dict.get(dictIndex), at + " voxel " + i);
+        }
     }
 }

--- a/fabric/src/test/java/dev/vox/lss/common/wire/WireSectionCursorCorpusTest.java
+++ b/fabric/src/test/java/dev/vox/lss/common/wire/WireSectionCursorCorpusTest.java
@@ -1,0 +1,75 @@
+package dev.vox.lss.common.wire;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The cursor's NATIVE-layout knowledge, proven against the REAL emitter's output:
+ * every committed {@code nbt-corpus} golden (raw {@code serializeChunkNbt} bodies —
+ * incl. DIRECT/global palettes, negative Y, waterlogged, light combos, masked) must
+ * scan to its exact length and survive parse → emit byte-identical. A cursor that
+ * misread any layout detail (palette thresholds, implied long counts, light framing)
+ * cannot pass this against all fourteen shapes.
+ */
+class WireSectionCursorCorpusTest {
+
+    private static Path corpusDir() {
+        Path dir = Path.of("").toAbsolutePath();
+        for (int depth = 0; depth < 5 && dir != null; depth++, dir = dir.getParent()) {
+            if (Files.isDirectory(dir.resolve("src/test/java/dev/vox/lss"))) {
+                return dir.resolve("src/test/resources/nbt-corpus");
+            }
+            Path nested = dir.resolve("fabric");
+            if (Files.isDirectory(nested.resolve("src/test/java/dev/vox/lss"))) {
+                return nested.resolve("src/test/resources/nbt-corpus");
+            }
+        }
+        throw new IllegalStateException("cannot locate the fabric module source tree from "
+                + Path.of("").toAbsolutePath());
+    }
+
+    private static List<Path> corpusFiles() throws IOException {
+        try (Stream<Path> files = Files.list(corpusDir())) {
+            List<Path> bins = files.filter(p -> p.getFileName().toString().endsWith(".bin"))
+                    .sorted().toList();
+            assertFalse(bins.isEmpty(), "corpus dir has no .bin goldens");
+            return bins;
+        }
+    }
+
+    @Test
+    void everyCorpusGoldenScansToItsExactLength() throws IOException {
+        for (Path bin : corpusFiles()) {
+            byte[] body = Files.readAllBytes(bin);
+            assertEquals(body.length,
+                    WireSectionCursor.scan(body, 0, WireSectionCursor.Layout.NATIVE),
+                    bin.getFileName() + " must scan cleanly to its end");
+        }
+    }
+
+    @Test
+    void everyCorpusGoldenSurvivesParseEmitByteIdentical() throws IOException {
+        boolean sawDirect = false;
+        for (Path bin : corpusFiles()) {
+            byte[] body = Files.readAllBytes(bin);
+            var column = WireSectionCursor.parse(body, WireSectionCursor.Layout.NATIVE);
+            assertArrayEquals(body,
+                    WireSectionCursor.emit(column, WireSectionCursor.Layout.NATIVE),
+                    bin.getFileName() + " must re-emit byte-identical");
+            sawDirect |= column.sections().stream().anyMatch(
+                    s -> s.blocks().isDirect() || s.biomes().isDirect());
+        }
+        assertTrue(sawDirect, "corpus must exercise at least one DIRECT container "
+                + "(global-palette / biome-global goldens) or this suite lost its teeth");
+    }
+}

--- a/fabric/src/test/java/dev/vox/lss/common/wire/WireSectionCursorTest.java
+++ b/fabric/src/test/java/dev/vox/lss/common/wire/WireSectionCursorTest.java
@@ -195,6 +195,82 @@ class WireSectionCursorTest {
                 () -> WireSectionCursor.parse(empty.toByteArray(), Layout.V20));
     }
 
+    /** MAJOR 1: v20 palette values are dictionary references — the cursor owns the
+     *  range check on BOTH directions, so no consumer can index out of the dict. */
+    @Test
+    void v20PaletteIndicesAreRangeCheckedAgainstTheDictionaryBothDirections() {
+        // Parse: single-value index == dictSize (one past the end).
+        var out = new WireBytes.Writer(64);
+        out.writeVarInt(1).writeUtf("minecraft:stone")
+                .writeVarInt(1).writeByte(0).writeShort(0).writeShort(0)
+                .writeByte(0).writeVarInt(1);
+        assertThrows(WireFormatException.class,
+                () -> WireSectionCursor.parse(out.toByteArray(), Layout.V20));
+        // Parse: negative palette value (5-byte VarInt -1).
+        var neg = new WireBytes.Writer(64);
+        neg.writeVarInt(1).writeUtf("minecraft:stone")
+                .writeVarInt(1).writeByte(0).writeShort(0).writeShort(0)
+                .writeByte(0).writeVarInt(-1);
+        assertThrows(WireFormatException.class,
+                () -> WireSectionCursor.parse(neg.toByteArray(), Layout.V20));
+        // Emit: an index outside the dictionary must be refused, not shipped.
+        var single = new WireContainer(0, new int[] { 5 }, new long[0]);
+        var ok = new WireContainer(0, new int[] { 0 }, new long[0]);
+        assertThrows(WireFormatException.class, () -> WireSectionCursor.emit(
+                new WireColumn(List.of("minecraft:stone"),
+                        List.of(new WireSection(0, 1, 0, single, ok, null, null))), Layout.V20));
+        // Emit: negative native palette value refused too.
+        var negNative = new WireContainer(0, new int[] { -1 }, new long[0]);
+        assertThrows(WireFormatException.class, () -> WireSectionCursor.emit(
+                new WireColumn(List.of(),
+                        List.of(new WireSection(0, 1, 0, negNative, ok, null, null))), Layout.NATIVE));
+    }
+
+    /** MAJOR 4/5: block containers at bits 1-3 have no vanilla shape (native) and
+     *  violate the §2.1 floor (v20) — illegal on BOTH parse and emit, both layouts. */
+    @Test
+    void blockWidths1To3AreRejectedOnBothLayoutsAndBothDirections() {
+        for (int bits = 1; bits <= 3; bits++) {
+            var nat = new WireBytes.Writer(64);
+            nat.writeVarInt(1).writeByte(0).writeShort(0).writeShort(0).writeByte(bits);
+            byte[] natBytes = nat.toByteArray();
+            assertThrows(WireFormatException.class,
+                    () -> WireSectionCursor.parse(natBytes, Layout.NATIVE), "native parse bits " + bits);
+            var v20 = new WireBytes.Writer(64);
+            v20.writeVarInt(1).writeUtf("minecraft:stone")
+                    .writeVarInt(1).writeByte(0).writeShort(0).writeShort(0).writeByte(bits);
+            byte[] v20Bytes = v20.toByteArray();
+            assertThrows(WireFormatException.class,
+                    () -> WireSectionCursor.parse(v20Bytes, Layout.V20), "v20 parse bits " + bits);
+
+            var badBlocks = new WireContainer(bits, new int[] { 0, 1 },
+                    new long[(4096 + (64 / bits) - 1) / (64 / bits)]);
+            var okBiome = new WireContainer(0, new int[] { 0 }, new long[0]);
+            assertThrows(WireFormatException.class, () -> WireSectionCursor.emit(
+                    new WireColumn(List.of(), List.of(
+                            new WireSection(0, 1, 0, badBlocks, okBiome, null, null))), Layout.NATIVE),
+                    "native emit bits " + bits);
+        }
+        // Biomes keep their 1-3-bit linear shapes — bits 2 biomes must stay legal.
+        var biome2 = new WireContainer(2, new int[] { 0, 1, 2 }, new long[2]);
+        var single = new WireContainer(0, new int[] { 0 }, new long[0]);
+        byte[] ok = WireSectionCursor.emit(new WireColumn(List.of(),
+                List.of(new WireSection(0, 1, 0, single, biome2, null, null))), Layout.NATIVE);
+        assertEquals(2, WireSectionCursor.parse(ok, Layout.NATIVE).sections().get(0).biomes().bits());
+    }
+
+    /** Emit refuses out-of-domain scalar fields instead of silently truncating them. */
+    @Test
+    void emitRejectsOutOfRangeSectionYAndCounts() {
+        var single = new WireContainer(0, new int[] { 0 }, new long[0]);
+        assertThrows(WireFormatException.class, () -> WireSectionCursor.emit(
+                new WireColumn(List.of(), List.of(
+                        new WireSection(300, 1, 0, single, single, null, null))), Layout.NATIVE));
+        assertThrows(WireFormatException.class, () -> WireSectionCursor.emit(
+                new WireColumn(List.of(), List.of(
+                        new WireSection(0, 70000, 0, single, single, null, null))), Layout.NATIVE));
+    }
+
     @Test
     void emitRefusesMalformedColumns() {
         var direct = new WireContainer(15, null, filledData(4096, 15, 1));

--- a/fabric/src/test/java/dev/vox/lss/common/wire/WireSectionCursorTest.java
+++ b/fabric/src/test/java/dev/vox/lss/common/wire/WireSectionCursorTest.java
@@ -1,0 +1,245 @@
+package dev.vox.lss.common.wire;
+
+import dev.vox.lss.common.wire.WireSectionCursor.Layout;
+import dev.vox.lss.common.wire.WireSectionCursor.WireColumn;
+import dev.vox.lss.common.wire.WireSectionCursor.WireContainer;
+import dev.vox.lss.common.wire.WireSectionCursor.WireSection;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Random;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+/**
+ * The layout walker: parse/re-emit byte identity on hand-built fixtures of BOTH
+ * layouts (the real-emitter cross-check against the committed nbt-corpus lives in
+ * {@code WireSectionCursorCorpusTest}, where the corpus is reachable), skip/scan
+ * correctness, and hostile-input containment — every malformed shape must surface as
+ * {@link WireFormatException}, never an array error or a wire-claimed allocation.
+ */
+class WireSectionCursorTest {
+
+    // ---- fixture builders ------------------------------------------------------
+
+    private static long[] filledData(int entries, int bits, int seed) {
+        int valuesPerLong = 64 / bits;
+        var data = new long[(entries + valuesPerLong - 1) / valuesPerLong];
+        var rng = new Random(seed);
+        for (int i = 0; i < data.length; i++) {
+            data[i] = rng.nextLong();
+        }
+        // Zero the tail beyond the last real entry so pack/unpack round-trips exactly.
+        int used = entries % valuesPerLong;
+        if (used != 0) {
+            long mask = (1L << ((long) used * bits)) - 1;
+            data[data.length - 1] &= mask;
+        }
+        return data;
+    }
+
+    private static byte[] light(int fill) {
+        var b = new byte[2048];
+        java.util.Arrays.fill(b, (byte) fill);
+        return b;
+    }
+
+    /** Indexed blocks (bits 4), single-value biomes, both light layers. */
+    private static WireSection typicalSection(int y) {
+        var blocks = new WireContainer(4, new int[] { 0, 9, 130 }, filledData(4096, 4, y));
+        var biomes = new WireContainer(0, new int[] { 2 }, new long[0]);
+        return new WireSection(y, 271, 3, blocks, biomes, light(0x12), light(0xFF));
+    }
+
+    /** DIRECT blocks (bits 15) + DIRECT biomes (bits 4), no light. */
+    private static WireSection directSection(int y) {
+        var blocks = new WireContainer(15, null, filledData(4096, 15, y));
+        var biomes = new WireContainer(4, null, filledData(64, 4, y + 1));
+        return new WireSection(y, 4096, 0, blocks, biomes, null, null);
+    }
+
+    // ---- parse / emit ----------------------------------------------------------
+
+    @Test
+    void nativeParseEmitByteIdentity() {
+        var column = new WireColumn(List.of(), List.of(typicalSection(-4), directSection(7)));
+        byte[] bytes = WireSectionCursor.emit(column, Layout.NATIVE);
+        var reparsed = WireSectionCursor.parse(bytes, Layout.NATIVE);
+        assertArrayEquals(bytes, WireSectionCursor.emit(reparsed, Layout.NATIVE));
+        assertEquals(2, reparsed.sections().size());
+        assertEquals(-4, reparsed.sections().get(0).sectionY());
+        assertTrue(reparsed.sections().get(1).blocks().isDirect());
+        assertNull(reparsed.sections().get(1).blockLight());
+    }
+
+    @Test
+    void v20ParseEmitByteIdentity() {
+        var blocks = new WireContainer(4, new int[] { 0, 1, 2 }, filledData(4096, 4, 5));
+        var biomes = new WireContainer(0, new int[] { 3 }, new long[0]);
+        var wide = new WireContainer(12, new int[] { 0, 1 }, filledData(4096, 12, 6));
+        var column = new WireColumn(
+                List.of("minecraft:stone", "minecraft:dirt",
+                        "minecraft:oak_stairs[facing=north,half=top,waterlogged=false]",
+                        "minecraft:plains"),
+                List.of(new WireSection(-4, 100, 0, blocks, biomes, light(1), null),
+                        new WireSection(0, 4096, 12, wide, biomes, null, light(15))));
+        byte[] bytes = WireSectionCursor.emit(column, Layout.V20);
+        var reparsed = WireSectionCursor.parse(bytes, Layout.V20);
+        assertEquals(column.dictionary(), reparsed.dictionary());
+        assertArrayEquals(bytes, WireSectionCursor.emit(reparsed, Layout.V20));
+    }
+
+    @Test
+    void clearColumnIsTheEmptyDictionaryEmptySectionFrameInBothLayouts() {
+        var clear = new WireColumn(List.of(), List.of());
+        assertArrayEquals(new byte[] { 0 }, WireSectionCursor.emit(clear, Layout.NATIVE));
+        // v20: dictCount 0 + sectionCount 0 — the ghost-clear shape (§2.1).
+        assertArrayEquals(new byte[] { 0, 0 }, WireSectionCursor.emit(clear, Layout.V20));
+        assertEquals(0, WireSectionCursor.parse(new byte[] { 0, 0 }, Layout.V20).sections().size());
+    }
+
+    @Test
+    void scanReturnsConsumedLengthAndHonorsOffset() {
+        byte[] body = WireSectionCursor.emit(
+                new WireColumn(List.of(), List.of(typicalSection(3))), Layout.NATIVE);
+        assertEquals(body.length, WireSectionCursor.scan(body, 0, Layout.NATIVE));
+        byte[] shifted = new byte[body.length + 5];
+        System.arraycopy(body, 0, shifted, 5, body.length);
+        assertEquals(body.length, WireSectionCursor.scan(shifted, 5, Layout.NATIVE));
+    }
+
+    @Test
+    void trailingBytesAfterTheSectionArrayAreRejectedByParse() {
+        byte[] body = WireSectionCursor.emit(
+                new WireColumn(List.of(), List.of(typicalSection(0))), Layout.NATIVE);
+        byte[] padded = java.util.Arrays.copyOf(body, body.length + 1);
+        assertThrows(WireFormatException.class,
+                () -> WireSectionCursor.parse(padded, Layout.NATIVE));
+        // scan tolerates trailing content by design — it reports what it consumed.
+        assertEquals(body.length, WireSectionCursor.scan(padded, 0, Layout.NATIVE));
+    }
+
+    // ---- hostile-input containment --------------------------------------------
+
+    /** Every strict prefix of a valid body must throw WireFormatException — nothing else. */
+    @Test
+    void truncationAtEveryByteIsContained() {
+        for (Layout layout : Layout.values()) {
+            byte[] body = layout == Layout.NATIVE
+                    ? WireSectionCursor.emit(new WireColumn(List.of(),
+                            List.of(typicalSection(-1), directSection(2))), Layout.NATIVE)
+                    : WireSectionCursor.emit(new WireColumn(List.of("minecraft:stone"),
+                            List.of(new WireSection(0, 1, 0,
+                                    new WireContainer(0, new int[] { 0 }, new long[0]),
+                                    new WireContainer(0, new int[] { 0 }, new long[0]),
+                                    light(2), null))), Layout.V20);
+            for (int len = 0; len < body.length; len++) {
+                byte[] prefix = java.util.Arrays.copyOf(body, len);
+                try {
+                    WireSectionCursor.parse(prefix, layout);
+                    fail(layout + " prefix of " + len + " bytes parsed without error");
+                } catch (WireFormatException expected) {
+                    // the pinned failure mode
+                } catch (RuntimeException other) {
+                    fail(layout + " prefix of " + len + " bytes threw " + other, other);
+                }
+            }
+        }
+    }
+
+    @Test
+    void negativeAndOversizedCountsAreContained() {
+        // sectionCount = -1 (five-byte VarInt).
+        byte[] negativeCount = { (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, 0x0F };
+        assertThrows(WireFormatException.class,
+                () -> WireSectionCursor.parse(negativeCount, Layout.NATIVE));
+        // dictCount claims 2^28 with 2 bytes remaining — must throw BEFORE allocating.
+        byte[] hugeDict = { (byte) 0x80, (byte) 0x80, (byte) 0x80, (byte) 0x80, 0x01, 0, 0 };
+        assertThrows(WireFormatException.class,
+                () -> WireSectionCursor.parse(hugeDict, Layout.V20));
+        // paletteCount above the container's entry count.
+        var out = new WireBytes.Writer(64);
+        out.writeVarInt(1).writeByte(0).writeShort(0).writeShort(0)
+                .writeByte(4).writeVarInt(4097);
+        assertThrows(WireFormatException.class,
+                () -> WireSectionCursor.parse(out.toByteArray(), Layout.NATIVE));
+        // VarInt wider than 5 bytes.
+        byte[] wideVarInt = { (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, 0x01 };
+        assertThrows(WireFormatException.class,
+                () -> WireSectionCursor.parse(wideVarInt, Layout.NATIVE));
+    }
+
+    @Test
+    void v20WidthCeilingsAndClearInvariantAreEnforcedOnParse() {
+        // Block container claiming width 13 (> v20 max 12).
+        var out = new WireBytes.Writer(64);
+        out.writeVarInt(1).writeUtf("minecraft:stone")
+                .writeVarInt(1).writeByte(0).writeShort(0).writeShort(0)
+                .writeByte(13);
+        assertThrows(WireFormatException.class,
+                () -> WireSectionCursor.parse(out.toByteArray(), Layout.V20));
+        // Dictionary content with zero sections — the leak isClearColumn must never see.
+        var leak = new WireBytes.Writer(32);
+        leak.writeVarInt(1).writeUtf("minecraft:stone").writeVarInt(0);
+        assertThrows(WireFormatException.class,
+                () -> WireSectionCursor.parse(leak.toByteArray(), Layout.V20));
+        // Sections with an EMPTY dictionary — indices with nothing to reference.
+        var empty = new WireBytes.Writer(32);
+        empty.writeVarInt(0).writeVarInt(1);
+        assertThrows(WireFormatException.class,
+                () -> WireSectionCursor.parse(empty.toByteArray(), Layout.V20));
+    }
+
+    @Test
+    void emitRefusesMalformedColumns() {
+        var direct = new WireContainer(15, null, filledData(4096, 15, 1));
+        var single = new WireContainer(0, new int[] { 0 }, new long[0]);
+        var directSection = new WireSection(0, 1, 0, direct, single, null, null);
+        assertThrows(WireFormatException.class, () -> WireSectionCursor.emit(
+                new WireColumn(List.of("minecraft:stone"), List.of(directSection)), Layout.V20));
+        assertThrows(WireFormatException.class, () -> WireSectionCursor.emit(
+                new WireColumn(List.of("minecraft:stone"), List.of()), Layout.V20));
+        assertThrows(WireFormatException.class, () -> WireSectionCursor.emit(
+                new WireColumn(List.of("minecraft:stone"), List.of(directSection)), Layout.NATIVE));
+        var badData = new WireSection(0, 1, 0,
+                new WireContainer(4, new int[] { 1 }, new long[7]), single, null, null);
+        assertThrows(WireFormatException.class, () -> WireSectionCursor.emit(
+                new WireColumn(List.of(), List.of(badData)), Layout.NATIVE));
+        var badLight = new WireSection(0, 1, 0, single, single, new byte[100], null);
+        assertThrows(WireFormatException.class, () -> WireSectionCursor.emit(
+                new WireColumn(List.of(), List.of(badLight)), Layout.NATIVE));
+    }
+
+    // ---- packed-array helpers --------------------------------------------------
+
+    @Test
+    void packUnpackRoundTripsAcrossWidths() {
+        var rng = new Random(42);
+        for (int bits = 1; bits <= 15; bits++) {
+            for (int entries : new int[] { 64, 4096 }) {
+                var values = new int[entries];
+                for (int i = 0; i < entries; i++) {
+                    values[i] = rng.nextInt(1 << bits);
+                }
+                assertArrayEquals(values,
+                        WireSectionCursor.unpack(WireSectionCursor.pack(values, bits), bits, entries),
+                        "width " + bits + " x " + entries);
+            }
+        }
+    }
+
+    @Test
+    void packRejectsValuesThatDoNotFit() {
+        assertThrows(WireFormatException.class,
+                () -> WireSectionCursor.pack(new int[] { 16 }, 4));
+        assertThrows(WireFormatException.class,
+                () -> WireSectionCursor.pack(new int[] { -1 }, 4));
+        assertThrows(WireFormatException.class,
+                () -> WireSectionCursor.unpack(new long[3], 4, 4096));
+    }
+}

--- a/fabric/src/test/java/dev/vox/lss/networking/server/IdentityTablesTest.java
+++ b/fabric/src/test/java/dev/vox/lss/networking/server/IdentityTablesTest.java
@@ -1,0 +1,99 @@
+package dev.vox.lss.networking.server;
+
+import dev.vox.lss.common.wire.IdentityCodec;
+import net.minecraft.SharedConstants;
+import net.minecraft.core.registries.Registries;
+import net.minecraft.data.registries.VanillaRegistries;
+import net.minecraft.server.Bootstrap;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.state.properties.BlockStateProperties;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashSet;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The registry identity tables against the REAL 26.2 registries: spot-pinned
+ * canonical forms, and the whole-registry sweep that is the charset-safety pin's
+ * strongest form — every one of the ~29k block states must produce a canonical,
+ * strictly-parseable, GLOBALLY UNIQUE identity, and the inverse table must be the
+ * exact mirror. A vanilla (or, on a modded server, modded) property value that
+ * violated the no-escaping charset would fail here at table build, not on the wire.
+ */
+class IdentityTablesTest {
+
+    static {
+        SharedConstants.tryDetectVersion();
+        Bootstrap.bootStrap();
+    }
+
+    private static net.minecraft.core.Registry<net.minecraft.world.level.biome.Biome> BIOMES;
+
+    @BeforeAll
+    static void setup() {
+        var biomes = VanillaRegistries.createLookup().lookupOrThrow(Registries.BIOME);
+        var registry = new net.minecraft.core.MappedRegistry<>(Registries.BIOME,
+                com.mojang.serialization.Lifecycle.stable());
+        biomes.listElements().forEach(ref -> registry.register(ref.key(), ref.value(),
+                net.minecraft.core.RegistrationInfo.BUILT_IN));
+        registry.freeze();
+        BIOMES = registry;
+    }
+
+    @Test
+    void propertylessStateIsTheBareForm() {
+        int stoneId = Block.BLOCK_STATE_REGISTRY.getId(Blocks.STONE.defaultBlockState());
+        assertEquals("minecraft:stone", IdentityTables.blockIdentities()[stoneId]);
+    }
+
+    @Test
+    void propertiedStateCarriesAllPropertiesSorted() {
+        var state = Blocks.OAK_STAIRS.defaultBlockState()
+                .setValue(BlockStateProperties.WATERLOGGED, true);
+        String identity = IdentityTables.canonicalOf(state);
+        assertEquals("minecraft:oak_stairs[facing=north,half=bottom,shape=straight,waterlogged=true]",
+                identity);
+    }
+
+    @Test
+    void everyBlockStateIdentityIsCanonicalAndGloballyUnique() {
+        String[] table = IdentityTables.blockIdentities();
+        assertEquals(Block.BLOCK_STATE_REGISTRY.size(), table.length);
+        var seen = new HashSet<String>(table.length * 2);
+        for (int id = 0; id < table.length; id++) {
+            String identity = table[id];
+            assertNotNull(identity, "hole at global id " + id);
+            IdentityCodec.validate(identity);  // throws on any charset/grammar violation
+            assertTrue(seen.add(identity), "duplicate identity: " + identity);
+        }
+    }
+
+    @Test
+    void inverseTableIsTheExactMirror() {
+        String[] table = IdentityTables.blockIdentities();
+        var inverse = IdentityTables.blockIdsByIdentity();
+        assertEquals(table.length, inverse.size());
+        for (int id = 0; id < table.length; id++) {
+            assertEquals(id, inverse.get(table[id]), "inverse of " + table[id]);
+        }
+    }
+
+    @Test
+    void biomeTableCoversTheRegistryBothDirections() {
+        var biomeTable = IdentityTables.biomeTable(BIOMES);
+        assertEquals(BIOMES.size(), biomeTable.identities().length);
+        assertTrue(biomeTable.identities().length > 50, "vanilla has ~65 biomes");
+        for (int id = 0; id < biomeTable.identities().length; id++) {
+            String identity = biomeTable.identities()[id];
+            assertNotNull(identity, "hole at biome id " + id);
+            IdentityCodec.validate(identity);
+            assertEquals(id, biomeTable.idsByIdentity().get(identity));
+        }
+        assertTrue(biomeTable.idsByIdentity().containsKey("minecraft:plains"));
+    }
+}

--- a/fabric/src/test/java/dev/vox/lss/networking/server/IdentityTablesTest.java
+++ b/fabric/src/test/java/dev/vox/lss/networking/server/IdentityTablesTest.java
@@ -84,6 +84,13 @@ class IdentityTablesTest {
     }
 
     @Test
+    void boundsCheckedLookupReturnsNullOutsideTheTable() {
+        assertEquals(null, IdentityTables.blockIdentityFor(-1));
+        assertEquals(null, IdentityTables.blockIdentityFor(Integer.MAX_VALUE));
+        assertNotNull(IdentityTables.blockIdentityFor(0));
+    }
+
+    @Test
     void biomeTableCoversTheRegistryBothDirections() {
         var biomeTable = IdentityTables.biomeTable(BIOMES);
         assertEquals(BIOMES.size(), biomeTable.identities().length);

--- a/fabric/src/test/java/dev/vox/lss/networking/server/V20SettlingExperimentTool.java
+++ b/fabric/src/test/java/dev/vox/lss/networking/server/V20SettlingExperimentTool.java
@@ -148,8 +148,8 @@ class V20SettlingExperimentTool {
                     byte[] v20Wire;
                     try {
                         v20Wire = NativeToV20Translator.translate(nativeWire,
-                                id -> blockIdentities[id],
-                                id -> biomeTable.identities()[id]);
+                                IdentityTables::blockIdentityFor,
+                                biomeTable::identityFor);
                     } catch (RuntimeException e) {
                         translateFailures++;
                         continue;
@@ -177,6 +177,14 @@ class V20SettlingExperimentTool {
         }
 
         assumeTrue(columns > 0, "corpus produced no columns");
+        // Self-invalidating gate (review MINOR 9): a failing column is EXCLUDED from
+        // the size series, so a run with failures would confidently report numbers
+        // computed over exactly the columns that happened to work. §8 gates every
+        // published size claim on this run — it must not under-report quietly.
+        if (translateFailures + reparseFailures > 0) {
+            throw new AssertionError("size figures are invalid: " + translateFailures
+                    + " translate + " + reparseFailures + " reparse failures were excluded");
+        }
         var report = new StringBuilder();
         report.append("{\n");
         report.append("  \"columns\": ").append(columns)

--- a/fabric/src/test/java/dev/vox/lss/networking/server/V20SettlingExperimentTool.java
+++ b/fabric/src/test/java/dev/vox/lss/networking/server/V20SettlingExperimentTool.java
@@ -1,0 +1,253 @@
+package dev.vox.lss.networking.server;
+
+import com.github.luben.zstd.Zstd;
+import com.mojang.serialization.Lifecycle;
+import dev.vox.lss.common.wire.NativeToV20Translator;
+import dev.vox.lss.common.wire.WireSectionCursor;
+import net.minecraft.SharedConstants;
+import net.minecraft.core.MappedRegistry;
+import net.minecraft.core.RegistrationInfo;
+import net.minecraft.core.RegistryAccess;
+import net.minecraft.core.registries.Registries;
+import net.minecraft.data.registries.VanillaRegistries;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.NbtAccounter;
+import net.minecraft.nbt.NbtIo;
+import net.minecraft.server.Bootstrap;
+import net.minecraft.world.level.biome.Biome;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.DataInputStream;
+import java.io.IOException;
+import java.io.RandomAccessFile;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.regex.Pattern;
+import java.util.zip.GZIPInputStream;
+import java.util.zip.InflaterInputStream;
+
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+/**
+ * XVER Phase 0 SETTLING MEASUREMENT (§8): encode a real-terrain corpus through BOTH
+ * real encoders — the production native path ({@code serializeChunkNbt}) and the v20
+ * identity-dictionary translation ({@code NativeToV20Translator} over the real
+ * registry tables) — and diff ACTUAL zstd-1 frames. §8's +1,174 B/col raw estimate
+ * mixed corpora and used a zlib proxy; these are the numbers the release notes and
+ * store-growth statements must cite instead (the plan gates any published size claim
+ * on this run).
+ *
+ * <p>NOT a CI test: skips itself unless {@code -Dlss.store.experiment.regionDir} is
+ * set (the store/compressed tools' pass-through — zero gradle changes). §8's corpus
+ * is the played test-server world:
+ * {@code ./gradlew :fabric:test --tests "*V20SettlingExperimentTool*"
+ * -Plss.store.experiment.regionDir=$PWD/test-server/paper/world/dimensions/minecraft/overworld/region
+ * -Plss.store.experiment.out=$PWD/profile-results/v20-settling}.
+ */
+class V20SettlingExperimentTool {
+
+    static {
+        SharedConstants.tryDetectVersion();
+        Bootstrap.bootStrap();
+    }
+
+    private static final Pattern REGION_NAME = Pattern.compile("r\\.(-?\\d+)\\.(-?\\d+)\\.mca");
+
+    private static RegistryAccess buildFullBiomeRegistry() {
+        var provider = VanillaRegistries.createLookup();
+        var src = provider.lookupOrThrow(Registries.BIOME);
+        MappedRegistry<Biome> biomes = new MappedRegistry<>(Registries.BIOME, Lifecycle.stable());
+        src.listElements().forEach(ref -> biomes.register(ref.key(), ref.value(), RegistrationInfo.BUILT_IN));
+        biomes.freeze();
+        return new RegistryAccess.ImmutableRegistryAccess(List.of(biomes));
+    }
+
+    private static final class Series {
+        private long[] v = new long[4096];
+        private int n;
+        void add(long x) {
+            if (this.n == this.v.length) this.v = Arrays.copyOf(this.v, this.n * 2);
+            this.v[this.n++] = x;
+        }
+        long total() {
+            long s = 0;
+            for (int i = 0; i < this.n; i++) s += this.v[i];
+            return s;
+        }
+        double mean() { return this.n == 0 ? 0 : (double) total() / this.n; }
+        long pct(double p) {
+            if (this.n == 0) return 0;
+            long[] c = Arrays.copyOf(this.v, this.n);
+            Arrays.sort(c);
+            return c[Math.min(this.n - 1, (int) Math.floor(p * this.n))];
+        }
+    }
+
+    @Test
+    void runSettlingMeasurement() throws Exception {
+        String regionDirProp = System.getProperty("lss.store.experiment.regionDir");
+        assumeTrue(regionDirProp != null && !regionDirProp.isBlank(),
+                "settling measurement not requested (-Dlss.store.experiment.regionDir absent)");
+        Path regionDir = Path.of(regionDirProp);
+        Path outDir = Path.of(System.getProperty("lss.store.experiment.out",
+                "profile-results/v20-settling"));
+        Files.createDirectories(outDir);
+        int maxColumns = Integer.getInteger("lss.store.experiment.maxColumns", Integer.MAX_VALUE);
+
+        RegistryAccess registryAccess = buildFullBiomeRegistry();
+        String[] blockIdentities = IdentityTables.blockIdentities();
+        var biomeTable = IdentityTables.biomeTable(
+                registryAccess.lookupOrThrow(Registries.BIOME));
+
+        Series nativeRaw = new Series(), v20Raw = new Series(), deltaRaw = new Series();
+        Series nativeFrame = new Series(), v20Frame = new Series(), deltaFrame = new Series();
+        Series dictEntries = new Series(), sectionsPerCol = new Series();
+        int columns = 0, allAir = 0, notFull = 0, unparseable = 0, external = 0;
+        int translateFailures = 0, reparseFailures = 0;
+
+        List<Path> regionFiles = new ArrayList<>();
+        try (var stream = Files.list(regionDir)) {
+            stream.filter(p -> REGION_NAME.matcher(p.getFileName().toString()).matches())
+                    .sorted().forEach(regionFiles::add);
+        }
+        assumeTrue(!regionFiles.isEmpty(), "no region files in " + regionDir);
+
+        outer:
+        for (Path mca : regionFiles) {
+            try (RandomAccessFile raf = new RandomAccessFile(mca.toFile(), "r")) {
+                if (raf.length() < 8192) continue;
+                byte[] header = new byte[8192];
+                raf.readFully(header);
+                for (int idx = 0; idx < 1024; idx++) {
+                    int loc = readBE(header, idx * 4);
+                    if (loc == 0) continue;
+                    byte[] nbtBytes = readChunkPayload(raf, loc >>> 8);
+                    if (nbtBytes == EXTERNAL_SENTINEL) { external++; continue; }
+                    if (nbtBytes == null) continue;
+                    CompoundTag tag;
+                    try (var in = new DataInputStream(new ByteArrayInputStream(nbtBytes))) {
+                        tag = NbtIo.read(in, NbtAccounter.unlimitedHeap());
+                    } catch (Exception e) {
+                        unparseable++;
+                        continue;
+                    }
+
+                    byte[] nativeWire = NbtSectionSerializer.serializeChunkNbt(tag, registryAccess);
+                    if (nativeWire == null) { notFull++; continue; }
+                    columns++;
+                    if (nativeWire.length == 0) {
+                        allAir++;
+                        if (columns >= maxColumns) break outer;
+                        continue;
+                    }
+
+                    byte[] v20Wire;
+                    try {
+                        v20Wire = NativeToV20Translator.translate(nativeWire,
+                                id -> blockIdentities[id],
+                                id -> biomeTable.identities()[id]);
+                    } catch (RuntimeException e) {
+                        translateFailures++;
+                        continue;
+                    }
+                    try {
+                        var column = WireSectionCursor.parse(v20Wire, WireSectionCursor.Layout.V20);
+                        dictEntries.add(column.dictionary().size());
+                        sectionsPerCol.add(column.sections().size());
+                    } catch (RuntimeException e) {
+                        reparseFailures++;
+                    }
+
+                    byte[] nativeZstd = Zstd.compress(nativeWire, 1);
+                    byte[] v20Zstd = Zstd.compress(v20Wire, 1);
+                    nativeRaw.add(nativeWire.length);
+                    v20Raw.add(v20Wire.length);
+                    deltaRaw.add(v20Wire.length - nativeWire.length);
+                    nativeFrame.add(nativeZstd.length);
+                    v20Frame.add(v20Zstd.length);
+                    deltaFrame.add(v20Zstd.length - nativeZstd.length);
+
+                    if (columns >= maxColumns) break outer;
+                }
+            }
+        }
+
+        assumeTrue(columns > 0, "corpus produced no columns");
+        var report = new StringBuilder();
+        report.append("{\n");
+        report.append("  \"columns\": ").append(columns)
+                .append(", \"allAir\": ").append(allAir)
+                .append(", \"notFull\": ").append(notFull)
+                .append(", \"unparseable\": ").append(unparseable)
+                .append(", \"external\": ").append(external).append(",\n");
+        report.append("  \"translateFailures\": ").append(translateFailures)
+                .append(", \"reparseFailures\": ").append(reparseFailures).append(",\n");
+        appendSeries(report, "nativeRawBytes", nativeRaw);
+        appendSeries(report, "v20RawBytes", v20Raw);
+        appendSeries(report, "deltaRawBytes", deltaRaw);
+        appendSeries(report, "nativeZstd1Bytes", nativeFrame);
+        appendSeries(report, "v20Zstd1Bytes", v20Frame);
+        appendSeries(report, "deltaZstd1Bytes", deltaFrame);
+        appendSeries(report, "dictEntries", dictEntries);
+        appendSeries(report, "sectionsPerColumn", sectionsPerCol);
+        report.append("  \"rawGrowthPct\": ")
+                .append(pct(nativeRaw.total(), v20Raw.total())).append(",\n");
+        report.append("  \"zstd1FrameGrowthPct\": ")
+                .append(pct(nativeFrame.total(), v20Frame.total())).append("\n");
+        report.append("}\n");
+        Files.writeString(outDir.resolve("settling.json"), report);
+        System.out.println("[v20-settling] " + columns + " columns ("
+                + translateFailures + " translate failures, " + reparseFailures + " reparse failures)");
+        System.out.println("[v20-settling] raw: " + Math.round(nativeRaw.mean()) + " -> "
+                + Math.round(v20Raw.mean()) + " B/col (" + pct(nativeRaw.total(), v20Raw.total()) + "%)");
+        System.out.println("[v20-settling] zstd-1: " + Math.round(nativeFrame.mean()) + " -> "
+                + Math.round(v20Frame.mean()) + " B/col (" + pct(nativeFrame.total(), v20Frame.total()) + "%)");
+        System.out.println("[v20-settling] report: " + outDir.resolve("settling.json"));
+    }
+
+    private static String pct(long base, long changed) {
+        return base == 0 ? "0" : String.format("%.2f", 100.0 * (changed - base) / base);
+    }
+
+    private static void appendSeries(StringBuilder out, String name, Series s) {
+        out.append("  \"").append(name).append("\": {\"mean\": ").append(Math.round(s.mean()))
+                .append(", \"p50\": ").append(s.pct(0.50))
+                .append(", \"p95\": ").append(s.pct(0.95))
+                .append(", \"max\": ").append(s.pct(1.0)).append("},\n");
+    }
+
+    // ---- region reading (LodStoreExperimentTool's reader, verbatim) ----
+
+    private static final byte[] EXTERNAL_SENTINEL = new byte[0];
+
+    private static int readBE(byte[] b, int off) {
+        return ((b[off] & 0xFF) << 24) | ((b[off + 1] & 0xFF) << 16)
+                | ((b[off + 2] & 0xFF) << 8) | (b[off + 3] & 0xFF);
+    }
+
+    private static byte[] readChunkPayload(RandomAccessFile raf, int sectorOffset) throws IOException {
+        long pos = (long) sectorOffset * 4096;
+        if (pos + 5 > raf.length()) return null;
+        raf.seek(pos);
+        int declared = raf.readInt();
+        if (declared <= 0 || declared > 4 * 1024 * 1024) return null;
+        int compressionType = raf.readByte() & 0xFF;
+        if ((compressionType & 0x80) != 0) return EXTERNAL_SENTINEL;
+        byte[] payload = new byte[declared - 1];
+        raf.readFully(payload);
+        try {
+            return switch (compressionType) {
+                case 1 -> new GZIPInputStream(new ByteArrayInputStream(payload)).readAllBytes();
+                case 2 -> new InflaterInputStream(new ByteArrayInputStream(payload)).readAllBytes();
+                case 3 -> payload;
+                default -> null;
+            };
+        } catch (IOException e) {
+            return null;
+        }
+    }
+}

--- a/paper/src/main/java/dev/vox/lss/paper/PaperIdentityTables.java
+++ b/paper/src/main/java/dev/vox/lss/paper/PaperIdentityTables.java
@@ -68,6 +68,18 @@ public final class PaperIdentityTables {
         return table;
     }
 
+    /**
+     * Bounds-checked lookup for wire-derived ids — the shape every consumer should
+     * use (a bare {@code table[id]} turns a corrupt palette id into
+     * {@code ArrayIndexOutOfBoundsException} instead of the translator's pinned
+     * loud failure). Returns null for an unknown id; {@code NativeToV20Translator}
+     * converts null into {@code IllegalArgumentException}.
+     */
+    public static String blockIdentityFor(int globalId) {
+        String[] table = blockIdentities();
+        return globalId >= 0 && globalId < table.length ? table[globalId] : null;
+    }
+
     /** The canonical identity of one block state — name + ALL properties, sorted. */
     public static String canonicalOf(BlockState state) {
         String name = BuiltInRegistries.BLOCK.getKey(state.getBlock()).toString();
@@ -83,7 +95,12 @@ public final class PaperIdentityTables {
     }
 
     /** Both directions for one biome registry (dynamic — per RegistryAccess). */
-    public record BiomeTable(String[] identities, Map<String, Integer> idsByIdentity) {}
+    public record BiomeTable(String[] identities, Map<String, Integer> idsByIdentity) {
+        /** Bounds-checked lookup for wire-derived ids (see {@code blockIdentityFor}). */
+        public String identityFor(int id) {
+            return id >= 0 && id < identities.length ? identities[id] : null;
+        }
+    }
 
     public static BiomeTable biomeTable(Registry<Biome> biomes) {
         var identities = new String[biomes.size()];
@@ -92,7 +109,10 @@ public final class PaperIdentityTables {
             int id = biomes.getId(biome);
             var key = biomes.getKey(biome);
             if (key == null) {
-                continue;  // unkeyed intrusive entry: left null, translator fails loudly on use
+                // A registry-iterated value always has a key; a null here means the
+                // registry is broken — fail the table build loudly rather than leave
+                // a hole that surfaces as a per-serve exception later.
+                throw new IllegalStateException("biome id " + id + " has no registry key");
             }
             String identity = key.toString();
             IdentityCodec.validate(identity);

--- a/paper/src/main/java/dev/vox/lss/paper/PaperIdentityTables.java
+++ b/paper/src/main/java/dev/vox/lss/paper/PaperIdentityTables.java
@@ -1,0 +1,104 @@
+package dev.vox.lss.paper;
+
+import dev.vox.lss.common.wire.IdentityCodec;
+import net.minecraft.core.Registry;
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.world.level.biome.Biome;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.block.state.properties.Property;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Paper twin of the Fabric {@code IdentityTables} — textual twin discipline, same
+ * enumeration ({@code Block.BLOCK_STATE_REGISTRY} / the dynamic biome registry) and
+ * the same {@link IdentityCodec} canonical form, so both platforms emit identical
+ * v20 dictionaries for identical content (the wire-parity contract). Ships INERT at
+ * Phase 0 — no serve path consults it until the v20 encode lands.
+ */
+public final class PaperIdentityTables {
+    private PaperIdentityTables() {}
+
+    private static volatile String[] blockIdentities;
+    private static volatile Map<String, Integer> blockIdsByIdentity;
+
+    /** Canonical identity for every block state, indexed by global id. */
+    public static String[] blockIdentities() {
+        String[] table = blockIdentities;
+        if (table == null) {
+            synchronized (PaperIdentityTables.class) {
+                table = blockIdentities;
+                if (table == null) {
+                    blockIdentities = table = buildBlockIdentities();
+                }
+            }
+        }
+        return table;
+    }
+
+    /** The inverse direction (legacy egress / decode): canonical identity → global id. */
+    public static Map<String, Integer> blockIdsByIdentity() {
+        Map<String, Integer> map = blockIdsByIdentity;
+        if (map == null) {
+            synchronized (PaperIdentityTables.class) {
+                map = blockIdsByIdentity;
+                if (map == null) {
+                    String[] table = blockIdentities();
+                    var built = new HashMap<String, Integer>(table.length * 2);
+                    for (int id = 0; id < table.length; id++) {
+                        if (table[id] != null) {
+                            built.put(table[id], id);
+                        }
+                    }
+                    blockIdsByIdentity = map = Map.copyOf(built);
+                }
+            }
+        }
+        return map;
+    }
+
+    private static String[] buildBlockIdentities() {
+        var registry = Block.BLOCK_STATE_REGISTRY;
+        var table = new String[registry.size()];
+        for (BlockState state : registry) {
+            table[registry.getId(state)] = canonicalOf(state);
+        }
+        return table;
+    }
+
+    /** The canonical identity of one block state — name + ALL properties, sorted. */
+    public static String canonicalOf(BlockState state) {
+        String name = BuiltInRegistries.BLOCK.getKey(state.getBlock()).toString();
+        var props = new HashMap<String, String>();
+        for (Property<?> property : state.getProperties()) {
+            props.put(property.getName(), valueName(state, property));
+        }
+        return IdentityCodec.canonical(name, props);
+    }
+
+    private static <T extends Comparable<T>> String valueName(BlockState state, Property<T> property) {
+        return property.getName(state.getValue(property));
+    }
+
+    /** Both directions for one biome registry (dynamic — per RegistryAccess). */
+    public record BiomeTable(String[] identities, Map<String, Integer> idsByIdentity) {}
+
+    public static BiomeTable biomeTable(Registry<Biome> biomes) {
+        var identities = new String[biomes.size()];
+        var inverse = new HashMap<String, Integer>(biomes.size() * 2);
+        for (Biome biome : biomes) {
+            int id = biomes.getId(biome);
+            var key = biomes.getKey(biome);
+            if (key == null) {
+                continue;  // unkeyed intrusive entry: left null, translator fails loudly on use
+            }
+            String identity = key.toString();
+            IdentityCodec.validate(identity);
+            identities[id] = identity;
+            inverse.put(identity, id);
+        }
+        return new BiomeTable(identities, Map.copyOf(inverse));
+    }
+}

--- a/paper/src/test/java/dev/vox/lss/paper/PaperIdentityTablesTest.java
+++ b/paper/src/test/java/dev/vox/lss/paper/PaperIdentityTablesTest.java
@@ -1,0 +1,67 @@
+package dev.vox.lss.paper;
+
+import dev.vox.lss.common.wire.IdentityCodec;
+import net.minecraft.SharedConstants;
+import net.minecraft.server.Bootstrap;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.state.properties.BlockStateProperties;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashSet;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Paper twin of {@code IdentityTablesTest}: the same spot pins and the whole-registry
+ * canonical/unique sweep, run against Paper's runtime — both platforms must produce
+ * IDENTICAL canonical identities or v20 dictionaries would diverge across platforms
+ * (the wire-parity contract). The exact-string spot pins here are the cross-platform
+ * anchor: they must match the Fabric suite's literals character-for-character.
+ */
+class PaperIdentityTablesTest {
+
+    static {
+        SharedConstants.tryDetectVersion();
+        Bootstrap.bootStrap();
+    }
+
+    @Test
+    void propertylessStateIsTheBareForm() {
+        int stoneId = Block.BLOCK_STATE_REGISTRY.getId(Blocks.STONE.defaultBlockState());
+        assertEquals("minecraft:stone", PaperIdentityTables.blockIdentities()[stoneId]);
+    }
+
+    @Test
+    void propertiedStateCarriesAllPropertiesSorted() {
+        var state = Blocks.OAK_STAIRS.defaultBlockState()
+                .setValue(BlockStateProperties.WATERLOGGED, true);
+        assertEquals("minecraft:oak_stairs[facing=north,half=bottom,shape=straight,waterlogged=true]",
+                PaperIdentityTables.canonicalOf(state));
+    }
+
+    @Test
+    void everyBlockStateIdentityIsCanonicalAndGloballyUnique() {
+        String[] table = PaperIdentityTables.blockIdentities();
+        assertEquals(Block.BLOCK_STATE_REGISTRY.size(), table.length);
+        var seen = new HashSet<String>(table.length * 2);
+        for (int id = 0; id < table.length; id++) {
+            String identity = table[id];
+            assertNotNull(identity, "hole at global id " + id);
+            IdentityCodec.validate(identity);
+            assertTrue(seen.add(identity), "duplicate identity: " + identity);
+        }
+    }
+
+    @Test
+    void inverseTableIsTheExactMirror() {
+        String[] table = PaperIdentityTables.blockIdentities();
+        var inverse = PaperIdentityTables.blockIdsByIdentity();
+        assertEquals(table.length, inverse.size());
+        for (int id = 0; id < table.length; id++) {
+            assertEquals(id, inverse.get(table[id]), "inverse of " + table[id]);
+        }
+    }
+}

--- a/paper/src/test/java/dev/vox/lss/paper/PaperIdentityTablesTest.java
+++ b/paper/src/test/java/dev/vox/lss/paper/PaperIdentityTablesTest.java
@@ -64,4 +64,35 @@ class PaperIdentityTablesTest {
             assertEquals(id, inverse.get(table[id]), "inverse of " + table[id]);
         }
     }
+
+    @Test
+    void boundsCheckedLookupReturnsNullOutsideTheTable() {
+        assertEquals(null, PaperIdentityTables.blockIdentityFor(-1));
+        assertEquals(null, PaperIdentityTables.blockIdentityFor(Integer.MAX_VALUE));
+        assertNotNull(PaperIdentityTables.blockIdentityFor(0));
+    }
+
+    @Test
+    void biomeTableCoversTheRegistryBothDirections() {
+        var provider = net.minecraft.data.registries.VanillaRegistries.createLookup();
+        var src = provider.lookupOrThrow(net.minecraft.core.registries.Registries.BIOME);
+        var registry = new net.minecraft.core.MappedRegistry<>(
+                net.minecraft.core.registries.Registries.BIOME,
+                com.mojang.serialization.Lifecycle.stable());
+        src.listElements().forEach(ref -> registry.register(ref.key(), ref.value(),
+                net.minecraft.core.RegistrationInfo.BUILT_IN));
+        registry.freeze();
+
+        var biomeTable = PaperIdentityTables.biomeTable(registry);
+        assertEquals(registry.size(), biomeTable.identities().length);
+        assertTrue(biomeTable.identities().length > 50, "vanilla has ~65 biomes");
+        for (int id = 0; id < biomeTable.identities().length; id++) {
+            String identity = biomeTable.identities()[id];
+            assertNotNull(identity, "hole at biome id " + id);
+            IdentityCodec.validate(identity);
+            assertEquals(id, biomeTable.idsByIdentity().get(identity));
+        }
+        assertTrue(biomeTable.idsByIdentity().containsKey("minecraft:plains"));
+        assertEquals(null, biomeTable.identityFor(-1));
+    }
 }


### PR DESCRIPTION
Stage C0 of the v0.10.0 program (XVER Phase 0, protocol 20). **Lands INERT** — no serve path consults any of this until C1 (verified by review: a strict grep for the new type names across all three main source trees, excluding the new files, returns nothing).

### What lands

- **`common/wire`** (new package, MC-free): `WireBytes` (hand-rolled MC-format VarInt/scalar/UTF primitives — bit-identity against the real `FriendlyByteBuf` pinned fabric-side, including READ-parity on non-canonical overflow forms), `WireFormatException` (the single pinned hostile-input failure mode), `IdentityCodec` (canonical `namespace:path[k1=v1,…]` form; strict parse accepting only canonical spellings; charset grammar that PROVES the four structural chars cannot occur — the no-escaping premise as code), `IdentityDictionary` (first-seen indices, validated at insertion), `WireSectionCursor` (both layouts parse/scan/emit with layout-rule enforcement), `NativeToV20Translator` (the §4.2 encode direction: verbatim longs for indexed containers, first-seen re-palettization + repack for DIRECT ones — the C4 store-migration workhorse).
- **`IdentityTables` + `PaperIdentityTables`** (textual twins): global id ↔ canonical identity, both directions, blocks from `Block.BLOCK_STATE_REGISTRY`, biomes per dynamic registry; bounds-checked `identityFor` accessors; loud table-build failure on any charset violation.
- **`V20SettlingExperimentTool`**: the §8-gated settling measurement (self-skipping, the experiment tools' `-Dlss.store.experiment.regionDir` contract).

### Settling measurement (the §8 gate on published size claims)

2,684 real played-terrain columns (`test-server/paper` overworld), production `serializeChunkNbt` vs the real translator, actual zstd-1 frames, **0 translate / 0 reparse failures**:

| | mean B/col | growth |
|---|---|---|
| raw | 35,829 → 37,719 | **+5.28%** (inside §8's +3.5–6% envelope) |
| zstd-1 frame | 5,785 → 6,346 | **+9.70%** — **above §8's ≈+4–6% wire estimate** |

The zlib proxy understated the compressed dictionary cost — **release notes and C4 store-growth planning now say ~+10%**, recorded in the ledger. The tool now FAILS if any column is excluded, so a re-run on a modded corpus cannot quietly under-report.

### Review round (single grouped Opus reviewer, all three lenses): 0 CRITICALs, 6 MAJORs + 11 minors, all addressed

The cleared list was verified against **26.2 bytecode** (disassembled `PalettedContainer$Data.write`, the `Strategy$1/$2` width→shape tables, `VarInt.read`, `StateDefinition.NAME_PATTERN`), not repo comments. Fixes:

- **M1**: v20 palette indices range-checked against the dictionary on parse AND emit — referential integrity is the cursor's job, not each consumer's.
- **M2**: native palette values must be non-negative; bounds-checked table accessors so corrupt input hits the pinned `WireFormatException`, never AIOOBE.
- **M3**: `dictCount` no longer pre-sizes an allocation (§2.3's hostile-allocation pin, dictCount included).
- **M4 (headline)**: vanilla's shape tables make block widths 1–3 ILLEGAL on the native wire (indexed blocks exist only at 4–8; a bits-2 frame desyncs a real `section.read` by 128 longs). The cursor enforces the shape table both directions, so cursor-accepted ⇒ vanilla-decodable is a real invariant before C2's egress translator can violate it.
- **M5**: the §2.1 v20 block width floor (4) enforced alongside the ceilings.
- **M6 (spec hazard, plan-text pair)**: §4.1's "canonicalize straight from disk NBT" is RETRACTED in the XVER plan — the pinned rule is now *wire identities are always the identity of a state RESOLVED in the emitting server's registry* (the literal reading would break disk/live byte parity whenever `MemoizedNbtCodec` leniency fires, and void §4.2's lossless-egress premise).
- Minors: corpus-driven translator test (voxel-for-voxel over all 14 goldens incl. duplicate-palette + masked), golden count pinned at 14, Paper biome-table twin, emit-side range/length checks instead of silent truncation, box-free first-seen remap (no Integer boxing per voxel on the migration path), null-property loud failure, biome null-key → throw at build, `scan` limit overload, writer pre-sizing.

Tests: full Fabric T1 + Paper T1 + Tier 2 green before and after the fix round; settling numbers bit-stable across the translator rewrite.

R-5 compliance verified: `MemoizedNbtCodec`, `SelectiveChunkNbtLoader`, `ChunkRawRead`, `NbtSectionSerializer`, and every serve path untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)