### PR TITLE
docs: D3 prep — matrix checklist, per-line tag texts, #85 draft

### DIFF
--- a/docs/planning/issue-85-answer-draft.md
+++ b/docs/planning/issue-85-answer-draft.md
@@ -1,0 +1,11 @@
+# Issue #85 answer — DRAFT (post ONLY at the real tri-release; D3 prep)
+
+v0.10.0 makes cross-Minecraft-version LOD serving real. The concrete pair you
+need: the SERVER on v0.10.0 or later, and EVERY cross-version player's CLIENT
+on its own Minecraft version's v0.10.0 build (all three lines — 26.2, 26.1,
+1.21.11 — released together at the same feature level). A v0.9.x-or-older
+client on a different MC version still cannot decode the columns; through Via
+it is now cleanly declined instead of receiving garbage (with one documented
+hole: Via running on a Velocity/Bungee proxy is invisible to the server-side
+guard). Blocks that don't exist on the client's version render via the
+configurable `unknownBlockFallback` (default stone) / `crossVersionBlockFallbacks`.

--- a/docs/planning/release-tag-v0.10.0-mc1.21.11.txt
+++ b/docs/planning/release-tag-v0.10.0-mc1.21.11.txt
@@ -1,0 +1,91 @@
+### New Features
+
+- **Cross-version LOD serving (protocol 20)** — A client and server on different
+  supported Minecraft versions can now exchange LODs: columns travel as
+  version-independent block identities and translate to whatever your client
+  runs. Supported pairs: any two of 26.2, 26.1, and 1.21.11 running v0.10.0.
+  Blocks that don't exist on your version render via a configurable fallback
+  (`unknownBlockFallback`, default stone). Older LSS clients keep working: v0.9.x
+  gets a NEW native rung (`enableV19Compat`), and v0.7.x–v0.8.x keep their
+  existing ones.
+- **Via-proxy mismatch guard** — When ViaVersion/ViaBackwards lets a client on
+  a different MC version join with an OLDER LSS installed, the server now
+  detects the mismatch and declines the LOD session cleanly instead of serving
+  columns that client would decode as garbage (a vanilla client has no LSS and
+  never starts a session). **Known hole:** when Via runs on a proxy (Velocity/Bungee)
+  in front of the server, the server cannot see the client's real version — such
+  setups should not rely on the guard.
+- **Vanilla-first transport yield** (`lodYieldsToVanillaTransport`, default
+  `false`) — When enabled, LOD sending pauses while a player's connection is
+  backed up, so LSS never deepens the queue ahead of vanilla's own chunk
+  packets. Ships off pending live validation; behind a buffering proxy the gate
+  is best-effort (it under-yields, never over-yields).
+
+### Performance
+
+- **LOD disk reads leave Minecraft's chunk-IO thread almost entirely** — On
+  Fabric's vanilla read path, LSS now only fetches raw bytes on the shared IO
+  thread; decompression and parsing run on LSS's own reader pool
+  (`useBackgroundReadSplit`, default on). This removes the main historic cause
+  of LOD serving slowing vanilla chunk loads under pressure.
+- **The background store warm-up is cheaper net-of-everything** — the perf
+  round cut the walk's parse/hash work by ~21%, the new cross-version encode
+  added roughly 17% of it back, and deposit throughput is unchanged
+  throughout: net, warming a store costs modestly less CPU than v0.9.x.
+- **Selective chunk parsing (Fabric)** — disk serves now materialize only the
+  chunk data LOD serving needs, cutting the targeted allocation-churn classes
+  roughly in half on the read path. (Net per-column allocation is still higher
+  than v0.9.x — the cross-version format costs more than the parsing saved;
+  see the cost item below.)
+- **The freshness cache tracks ~13× more terrain per MB** — its default (auto)
+  sizing now uses ~2.5× less RAM while remembering ~5× more columns, so large
+  view distances and roaming players stop thrashing it. Existing cache files
+  migrate automatically at first boot.
+- **The honest cost of cross-version columns** — Encoding version-independent
+  identities makes serving a cold column cost roughly 12–16% more CPU than
+  v0.9.x (composed from the separately measured arms; it was ~18% before a
+  follow-up optimization) with per-column allocation and wire/store bytes
+  ~10% higher. Warm store serves and backfill throughput are unaffected. This
+  buys the entire cross-version feature.
+- **Store rows are integrity-hashed with CRC32C** (hardware-accelerated),
+  replacing a slower software hash on the store's write path.
+
+### Configuration
+
+- **`lodYieldsToVanillaTransport`** (server, default `false`) — the transport
+  yield above.
+- **`useBackgroundReadSplit`** (server, default `true`) — the Fabric read split
+  above; `false` restores the old single-thread read.
+- **`useSelectiveNbtParse`** (server, default `true`) — parse only the chunk
+  data LOD serving needs; `false` restores the full parse.
+- **`enableV19Compat`** (server, default `true`) — serve v0.9.x clients natively
+  on their own wire format.
+- **`enableViaMismatchGuard`** (server, default `true`) — the Via guard above.
+- **`unknownBlockFallback`** (client, default `"minecraft:stone"`) and
+  **`crossVersionBlockFallbacks`** (client, default empty) — what a
+  cross-version column renders when a block has no local equivalent, globally
+  and per-block.
+- **`perDimensionTimestampCacheSizeMB`** keeps its `0` = auto default, but auto
+  now derives from the new tile layout (~2.5× less RAM for ~5× the coverage at
+  the same setting).
+
+### Store
+
+- **One-time background migration** — On first boot, existing LOD store rows
+  migrate to the cross-version format in a paced background walk (this is a
+  migration, NOT a rebuild: nothing is re-read from region files, and serving
+  continues meanwhile). Store rows grow ~10% with the new format; if you run a
+  `lodStoreMaxMB` cap, the same cap now holds ~10% fewer columns (evicted
+  columns re-warm on demand, as always).
+- A modded block/biome registry change still drops and rebuilds the store (the
+  fingerprint guard) — migration never runs on drifted registries.
+
+### Notes
+
+- This is the MC 1.21.11 build of the v0.10.0 tri-release: all three lines (26.2,
+  26.1, 1.21.11) ship the same mod at the same feature level, differing only in
+  Minecraft bindings. Cross-version LOD serving works between any two of them
+  once both sides run v0.10.0.
+
+- Folia support remains **experimental** (single-player soak validated;
+  concurrent multi-region ingress untested).

