### PR TITLE
docs: drop stale VSS-icon clause from the vssJar comment

### DIFF
--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -313,7 +313,7 @@ jar {
 // Same mod, second Modrinth project (voxy-server-side). Produced by BYTE-COPYING the built,
 // remapped LSS jar and rewriting only the fabric.mod.json branding fields + the
 // lss-brand.properties display resource (which drives the LOCAL /vss command + all VSS
-// display text via common/Brand) + injecting the VSS icon — every class, mixin, refmap, the
+// display text via common/Brand) — every class, mixin, refmap, the
 // Loom-injected `jars` field, and the nested META-INF/jars/common jar are copied verbatim.
 // This guarantees the VSS jar is wire-identical to the LSS jar (same protocol, channels, mod
 // id `lss`, config paths — the nested common jar is byte-identical, release_check.py pins the


### PR DESCRIPTION
Two-word comment fix missed by #114 — the vssJar header still said "+ injecting the VSS icon" after the icon and its injection were deleted. Both support branches already carry this fix; this keeps main textually aligned for future cherry-picks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)