### PR TITLE
Direct v20 transcode-path emit (C6-triggered, pre-D2)

### DIFF
--- a/common/src/main/java/dev/vox/lss/common/wire/NativeToV20Translator.java
+++ b/common/src/main/java/dev/vox/lss/common/wire/NativeToV20Translator.java
@@ -104,6 +104,18 @@ public final class NativeToV20Translator {
                                                                  long[] data, boolean isBlocks,
                                                                  IdentityDictionary dict,
                                                                  IntFunction<String> identity) {
+        // The byte-identity claim rests on the descriptor width sitting INSIDE the
+        // native indexed thresholds — beyond them, parse would classify the same bytes
+        // DIRECT and translate() would take the re-palettize branch (or throw the
+        // C1-16 asymmetry guard), silently diverging from this path. Enforced, not
+        // assumed: a transcoder that relaxes its fallback gate must red here.
+        int maxBits = isBlocks ? WireSectionCursor.NATIVE_BLOCK_PALETTE_MAX_BITS
+                : WireSectionCursor.NATIVE_BIOME_PALETTE_MAX_BITS;
+        if (bits > maxBits) {
+            throw new IllegalArgumentException("convertIndexed given "
+                    + (isBlocks ? "block" : "biome") + " width " + bits
+                    + " beyond the native indexed threshold " + maxBits);
+        }
         int[] palette = new int[paletteIds.length];
         for (int i = 0; i < palette.length; i++) {
             palette[i] = dict.indexOf(identityFor(identity, paletteIds[i], isBlocks));

--- a/common/src/main/java/dev/vox/lss/common/wire/NativeToV20Translator.java
+++ b/common/src/main/java/dev/vox/lss/common/wire/NativeToV20Translator.java
@@ -90,6 +90,27 @@ public final class NativeToV20Translator {
         return new WireSectionCursor.WireContainer(bits, palette, data);
     }
 
+    /**
+     * The DIRECT-EMIT rung (the C6-triggered follow-up to translate-at-producer):
+     * converts an already-INDEXED native container descriptor — palette of global ids
+     * in wire order plus the verbatim long words at a vanilla-shaped width — without
+     * ever materializing or re-parsing native bytes. Byte-equal to {@link #translate}
+     * on the same container by the indexed rule above (longs verbatim, palette values
+     * rewritten to dictionary indices); callers own the guarantee that the descriptor
+     * is indexed-shaped (the NBT transcoder's fallback ladder routes every other shape
+     * through the object path, which keeps the translate route).
+     */
+    public static WireSectionCursor.WireContainer convertIndexed(int bits, int[] paletteIds,
+                                                                 long[] data, boolean isBlocks,
+                                                                 IdentityDictionary dict,
+                                                                 IntFunction<String> identity) {
+        int[] palette = new int[paletteIds.length];
+        for (int i = 0; i < palette.length; i++) {
+            palette[i] = dict.indexOf(identityFor(identity, paletteIds[i], isBlocks));
+        }
+        return new WireSectionCursor.WireContainer(bits, palette, data);
+    }
+
     private static String identityFor(IntFunction<String> lookup, int id, boolean isBlocks) {
         String identity = lookup.apply(id);
         if (identity == null) {

--- a/docs/planning/v0.10.0-progress.md
+++ b/docs/planning/v0.10.0-progress.md
@@ -767,6 +767,56 @@ the mega plan at the overridden text — never a silent divergence.
   user-optional smoke (the automated arms exercise the same load path). Next:
   grouped review round, single PR to main.
 
+- **2026-08-08 (task #8 — direct v20 transcode-path emit MEASURED, on
+  `feat/v20-direct-emit` commit `20951f13`)**: all-transcoded disk columns now
+  build the v20 `WireColumn` straight from the transcode descriptors
+  (`NativeToV20Translator.convertIndexed` + `WireSectionCursor.emit`), skipping
+  the native emit + whole-column translator re-parse; mixed/fallback/masked
+  columns and the live path keep the translate route (recorded scope). Routing
+  telemetry `DIRECT_V20_EMITS` + pins on both platforms (byte-identical outputs
+  make a silent re-route invisible to every golden — only a counter catches
+  it); the transcode-vs-object fuzz now proves direct-vs-translate byte
+  identity across its corpus, all goldens untouched. **Gate matrix**
+  (`profile-results/20260808-092305`, 4+4 × 150 s ABBA, R=256, base = main
+  `e9f83232` translate route, 8/8 arms valid): serve lss µs/col **246.0 →
+  231.3 (−6.0%)**, alloc/col 512 KB → 453 KB (−12%), disk-reader-thread LSS
+  cut **+11.8% [+7.2, +16.2]**, `lss_attributed` +5.9% [+1.9, +9.8],
+  `lss-other` (the translator's band) +24.9% [+16.8, +32.3]. Reading vs C6:
+  the intermediate's REMOVABLE cost (~15 µs/col) is recovered; the residual
+  vs the B5 baseline is the v20 capability's inherent price (dictionary +
+  identity emit — R-4's framing stands for release notes). Tripwires:
+  `nbt-other` n.s.; `serialize-live` ROSE (109→159 samples) — explained and
+  benign: `in_memory` probe serves +7% (1320→1414 across reps) with
+  `disk_read` identical (45,204), the faster pipeline shifting a handful of
+  columns to the untouched live path; not a live-path code change (the diff
+  never touches it).
+
+- **2026-08-08 (task #8 review round — one grouped Opus lens, 9 findings, no
+  correctness defect; all actionable ones fixed same day)**: byte identity,
+  dictionary determinism, the allTranscoded gate and the mask pre-gate all held
+  analytically and empirically (the reviewer measured with temporary probes).
+  Fixed: (1) MAJOR — `exactPreSizingNeverFallsBackAcrossTheCorpusShapes` had
+  gone VACUOUS on both platforms (its all-transcoded columns now route direct,
+  so the sizing arithmetic it pins never ran — proven `directEmits=2`); both
+  twins now serialize a MIXED column (transcoded + Global-fallback section)
+  with a routing premise assert; (2) the one demonstrated byte-identity gap —
+  an out-of-byte-range sectionY truncates through the native route's writeByte
+  but THREW on the direct route — closed by truncating identically ((byte)
+  cast, both platforms; production gates Y, but the range-free corpus/tool
+  overload serializes garbage Y by contract); (3) `convertIndexed` now
+  ENFORCES the native indexed-width thresholds (blocks 8 / biomes 3) instead
+  of assuming the transcoder's fallback gate — a relaxed gate would have
+  diverged the routes silently; (4) the new public API got its own suite pins
+  (direct-vs-translate byte equality across single/duplicate-entry/boundary
+  shapes + the width-guard throws); (5) the fuzz asserts a NONZERO direct
+  fraction (its comment was true but unverified); (6) the routing pin's
+  negative arms got servable-bytes premise asserts; (7) `direct_v20=` joined
+  `sel_fallbacks=` on the Fabric read_path diag line (the live liveness
+  receipt — the counter was write-only in production); (8) Paper counter
+  placement aligned to its pair. Import-style twin drift recorded as accepted
+  (Fabric imports WireSectionCursor, Paper fully qualifies — logic verified
+  line-identical by the reviewer).
+
 - **2026-08-08 (D0 grouped review round — 2 Opus lenses, 33 findings, all
   verified-real ones fixed same day)**: lens A (production semantics, 13
   findings) + lens B (§8/§9 compliance + fixture fidelity + blast radius, 20

--- a/fabric/src/main/java/dev/vox/lss/networking/server/ChunkDiskReader.java
+++ b/fabric/src/main/java/dev/vox/lss/networking/server/ChunkDiskReader.java
@@ -409,9 +409,13 @@ public class ChunkDiskReader extends AbstractChunkDiskReader {
         // serves, so a silently-inert split (dispatcher drift, wiring slip) is visible
         // as a missing token / frozen counter — the gametest asserts it after a serve.
         if (this.useBackgroundReadSplit) {
+            // direct_v20: the direct-emit liveness receipt (same rationale as
+            // raw_serves — byte-identical outputs make a silent re-route through the
+            // native intermediate invisible to everything but a counter).
             return base + ", read_path=bg-split, raw_serves=" + this.rawServes.get()
                     + ", sel=" + (this.useSelectiveNbtParse ? "on" : "off")
-                    + ", sel_fallbacks=" + NbtSectionSerializer.SELECTIVE_FALLBACKS.get();
+                    + ", sel_fallbacks=" + NbtSectionSerializer.SELECTIVE_FALLBACKS.get()
+                    + ", direct_v20=" + NbtSectionSerializer.DIRECT_V20_EMITS.get();
         }
         return base;
     }

--- a/fabric/src/main/java/dev/vox/lss/networking/server/NbtSectionSerializer.java
+++ b/fabric/src/main/java/dev/vox/lss/networking/server/NbtSectionSerializer.java
@@ -27,6 +27,8 @@ import net.minecraft.world.level.chunk.PalettedContainerRO;
 import net.minecraft.world.level.chunk.Strategy;
 import net.minecraft.world.level.chunk.status.ChunkStatus;
 
+import dev.vox.lss.common.wire.WireSectionCursor;
+
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
@@ -324,6 +326,13 @@ final class NbtSectionSerializer {
         }
     }
 
+    /** Direct-emit routing telemetry (C6 follow-up): bumped once per column served
+     *  through {@link #emitV20Direct}. Outputs are byte-identical to the translate
+     *  route, so WITHOUT this counter a regression silently re-routing everything
+     *  through the native intermediate would pass every golden — tests pin the
+     *  routing, and a benchmark validity check can assert the fast path engaged. */
+    static final AtomicLong DIRECT_V20_EMITS = new AtomicLong();
+
     /** Sizing-exactness telemetry: bumped when the exact pre-size mismatched the written
      *  bytes and the safe copy fallback ran (never wrong bytes, one warn). Tests pin 0. */
     static final AtomicLong SIZE_MISMATCH_FALLBACKS = new AtomicLong();
@@ -454,6 +463,26 @@ final class NbtSectionSerializer {
                     if (manager != null) manager.countMaskedSection();
                 }
             }
+        }
+
+        // Direct v20 emit (the C6-triggered follow-up, 2026-08-08): when EVERY surviving
+        // section is transcoded, the descriptors already hold global ids in wire order
+        // plus the verbatim disk longs — build the v20 column straight from them instead
+        // of emitting native bytes and re-parsing the whole column through the
+        // translator (the measured +18.5% serve cost of translate-at-producer).
+        // Byte-identical by the translator's indexed rule (the transcode pre-gate
+        // guarantees indexed shapes; the transcode-vs-object fuzz now compares this
+        // path against the translate route for free). Any object-path or mask-needing
+        // section keeps the native-emit + translate route wholesale.
+        boolean allTranscoded = true;
+        for (var p : parsed) {
+            if (p.transcoded() == null) {
+                allTranscoded = false;
+                break;
+            }
+        }
+        if (allTranscoded) {
+            return emitV20Direct(parsed, registryAccess);
         }
 
         // Second pass: serialize to wire format, into an EXACTLY-sized buffer (the old
@@ -919,13 +948,43 @@ final class NbtSectionSerializer {
 
     /** The C1 produce-path v20 hook (progress-doc decision 2026-08-07): every producer
      *  emits its NATIVE body exactly as before and translates at the return boundary —
-     *  ONE corpus-proven encoder, byte-determinism across paths by construction. The
-     *  direct transcode-path emit is the recorded C6-gated optimization; output bytes
-     *  are identical either way, so swapping later is invisible to every golden. */
+     *  ONE corpus-proven encoder, byte-determinism across paths by construction. Since
+     *  the C6-gated follow-up landed, the all-transcoded disk column bypasses this via
+     *  {@link #emitV20Direct} (byte-identical by the translator's indexed rule); this
+     *  translate route remains for the live path, mixed/fallback columns, and masking. */
     static byte[] toV20(byte[] nativeBody, RegistryAccess registryAccess) {
         return dev.vox.lss.common.wire.NativeToV20Translator.translate(nativeBody,
                 IdentityTables::blockIdentityFor,
                 biomeIdentityLookup(registryAccess));
+    }
+
+    /** The direct transcode-path v20 emit (C6 follow-up): every section's descriptor
+     *  carries palette GLOBAL ids in wire order + the disk long words verbatim, which
+     *  is exactly the translator's indexed input — so the dictionary walk (first-seen,
+     *  sections in order, blocks then biomes) runs on the descriptors and the native
+     *  intermediate (emit + whole-column re-parse) disappears. Callers guarantee every
+     *  section is transcoded (the assembly's allTranscoded gate). */
+    private static byte[] emitV20Direct(java.util.List<ParsedSection> parsed,
+                                        RegistryAccess registryAccess) {
+        DIRECT_V20_EMITS.incrementAndGet();
+        var dict = new dev.vox.lss.common.wire.IdentityDictionary();
+        java.util.function.IntFunction<String> blockIdentity = IdentityTables::blockIdentityFor;
+        var biomeIdentity = biomeIdentityLookup(registryAccess);
+        var sections = new java.util.ArrayList<WireSectionCursor.WireSection>(parsed.size());
+        for (var p : parsed) {
+            var t = p.transcoded();
+            sections.add(new WireSectionCursor.WireSection(
+                    p.sectionY(), p.nonEmptyCount(), p.fluidCount(),
+                    dev.vox.lss.common.wire.NativeToV20Translator.convertIndexed(
+                            t.blockBits(), t.blockIds(), t.blockData(), true, dict, blockIdentity),
+                    dev.vox.lss.common.wire.NativeToV20Translator.convertIndexed(
+                            t.biomeBits(), t.biomeIds(), t.biomeData(), false, dict, biomeIdentity),
+                    p.litByBlock() ? p.blockLight() : null,
+                    p.litBySky() ? p.skyLight() : null));
+        }
+        return WireSectionCursor.emit(
+                new WireSectionCursor.WireColumn(dict.entries(), sections),
+                WireSectionCursor.Layout.V20);
     }
 
     /** The C2 egress inverse of {@link #toV20} (XVER §4.2): v20 body → native section

--- a/fabric/src/main/java/dev/vox/lss/networking/server/NbtSectionSerializer.java
+++ b/fabric/src/main/java/dev/vox/lss/networking/server/NbtSectionSerializer.java
@@ -974,7 +974,13 @@ final class NbtSectionSerializer {
         for (var p : parsed) {
             var t = p.transcoded();
             sections.add(new WireSectionCursor.WireSection(
-                    p.sectionY(), p.nonEmptyCount(), p.fluidCount(),
+                    // (byte) cast: the native route's writeByte TRUNCATES an
+                    // out-of-byte-range sectionY (translate then round-trips the
+                    // truncated value), so the direct route must truncate identically —
+                    // production gates Y to the world range, but the range-free corpus/
+                    // tool overload serializes garbage Y and the byte-identity claim
+                    // must hold there too (review finding 2).
+                    (byte) p.sectionY(), p.nonEmptyCount(), p.fluidCount(),
                     dev.vox.lss.common.wire.NativeToV20Translator.convertIndexed(
                             t.blockBits(), t.blockIds(), t.blockData(), true, dict, blockIdentity),
                     dev.vox.lss.common.wire.NativeToV20Translator.convertIndexed(

--- a/fabric/src/test/java/dev/vox/lss/common/wire/NativeToV20TranslatorTest.java
+++ b/fabric/src/test/java/dev/vox/lss/common/wire/NativeToV20TranslatorTest.java
@@ -473,4 +473,72 @@ class NativeToV20TranslatorTest {
             assertTrue(s.blocks().bits() == 0 || s.blocks().bits() >= 4);
         }
     }
+
+    @Test
+    void convertIndexedByteMatchesTranslateAcrossIndexedShapes() {
+        // The direct-emit rung's identity pin (review finding 4): for every indexed
+        // shape the NBT transcoder can produce — single (bits 0), 4-bit linear with a
+        // DUPLICATE palette entry (the air-substitution shape), the 8-bit block /
+        // 3-bit biome boundary one short of the fallback — building the column via
+        // convertIndexed must byte-equal translate() on the equivalent native body.
+        var rng = new Random(11);
+        int[] fourBit = new int[4096];
+        for (int i = 0; i < 4096; i++) fourBit[i] = rng.nextInt(4);
+        int[] eightBit = new int[4096];
+        for (int i = 0; i < 4096; i++) eightBit[i] = rng.nextInt(256);
+        int[] biome2 = new int[64];
+        for (int i = 0; i < 64; i++) biome2[i] = rng.nextInt(3);
+        int[] biome3 = new int[64];
+        for (int i = 0; i < 64; i++) biome3[i] = rng.nextInt(8);
+        int[] pal256 = new int[256];
+        for (int i = 0; i < 256; i++) pal256[i] = i;
+        int[] biomePal8 = new int[8];
+        for (int i = 0; i < 8; i++) biomePal8[i] = i;
+        byte[] blockLight = new byte[2048];
+        blockLight[7] = 0x5A;
+
+        var shapes = List.of(
+                new WireSection(-4, 100, 5,
+                        new WireContainer(0, new int[]{9}, new long[0]),
+                        new WireContainer(0, new int[]{2}, new long[0]), null, null),
+                new WireSection(0, 42, 0,
+                        new WireContainer(4, new int[]{0, 9, 0, 130}, packed(fourBit, 4)),
+                        new WireContainer(2, new int[]{2, 5, 7}, packed(biome2, 2)),
+                        blockLight, null),
+                new WireSection(7, 4096, 12,
+                        new WireContainer(8, pal256, packed(eightBit, 8)),
+                        new WireContainer(3, biomePal8, packed(biome3, 3)), null, null));
+
+        byte[] viaTranslate = NativeToV20Translator.translate(
+                nativeBody(shapes.toArray(new WireSection[0])), BLOCKS, BIOMES);
+
+        var dict = new IdentityDictionary();
+        var sections = new java.util.ArrayList<WireSection>();
+        for (var s : shapes) {
+            sections.add(new WireSection(s.sectionY(), s.nonEmptyBlockCount(), s.fluidCount(),
+                    NativeToV20Translator.convertIndexed(s.blocks().bits(), s.blocks().palette(),
+                            s.blocks().data(), true, dict, BLOCKS),
+                    NativeToV20Translator.convertIndexed(s.biomes().bits(), s.biomes().palette(),
+                            s.biomes().data(), false, dict, BIOMES),
+                    s.blockLight(), s.skyLight()));
+        }
+        byte[] direct = WireSectionCursor.emit(
+                new WireColumn(dict.entries(), sections), Layout.V20);
+        assertArrayEquals(viaTranslate, direct,
+                "convertIndexed must be translate()'s indexed branch, byte for byte");
+    }
+
+    @Test
+    void convertIndexedRejectsWidthsBeyondTheNativeIndexedThresholds() {
+        // Beyond the native indexed thresholds, parse would classify the same bytes
+        // DIRECT and the two routes diverge — the width guard makes the transcoder's
+        // fallback-gate coupling enforced instead of assumed (review finding 3).
+        var dict = new IdentityDictionary();
+        assertThrows(IllegalArgumentException.class, () ->
+                NativeToV20Translator.convertIndexed(9, new int[512], new long[576], true,
+                        dict, BLOCKS));
+        assertThrows(IllegalArgumentException.class, () ->
+                NativeToV20Translator.convertIndexed(4, new int[16], new long[32], false,
+                        dict, BIOMES));
+    }
 }

--- a/fabric/src/test/java/dev/vox/lss/networking/server/NbtSectionSerializerTest.java
+++ b/fabric/src/test/java/dev/vox/lss/networking/server/NbtSectionSerializerTest.java
@@ -1290,6 +1290,49 @@ class NbtSectionSerializerTest {
     }
 
     @Test
+    void directEmitRoutesExactlyTheAllTranscodedColumns() {
+        // The C6 follow-up's routing pin. Direct-emit output is BYTE-IDENTICAL to the
+        // native-emit + translate route (the fuzz above proves it), so without this
+        // counter pin a regression silently re-routing everything through the native
+        // intermediate — re-paying the measured +18.5% serve cost — would pass every
+        // golden in the tree.
+        long before = NbtSectionSerializer.DIRECT_V20_EMITS.get();
+        NbtSectionSerializer.serializeChunkNbt(
+                chunkNbt("minecraft:full", sectionNbt(0, true, true, null, null)), REGISTRY_ACCESS);
+        assertEquals(before + 1, NbtSectionSerializer.DIRECT_V20_EMITS.get(),
+                "an all-transcoded column must take the direct v20 emit");
+
+        // A >256-entry palette is the transcoder's Global fallback: the object-path
+        // section makes the WHOLE column keep the translate route.
+        var pool = new ArrayList<net.minecraft.world.level.block.state.BlockState>();
+        for (var block : List.of(Blocks.OAK_STAIRS, Blocks.SPRUCE_STAIRS, Blocks.BIRCH_STAIRS,
+                Blocks.JUNGLE_STAIRS)) {
+            pool.addAll(block.getStateDefinition().getPossibleStates());
+        }
+        var globalStates = FACTORY.createForBlockStates();
+        int i = 0;
+        for (int y = 0; y < 16; y++)
+            for (int z = 0; z < 16; z++)
+                for (int x = 0; x < 16; x++)
+                    globalStates.set(x, y, z, pool.get(i++ % pool.size()));
+        long beforeMixed = NbtSectionSerializer.DIRECT_V20_EMITS.get();
+        NbtSectionSerializer.serializeChunkNbt(
+                chunkNbt("minecraft:full",
+                        sectionNbt(0, true, true, null, null),
+                        sectionFrom(1, globalStates, FACTORY.createForBiomes())),
+                REGISTRY_ACCESS);
+        assertEquals(beforeMixed, NbtSectionSerializer.DIRECT_V20_EMITS.get(),
+                "a column with any fallback section keeps the translate route wholesale");
+
+        // The flag-off rollback path must never route direct either.
+        NbtSectionSerializer.serializeChunkNbt(
+                chunkNbt("minecraft:full", sectionNbt(0, true, true, null, null)),
+                REGISTRY_ACCESS, null, Integer.MIN_VALUE, Integer.MAX_VALUE, false);
+        assertEquals(beforeMixed, NbtSectionSerializer.DIRECT_V20_EMITS.get(),
+                "useNbtTranscode=false is the object path — no direct emit");
+    }
+
+    @Test
     void maskedColumnMixesTranscodedAndFallbackSectionsByteIdentically() {
         // Under a mask, sections split by the pre-gate: ore-bearing below the cutoff go
         // to the object fallback and get masked; ore-free or above-cutoff sections

--- a/fabric/src/test/java/dev/vox/lss/networking/server/NbtSectionSerializerTest.java
+++ b/fabric/src/test/java/dev/vox/lss/networking/server/NbtSectionSerializerTest.java
@@ -1089,6 +1089,7 @@ class NbtSectionSerializerTest {
                 Biomes.SWAMP, Biomes.TAIGA, Biomes.SAVANNA, Biomes.BADLANDS, Biomes.BEACH,
                 Biomes.RIVER);
         var rng = new java.util.Random(20260730L);
+        long directBefore = NbtSectionSerializer.DIRECT_V20_EMITS.get();
         for (int round = 0; round < 32; round++) {
             var pool = round % 8 < 6 ? narrowPool : widePool;
             int placements = switch (round % 4) {
@@ -1116,6 +1117,10 @@ class NbtSectionSerializerTest {
                     null, Integer.MIN_VALUE, Integer.MAX_VALUE, false);
             assertArrayEquals(object, transcoded, "round " + round);
         }
+        assertTrue(NbtSectionSerializer.DIRECT_V20_EMITS.get() > directBefore,
+                "the fuzz must actually drive the direct emit — a pre-gate widening that"
+                        + " pushed every round to the object path would leave the"
+                        + " direct-vs-translate comparison vacuous");
     }
 
     /**
@@ -1316,18 +1321,21 @@ class NbtSectionSerializerTest {
                 for (int x = 0; x < 16; x++)
                     globalStates.set(x, y, z, pool.get(i++ % pool.size()));
         long beforeMixed = NbtSectionSerializer.DIRECT_V20_EMITS.get();
-        NbtSectionSerializer.serializeChunkNbt(
+        byte[] mixed = NbtSectionSerializer.serializeChunkNbt(
                 chunkNbt("minecraft:full",
                         sectionNbt(0, true, true, null, null),
                         sectionFrom(1, globalStates, FACTORY.createForBiomes())),
                 REGISTRY_ACCESS);
+        assertEquals(2, decode(mixed).size(),
+                "premise: the mixed column still SERVES both sections via translate");
         assertEquals(beforeMixed, NbtSectionSerializer.DIRECT_V20_EMITS.get(),
                 "a column with any fallback section keeps the translate route wholesale");
 
         // The flag-off rollback path must never route direct either.
-        NbtSectionSerializer.serializeChunkNbt(
+        byte[] flagOff = NbtSectionSerializer.serializeChunkNbt(
                 chunkNbt("minecraft:full", sectionNbt(0, true, true, null, null)),
                 REGISTRY_ACCESS, null, Integer.MIN_VALUE, Integer.MAX_VALUE, false);
+        assertEquals(1, decode(flagOff).size(), "premise: the flag-off column still serves");
         assertEquals(beforeMixed, NbtSectionSerializer.DIRECT_V20_EMITS.get(),
                 "useNbtTranscode=false is the object path — no direct emit");
     }
@@ -1384,6 +1392,27 @@ class NbtSectionSerializerTest {
                 sectionNbt(4, false, true, light(0, (byte) 1), null)), REGISTRY_ACCESS);
         NbtSectionSerializer.serializeChunkNbt(chunkNbt("minecraft:full",
                 sectionNbt(2, true, true, null, null)), REGISTRY_ACCESS);
+        // Since the direct v20 emit, ALL-transcoded columns never reach the sized
+        // buffer (the two above route direct) — a MIXED column (a >256-palette Global
+        // section alongside a transcoded one) is the shape that still exercises the
+        // exact-sizing arithmetic, so the pin needs one or it holds by non-execution.
+        var pool = new ArrayList<net.minecraft.world.level.block.state.BlockState>();
+        for (var block : List.of(Blocks.OAK_STAIRS, Blocks.SPRUCE_STAIRS, Blocks.BIRCH_STAIRS,
+                Blocks.JUNGLE_STAIRS)) {
+            pool.addAll(block.getStateDefinition().getPossibleStates());
+        }
+        var globalStates = FACTORY.createForBlockStates();
+        int gi = 0;
+        for (int y = 0; y < 16; y++)
+            for (int z = 0; z < 16; z++)
+                for (int x = 0; x < 16; x++)
+                    globalStates.set(x, y, z, pool.get(gi++ % pool.size()));
+        long directBefore = NbtSectionSerializer.DIRECT_V20_EMITS.get();
+        NbtSectionSerializer.serializeChunkNbt(chunkNbt("minecraft:full",
+                sectionNbt(0, true, true, light(3, (byte) 9), null),
+                sectionFrom(1, globalStates, FACTORY.createForBiomes())), REGISTRY_ACCESS);
+        assertEquals(directBefore, NbtSectionSerializer.DIRECT_V20_EMITS.get(),
+                "premise: the mixed column took the sized-buffer route, not the direct emit");
         assertEquals(before, NbtSectionSerializer.SIZE_MISMATCH_FALLBACKS.get(),
                 "exact sizing fell back to the copy path — getSerializedSize drifted from write");
     }

--- a/paper/src/main/java/dev/vox/lss/paper/PaperNbtSectionSerializer.java
+++ b/paper/src/main/java/dev/vox/lss/paper/PaperNbtSectionSerializer.java
@@ -177,11 +177,11 @@ final class PaperNbtSectionSerializer {
 
     /** Sizing-exactness telemetry — see the Fabric twin. Tests pin 0. */
     static final AtomicLong SIZE_MISMATCH_FALLBACKS = new AtomicLong();
+    private static final AtomicBoolean SIZE_MISMATCH_WARNED = new AtomicBoolean();
 
     /** Direct-emit routing telemetry (C6 follow-up) — see the Fabric twin: byte-equal
      *  outputs make silent re-routing invisible to goldens; tests pin the routing. */
     static final AtomicLong DIRECT_V20_EMITS = new AtomicLong();
-    private static final AtomicBoolean SIZE_MISMATCH_WARNED = new AtomicBoolean();
 
     /**
      * Serialize a chunk's NBT (as read from a region file) into MC-native wire format.
@@ -809,7 +809,9 @@ final class PaperNbtSectionSerializer {
         for (var p : parsed) {
             var t = p.transcoded();
             sections.add(new dev.vox.lss.common.wire.WireSectionCursor.WireSection(
-                    p.sectionY(), p.nonEmptyCount(), p.fluidCount(),
+                    // (byte) cast — see the Fabric twin: the native route's writeByte
+                    // truncates out-of-range sectionY; the direct route must match.
+                    (byte) p.sectionY(), p.nonEmptyCount(), p.fluidCount(),
                     dev.vox.lss.common.wire.NativeToV20Translator.convertIndexed(
                             t.blockBits(), t.blockIds(), t.blockData(), true, dict, blockIdentity),
                     dev.vox.lss.common.wire.NativeToV20Translator.convertIndexed(

--- a/paper/src/main/java/dev/vox/lss/paper/PaperNbtSectionSerializer.java
+++ b/paper/src/main/java/dev/vox/lss/paper/PaperNbtSectionSerializer.java
@@ -177,6 +177,10 @@ final class PaperNbtSectionSerializer {
 
     /** Sizing-exactness telemetry — see the Fabric twin. Tests pin 0. */
     static final AtomicLong SIZE_MISMATCH_FALLBACKS = new AtomicLong();
+
+    /** Direct-emit routing telemetry (C6 follow-up) — see the Fabric twin: byte-equal
+     *  outputs make silent re-routing invisible to goldens; tests pin the routing. */
+    static final AtomicLong DIRECT_V20_EMITS = new AtomicLong();
     private static final AtomicBoolean SIZE_MISMATCH_WARNED = new AtomicBoolean();
 
     /**
@@ -302,6 +306,21 @@ final class PaperNbtSectionSerializer {
                     if (manager != null) manager.countMaskedSection();
                 }
             }
+        }
+
+        // Direct v20 emit (the C6-triggered follow-up, 2026-08-08) — see the Fabric
+        // twin: all-transcoded columns build the v20 column straight from the
+        // descriptors (global ids + verbatim longs), skipping the native emit +
+        // whole-column translator re-parse; byte-identical by the indexed rule.
+        boolean allTranscoded = true;
+        for (var p : parsed) {
+            if (p.transcoded() == null) {
+                allTranscoded = false;
+                break;
+            }
+        }
+        if (allTranscoded) {
+            return emitV20Direct(parsed, registryAccess);
         }
 
         // Second pass: serialize to wire format, into an EXACTLY-sized buffer — see the
@@ -766,11 +785,41 @@ final class PaperNbtSectionSerializer {
 
     /** The C1 produce-path v20 hook (progress-doc decision 2026-08-07): every producer
      *  emits its NATIVE body exactly as before and translates at the return boundary —
-     *  ONE corpus-proven encoder, byte-determinism across paths by construction. */
+     *  ONE corpus-proven encoder, byte-determinism across paths by construction. Since
+     *  the C6-gated follow-up, all-transcoded disk columns bypass this via
+     *  {@link #emitV20Direct}; this route remains for live/mixed/masked columns. */
     static byte[] toV20(byte[] nativeBody, RegistryAccess registryAccess) {
         return dev.vox.lss.common.wire.NativeToV20Translator.translate(nativeBody,
                 PaperIdentityTables::blockIdentityFor,
                 biomeIdentityLookup(registryAccess));
+    }
+
+    /** The direct transcode-path v20 emit (C6 follow-up) — Fabric's
+     *  {@code NbtSectionSerializer.emitV20Direct} twin: the descriptors already carry
+     *  global ids in wire order + verbatim disk longs, so the dictionary walk runs on
+     *  them directly and the native intermediate disappears. Callers guarantee every
+     *  section is transcoded (the assembly's allTranscoded gate). */
+    private static byte[] emitV20Direct(java.util.List<ParsedSection> parsed,
+                                        RegistryAccess registryAccess) {
+        DIRECT_V20_EMITS.incrementAndGet();
+        var dict = new dev.vox.lss.common.wire.IdentityDictionary();
+        java.util.function.IntFunction<String> blockIdentity = PaperIdentityTables::blockIdentityFor;
+        var biomeIdentity = biomeIdentityLookup(registryAccess);
+        var sections = new java.util.ArrayList<dev.vox.lss.common.wire.WireSectionCursor.WireSection>(parsed.size());
+        for (var p : parsed) {
+            var t = p.transcoded();
+            sections.add(new dev.vox.lss.common.wire.WireSectionCursor.WireSection(
+                    p.sectionY(), p.nonEmptyCount(), p.fluidCount(),
+                    dev.vox.lss.common.wire.NativeToV20Translator.convertIndexed(
+                            t.blockBits(), t.blockIds(), t.blockData(), true, dict, blockIdentity),
+                    dev.vox.lss.common.wire.NativeToV20Translator.convertIndexed(
+                            t.biomeBits(), t.biomeIds(), t.biomeData(), false, dict, biomeIdentity),
+                    p.litByBlock() ? p.blockLight() : null,
+                    p.litBySky() ? p.skyLight() : null));
+        }
+        return dev.vox.lss.common.wire.WireSectionCursor.emit(
+                new dev.vox.lss.common.wire.WireSectionCursor.WireColumn(dict.entries(), sections),
+                dev.vox.lss.common.wire.WireSectionCursor.Layout.V20);
     }
 
     /** The C2 egress inverse of {@link #toV20} (XVER §4.2) — Fabric's

--- a/paper/src/test/java/dev/vox/lss/paper/NbtSectionSerializerTest.java
+++ b/paper/src/test/java/dev/vox/lss/paper/NbtSectionSerializerTest.java
@@ -1089,6 +1089,7 @@ class NbtSectionSerializerTest {
                 Biomes.SWAMP, Biomes.TAIGA, Biomes.SAVANNA, Biomes.BADLANDS, Biomes.BEACH,
                 Biomes.RIVER);
         var rng = new java.util.Random(20260730L);
+        long directBefore = PaperNbtSectionSerializer.DIRECT_V20_EMITS.get();
         for (int round = 0; round < 32; round++) {
             var pool = round % 8 < 6 ? narrowPool : widePool;
             int placements = switch (round % 4) {
@@ -1116,6 +1117,10 @@ class NbtSectionSerializerTest {
                     null, Integer.MIN_VALUE, Integer.MAX_VALUE, false);
             assertArrayEquals(object, transcoded, "round " + round);
         }
+        assertTrue(PaperNbtSectionSerializer.DIRECT_V20_EMITS.get() > directBefore,
+                "the fuzz must actually drive the direct emit — a pre-gate widening that"
+                        + " pushed every round to the object path would leave the"
+                        + " direct-vs-translate comparison vacuous");
     }
 
     /**
@@ -1312,17 +1317,20 @@ class NbtSectionSerializerTest {
                 for (int x = 0; x < 16; x++)
                     globalStates.set(x, y, z, pool.get(i++ % pool.size()));
         long beforeMixed = PaperNbtSectionSerializer.DIRECT_V20_EMITS.get();
-        PaperNbtSectionSerializer.serializeChunkNbt(
+        byte[] mixed = PaperNbtSectionSerializer.serializeChunkNbt(
                 chunkNbt("minecraft:full",
                         sectionNbt(0, true, true, null, null),
                         sectionFrom(1, globalStates, FACTORY.createForBiomes())),
                 REGISTRY_ACCESS);
+        assertEquals(2, decode(mixed).size(),
+                "premise: the mixed column still SERVES both sections via translate");
         assertEquals(beforeMixed, PaperNbtSectionSerializer.DIRECT_V20_EMITS.get(),
                 "a column with any fallback section keeps the translate route wholesale");
 
-        PaperNbtSectionSerializer.serializeChunkNbt(
+        byte[] flagOff = PaperNbtSectionSerializer.serializeChunkNbt(
                 chunkNbt("minecraft:full", sectionNbt(0, true, true, null, null)),
                 REGISTRY_ACCESS, null, Integer.MIN_VALUE, Integer.MAX_VALUE, false);
+        assertEquals(1, decode(flagOff).size(), "premise: the flag-off column still serves");
         assertEquals(beforeMixed, PaperNbtSectionSerializer.DIRECT_V20_EMITS.get(),
                 "useNbtTranscode=false is the object path — no direct emit");
     }
@@ -1379,6 +1387,25 @@ class NbtSectionSerializerTest {
                 sectionNbt(4, false, true, light(0, (byte) 1), null)), REGISTRY_ACCESS);
         PaperNbtSectionSerializer.serializeChunkNbt(chunkNbt("minecraft:full",
                 sectionNbt(2, true, true, null, null)), REGISTRY_ACCESS);
+        // Mixed column — see the Fabric twin: since the direct v20 emit, only a column
+        // with a fallback section still exercises the exact-sizing arithmetic.
+        var pool = new ArrayList<net.minecraft.world.level.block.state.BlockState>();
+        for (var block : List.of(Blocks.OAK_STAIRS, Blocks.SPRUCE_STAIRS, Blocks.BIRCH_STAIRS,
+                Blocks.JUNGLE_STAIRS)) {
+            pool.addAll(block.getStateDefinition().getPossibleStates());
+        }
+        var globalStates = FACTORY.createForBlockStates();
+        int gi = 0;
+        for (int y = 0; y < 16; y++)
+            for (int z = 0; z < 16; z++)
+                for (int x = 0; x < 16; x++)
+                    globalStates.set(x, y, z, pool.get(gi++ % pool.size()));
+        long directBefore = PaperNbtSectionSerializer.DIRECT_V20_EMITS.get();
+        PaperNbtSectionSerializer.serializeChunkNbt(chunkNbt("minecraft:full",
+                sectionNbt(0, true, true, light(3, (byte) 9), null),
+                sectionFrom(1, globalStates, FACTORY.createForBiomes())), REGISTRY_ACCESS);
+        assertEquals(directBefore, PaperNbtSectionSerializer.DIRECT_V20_EMITS.get(),
+                "premise: the mixed column took the sized-buffer route, not the direct emit");
         assertEquals(before, PaperNbtSectionSerializer.SIZE_MISMATCH_FALLBACKS.get(),
                 "exact sizing fell back to the copy path — getSerializedSize drifted from write");
     }

--- a/paper/src/test/java/dev/vox/lss/paper/NbtSectionSerializerTest.java
+++ b/paper/src/test/java/dev/vox/lss/paper/NbtSectionSerializerTest.java
@@ -1290,6 +1290,44 @@ class NbtSectionSerializerTest {
     }
 
     @Test
+    void directEmitRoutesExactlyTheAllTranscodedColumns() {
+        // The C6 follow-up's routing pin — see the Fabric twin: direct-emit output is
+        // byte-identical to the translate route, so only this counter catches a silent
+        // re-route back through the native intermediate.
+        long before = PaperNbtSectionSerializer.DIRECT_V20_EMITS.get();
+        PaperNbtSectionSerializer.serializeChunkNbt(
+                chunkNbt("minecraft:full", sectionNbt(0, true, true, null, null)), REGISTRY_ACCESS);
+        assertEquals(before + 1, PaperNbtSectionSerializer.DIRECT_V20_EMITS.get(),
+                "an all-transcoded column must take the direct v20 emit");
+
+        var pool = new ArrayList<net.minecraft.world.level.block.state.BlockState>();
+        for (var block : List.of(Blocks.OAK_STAIRS, Blocks.SPRUCE_STAIRS, Blocks.BIRCH_STAIRS,
+                Blocks.JUNGLE_STAIRS)) {
+            pool.addAll(block.getStateDefinition().getPossibleStates());
+        }
+        var globalStates = FACTORY.createForBlockStates();
+        int i = 0;
+        for (int y = 0; y < 16; y++)
+            for (int z = 0; z < 16; z++)
+                for (int x = 0; x < 16; x++)
+                    globalStates.set(x, y, z, pool.get(i++ % pool.size()));
+        long beforeMixed = PaperNbtSectionSerializer.DIRECT_V20_EMITS.get();
+        PaperNbtSectionSerializer.serializeChunkNbt(
+                chunkNbt("minecraft:full",
+                        sectionNbt(0, true, true, null, null),
+                        sectionFrom(1, globalStates, FACTORY.createForBiomes())),
+                REGISTRY_ACCESS);
+        assertEquals(beforeMixed, PaperNbtSectionSerializer.DIRECT_V20_EMITS.get(),
+                "a column with any fallback section keeps the translate route wholesale");
+
+        PaperNbtSectionSerializer.serializeChunkNbt(
+                chunkNbt("minecraft:full", sectionNbt(0, true, true, null, null)),
+                REGISTRY_ACCESS, null, Integer.MIN_VALUE, Integer.MAX_VALUE, false);
+        assertEquals(beforeMixed, PaperNbtSectionSerializer.DIRECT_V20_EMITS.get(),
+                "useNbtTranscode=false is the object path — no direct emit");
+    }
+
+    @Test
     void maskedColumnMixesTranscodedAndFallbackSectionsByteIdentically() {
         // Under a mask, sections split by the pre-gate: ore-bearing below the cutoff go
         // to the object fallback and get masked; ore-free or above-cutoff sections


### PR DESCRIPTION
The C6 benchmark arms measured C1's translate-at-producer intermediate at **+18.5% serve µs/col**, firing the recorded conditional ("the direct emit lands before D2"). This PR is that follow-up.

## What

All-transcoded disk columns build the v20 `WireColumn` **straight from the transcode descriptors** (palette global ids in wire order + verbatim disk longs — exactly the translator's indexed input) via a new `NativeToV20Translator.convertIndexed`, skipping the native emit + whole-column translator re-parse. Mixed/fallback and mask-needing columns keep the translate route wholesale; the live path is out of scope by the recorded C1 decision. `convertIndexed` enforces the native indexed-width thresholds, and out-of-range sectionY truncates identically to the native route.

`DIRECT_V20_EMITS` routing telemetry on both platforms (+ `direct_v20=` on the Fabric `read_path` diag line): outputs are byte-identical to the translate route, so only a counter can catch a silent re-route.

## Gate (profile-results/20260808-092305, 4+4 × 150 s ABBA, R=256, base = main, 8/8 arms valid)

- serve lss µs/col **246.0 → 231.3 (−6.0%)**; alloc/col 512 → 453 KB (−12%)
- disk-reader-thread LSS cut **+11.8% [+7.2, +16.2]**; `lss_attributed` +5.9% [+1.9, +9.8]
- The removable intermediate cost is recovered; the residual vs the B5 baseline is the v20 capability's inherent price (R-4's release-note framing stands).
- Tripwires clean: `serialize-live`'s rise is a +7% shift to in-memory probe serves (disk_read identical at 45,204) from the faster pipeline — the live path is untouched code.

## Review

One grouped Opus round: no correctness defect (byte identity, dictionary determinism, the gate, and the mask pre-gate verified analytically and empirically); all actionable findings fixed — headline: the exactPreSizing pin had gone vacuous and now serializes a mixed column.

## Tests

Fabric + Paper T1 and Tier 2 green. The transcode-vs-object fuzz now proves direct-vs-translate byte identity across its corpus (with a nonzero-direct-fraction assert); routing pins on both twins; translator-suite identity + width-guard pins; every committed golden untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)