--- a/docs/planning/release-tag-v0.10.0-mc26.1.txt
+++ b/docs/planning/release-tag-v0.10.0-mc26.1.txt
@@ -1,0 +1,91 @@
+### New Features
+
+- **Cross-version LOD serving (protocol 20)** — A client and server on different
+  supported Minecraft versions can now exchange LODs: columns travel as
+  version-independent block identities and translate to whatever your client
+  runs. Supported pairs: any two of 26.2, 26.1, and 1.21.11 running v0.10.0.
+  Blocks that don't exist on your version render via a configurable fallback
+  (`unknownBlockFallback`, default stone). Older LSS clients keep working: v0.9.x
+  gets a NEW native rung (`enableV19Compat`), and v0.7.x–v0.8.x keep their
+  existing ones.
+- **Via-proxy mismatch guard** — When ViaVersion/ViaBackwards lets a client on
+  a different MC version join with an OLDER LSS installed, the server now
+  detects the mismatch and declines the LOD session cleanly instead of serving
+  columns that client would decode as garbage (a vanilla client has no LSS and
+  never starts a session). **Known hole:** when Via runs on a proxy (Velocity/Bungee)
+  in front of the server, the server cannot see the client's real version — such
+  setups should not rely on the guard.
+- **Vanilla-first transport yield** (`lodYieldsToVanillaTransport`, default
+  `false`) — When enabled, LOD sending pauses while a player's connection is
+  backed up, so LSS never deepens the queue ahead of vanilla's own chunk
+  packets. Ships off pending live validation; behind a buffering proxy the gate
+  is best-effort (it under-yields, never over-yields).
+
+### Performance
+
+- **LOD disk reads leave Minecraft's chunk-IO thread almost entirely** — On
+  Fabric's vanilla read path, LSS now only fetches raw bytes on the shared IO
+  thread; decompression and parsing run on LSS's own reader pool
+  (`useBackgroundReadSplit`, default on). This removes the main historic cause
+  of LOD serving slowing vanilla chunk loads under pressure.
+- **The background store warm-up is cheaper net-of-everything** — the perf
+  round cut the walk's parse/hash work by ~21%, the new cross-version encode
+  added roughly 17% of it back, and deposit throughput is unchanged
+  throughout: net, warming a store costs modestly less CPU than v0.9.x.
+- **Selective chunk parsing (Fabric)** — disk serves now materialize only the
+  chunk data LOD serving needs, cutting the targeted allocation-churn classes
+  roughly in half on the read path. (Net per-column allocation is still higher
+  than v0.9.x — the cross-version format costs more than the parsing saved;
+  see the cost item below.)
+- **The freshness cache tracks ~13× more terrain per MB** — its default (auto)
+  sizing now uses ~2.5× less RAM while remembering ~5× more columns, so large
+  view distances and roaming players stop thrashing it. Existing cache files
+  migrate automatically at first boot.
+- **The honest cost of cross-version columns** — Encoding version-independent
+  identities makes serving a cold column cost roughly 12–16% more CPU than
+  v0.9.x (composed from the separately measured arms; it was ~18% before a
+  follow-up optimization) with per-column allocation and wire/store bytes
+  ~10% higher. Warm store serves and backfill throughput are unaffected. This
+  buys the entire cross-version feature.
+- **Store rows are integrity-hashed with CRC32C** (hardware-accelerated),
+  replacing a slower software hash on the store's write path.
+
+### Configuration
+
+- **`lodYieldsToVanillaTransport`** (server, default `false`) — the transport
+  yield above.
+- **`useBackgroundReadSplit`** (server, default `true`) — the Fabric read split
+  above; `false` restores the old single-thread read.
+- **`useSelectiveNbtParse`** (server, default `true`) — parse only the chunk
+  data LOD serving needs; `false` restores the full parse.
+- **`enableV19Compat`** (server, default `true`) — serve v0.9.x clients natively
+  on their own wire format.
+- **`enableViaMismatchGuard`** (server, default `true`) — the Via guard above.
+- **`unknownBlockFallback`** (client, default `"minecraft:stone"`) and
+  **`crossVersionBlockFallbacks`** (client, default empty) — what a
+  cross-version column renders when a block has no local equivalent, globally
+  and per-block.
+- **`perDimensionTimestampCacheSizeMB`** keeps its `0` = auto default, but auto
+  now derives from the new tile layout (~2.5× less RAM for ~5× the coverage at
+  the same setting).
+
+### Store
+
+- **One-time background migration** — On first boot, existing LOD store rows
+  migrate to the cross-version format in a paced background walk (this is a
+  migration, NOT a rebuild: nothing is re-read from region files, and serving
+  continues meanwhile). Store rows grow ~10% with the new format; if you run a
+  `lodStoreMaxMB` cap, the same cap now holds ~10% fewer columns (evicted
+  columns re-warm on demand, as always).
+- A modded block/biome registry change still drops and rebuilds the store (the
+  fingerprint guard) — migration never runs on drifted registries.
+
+### Notes
+
+- This is the MC 26.1 build of the v0.10.0 tri-release: all three lines (26.2,
+  26.1, 1.21.11) ship the same mod at the same feature level, differing only in
+  Minecraft bindings. Cross-version LOD serving works between any two of them
+  once both sides run v0.10.0.
+
+- Folia support remains **experimental** (single-player soak validated;
+  concurrent multi-region ingress untested).

