### PR TITLE
docs: D3 complete as prep — both re-ports green, no tags pushed

### DIFF
--- a/docs/planning/v0.10.0-progress.md
+++ b/docs/planning/v0.10.0-progress.md
@@ -767,6 +767,33 @@ the mega plan at the overridden text — never a silent divergence.
   user-optional smoke (the automated arms exercise the same load path). Next:
   grouped review round, single PR to main.
 
+- **2026-08-08 (D3 COMPLETE as PREP — both fresh re-ports GREEN; no tags
+  pushed, per the governing directive)**: `support/mc26.1-v0.10` (tip c435396e)
+  and `support/mc1.21.11-v0.10` (tip 9cf05332), both cut fresh from main per
+  XVER §11.2, both CI-green twice INCLUDING Tier 3, both release-gate green
+  (`0.10.0+26.1.2` / `0.10.0+1.21.11` jar sets, release_check OK). Highlights:
+  the 26.1 line needed only the publishServer single-overload flavor + the
+  xray-masked regeneration (R-7's three surfaces verified IDENTICAL — tracer
+  fully sound); the 1.21.11 line carried the big catalogued deltas (Java 21
+  toolchain + loom-remap, accesswidener named-namespace, ScopedValue shim
+  pass-through, the ONE-count-short wire divergence flavored through
+  WireSectionCursor/serializers with v20 keeping both shorts per §2.1,
+  per-line-AND-per-module nbt-corpus regeneration via new RegenTool twins,
+  corrupt-region triage label divergence) — and the tracer ships FULLY
+  FUNCTIONAL there too, R-7's degrade allowance unused. **The automated
+  issue-#85 proof holds on both lines**: the committed 26.2-captured
+  xver-live-corpus decodes STRICTLY (zero identity fallbacks) on 26.1.2 AND
+  1.21.11. The C6-recorded M-3/M-4/M-5 follow-ups landed on main (PR #112:
+  the drift arm + identity manifest + whole-body toNative pins). The old
+  support branches are UNTOUCHED (archival/rename is release-time branch
+  surgery, the user's call). Deferred user-assisted set (recorded in the
+  checklist): matrix cells 1a/1b/2a/2b/3 (GUI joins), the Prism profile half
+  of the rig refresh, the reverse-arm native corpus captures per line, the
+  Modrinth live deploy (archon token), the tri-release tag pushes + branch
+  archival. One repeat observation, not yet cataloged: MemoryLodStoreTest's
+  tombstone test failed ONCE mid-run on each port (passed all reruns) — a
+  third sighting should get a catalog entry.
+
 - **2026-08-08 (D3 STARTED — re-ports prep; NO tags will be pushed)**: the
   26.1 re-port is running as a delegated build on branch `support/mc26.1-v0.10`
   (fresh from main per XVER §11.2 — the old support branches are reference
@@ -786,14 +813,14 @@ the mega plan at the overridden text — never a silent divergence.
   - [ ] cell 3 (re-assigned from C6): the Via mismatch-guard live pull — old-LSS
         client via Via → denial messaging + `LSS_VIA_GUARD=0` kill-switch A/B:
         user-assisted (needs a GUI join)
-  - [ ] lss-multi-test refresh: SERVER_DEFS → v0.10.0 RC jars from main + the
+  - [x] lss-multi-test refresh (automatable half DONE — header retargeted, Via staging added, all SIX v0.10.0 RC jars installed: 26.2 pair from main@84096313, 26.1 pair from c435396e, 1.21.11 pair from 9cf05332; the Prism client-profile half is user-side): SERVER_DEFS → v0.10.0 RC jars from main + the
         two fresh branches, Via dimension on the 26.2 pair, per-line Prism
         profiles gain the backported clients, keep one v0.9.1 legacy profile;
         close every session with ./run.sh stop + the pgrep check
-  - [ ] per-line pre-flights: CI=true build + release_check.py --version 0.10.0
+  - [x] per-line pre-flights (26.1: gate OK, CI 2x green incl. local T3; 1.21.11: gate OK 3x, CI 2x green incl. T3): CI=true build + release_check.py --version 0.10.0
         green on BOTH fresh branches
-  - [ ] tag texts prepared for all three lines (NO pushes)
-  - [ ] issue #85 answer drafted (posted only at the real tri-release)
+  - [x] tag texts prepared for all three lines (NO pushes)
+  - [x] issue #85 answer drafted (posted only at the real tri-release)
 
 - **2026-08-08 (pre-D3 whole-program 3-Fable review EXECUTED + fix round
   MERGED — the user-directed gate is DISCHARGED)**: three Fable lenses over


### PR DESCRIPTION
Docs-only close-out: both fresh re-port branches CI-green with release gates OK, the #85 automated proof holding on both lines, the rig carrying all six RC jars, and the user-assisted remainder enumerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)