### PR TITLE
docs: live test server accepts all three supported MC versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Supports **Fabric** clients, and **Fabric**, **Paper**, **Purpur** and **Folia**
 
 https://github.com/user-attachments/assets/721fb344-890e-4e03-ab36-539444427f7b
 
-**Try it live:** join `lod-server-support.modrinth.gg` (Minecraft 26.2) with [Voxy](https://modrinth.com/mod/voxy) and this mod installed.
+**Try it live:** join `lod-server-support.modrinth.gg` with [Voxy](https://modrinth.com/mod/voxy) and this mod installed. The server runs Minecraft 26.2, but clients on **any supported version** — 26.2, 26.1.x, or 1.21.11 — can join and get full LOD streaming (cross-version columns, with ViaVersion bridging the Minecraft protocol).
 
 ## Installation
 


### PR DESCRIPTION
README-only: the try-it-live callout now states that lod-server-support.modrinth.gg (MC 26.2) serves full LODs to clients on 26.2, 26.1.x, and 1.21.11 — the v0.10.0 cross-version columns plus the ViaVersion/ViaBackwards/ViaFabric stack now installed on the live server. (Docs-only change — build.yml skips it, so no checks will appear.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)