--- a/docs/planning/v0.10.0-progress.md
+++ b/docs/planning/v0.10.0-progress.md
@@ -767,6 +767,34 @@ the mega plan at the overridden text — never a silent divergence.
   user-optional smoke (the automated arms exercise the same load path). Next:
   grouped review round, single PR to main.
 
+- **2026-08-08 (D3 STARTED — re-ports prep; NO tags will be pushed)**: the
+  26.1 re-port is running as a delegated build on branch `support/mc26.1-v0.10`
+  (fresh from main per XVER §11.2 — the old support branches are reference
+  only, frozen at v0.8.0). The R-8 verification-matrix checklist (manual smoke,
+  per the support-line effort budget — the automated load rides each line's CI):
+
+  **D3 verification matrix (checklist)**
+  - [ ] cell 1a: 26.1 line same-MC native smoke (join → cold arc → warm rejoin
+        w/ store hits → `Dialects: v20=1` → store status clean; Fabric AND Paper)
+  - [ ] cell 1b: 1.21.11 line same-MC native smoke (same ladder)
+  - [ ] cell 2a: cross-MC v20 — 1.21.11 client (its line's v0.10 build) → Via'd
+        26.2 server (terrain eyeball, `/lss trace` fallback counters bounded,
+        no decode loops) — THE issue-#85 end-to-end proof, needs the backported
+        client + a GUI: user-assisted
+  - [ ] cell 2b: cross-MC v20 — 26.1 client → Via'd 26.2 server (same ladder):
+        user-assisted
+  - [ ] cell 3 (re-assigned from C6): the Via mismatch-guard live pull — old-LSS
+        client via Via → denial messaging + `LSS_VIA_GUARD=0` kill-switch A/B:
+        user-assisted (needs a GUI join)
+  - [ ] lss-multi-test refresh: SERVER_DEFS → v0.10.0 RC jars from main + the
+        two fresh branches, Via dimension on the 26.2 pair, per-line Prism
+        profiles gain the backported clients, keep one v0.9.1 legacy profile;
+        close every session with ./run.sh stop + the pgrep check
+  - [ ] per-line pre-flights: CI=true build + release_check.py --version 0.10.0
+        green on BOTH fresh branches
+  - [ ] tag texts prepared for all three lines (NO pushes)
+  - [ ] issue #85 answer drafted (posted only at the real tri-release)
+
 - **2026-08-08 (pre-D3 whole-program 3-Fable review EXECUTED + fix round
   MERGED — the user-directed gate is DISCHARGED)**: three Fable lenses over
   `1f6e8a33..main` (the full program, 245 files). Verdicts: wire/protocol and


### PR DESCRIPTION
Docs-only D3 prep artifacts; the 26.1 re-port builds in parallel on its own branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)