### PR TITLE
docs: five reviewed feature plans for the v0.11.0 program

### DIFF
--- a/docs/planning/client-reset-command-and-cache-relocation-plan.md
+++ b/docs/planning/client-reset-command-and-cache-relocation-plan.md
@@ -1,0 +1,332 @@
+# Client full-reset command (`/lss reset`) + client cache relocation to `.lss/` — plan
+
+**Status: PLANNED, unimplemented** (2026-08-12). Two client-side features, one plan:
+
+1. A new client command that clears BOTH the Voxy data cache (disk + **in-memory** —
+   the player visibly watches all LODs disappear) AND the LSS client cache, then resets
+   LSS client session state to fresh-join equivalent so the server re-streams
+   everything and the LODs rebuild live.
+2. Relocate the LSS client cache from `config/lss/cache/` to a `.lss/` folder in the
+   game root (the `.voxy` convention) — adopting the OLD location when a cache already
+   exists there; only fresh installs use the new location. The JSON client config stays
+   at `config/lss-client-config.json`, untouched.
+
+Exploration ground truth: the full Voxy source is checked out at `research/voxy/`
+(HEAD `136381a7`) with a built 0.2.11 jar, and the newest shipped build is at
+`~/projects/lss-multi-test/downloads/voxy-0.2.18-beta-26.1.2.jar`. Every Voxy claim
+below was read from those, not inferred.
+
+**Reviewed 2026-08-12** (1 Fable subagent; every load-bearing Voxy claim re-verified
+by javap against BOTH shipped jars): verdict IMPLEMENT WITH FIXES, 3 MAJOR / 7 MINOR —
+all folded into this revision. Headlines: the wipe root now comes from the live
+instance's public `getStorageBasePath()` (stable across all three versions, and the
+only correct answer under a Flashback replay); the sequence gains an await on the
+decode-drain's in-flight column; and both mid-sequence failure paths
+(shutdownInstance/createInstance throwing) are now specified.
+
+---
+
+## Part 1 — the reset command
+
+### What already exists (reuse, don't rebuild)
+
+- **`/lss clearcache`** (`LSSClientCommands.java:19-33`, branded root literal via
+  `Brand.clientCommand()`): calls `LodRequestManager.flushCache()`
+  (`LodRequestManager.java:715-723`) — deletes the LSS cache files for the current
+  server (`ColumnCacheStore.clearForServer`), clears `ColumnStateMap` (including
+  `sessionSatisfied` NOT_GENERATED parks), clears `InFlightTracker`, resets
+  `RequestMetrics` rates, and `SpiralScanner.reset()` (re-primed to fire immediately).
+  After it, the scanner re-declares the whole want-set from ring 0 with `ts<=0` ("I
+  have nothing") and the server re-resolves honestly — **no server cooperation or
+  re-handshake is needed; the wire model self-heals by design.** This is the LSS half
+  of the reset, minus one gap (decode queue, below).
+- **Voxy's own `/voxy reload`** (`research/voxy/.../client/VoxyCommands.java:80-98`) is
+  the canonical in-memory teardown sequence:
+  `shutdownRenderer() → VoxyCommon.shutdownInstance() → System.gc() → VoxyCommon.createInstance() → levelRenderer.allChanged()`.
+  It does NOT touch disk. Our command replicates it reflectively and inserts the disk
+  wipe into the down-window.
+- **Bridge patterns**: `VoxyCompat`'s backlog probe (`VoxyCompat.java:191-215`) is the
+  all-or-nothing "resolve a chain, partial = absent, separate failure domain" template;
+  `AntiXrayCompat.buildEngineProbe` is the "live object, may fail per call, warn once"
+  template. The reset ladder combines both.
+
+### Voxy facts the design rests on (verified against 0.2.11 jar, 0.2.18 jar, dev source)
+
+- `me.cortex.voxy.commonImpl.VoxyCommon` — `getInstance()`, `shutdownInstance()`,
+  `createInstance()`, `isAvailable()` are `public static` and **byte-stable across all
+  three versions**. The most stable reflection surface available.
+- `shutdownInstance()` nulls the instance FIRST, then `VoxyInstance.shutdown()`
+  (`commonImpl/VoxyInstance.java:216-270`) stops services and `world.free()`s every
+  engine — which **flushes and closes storage**. So the disk wipe MUST happen after
+  `shutdownInstance()` returns and before `createInstance()`; wiping a live store races
+  `SectionSavingService` and gets partially resurrected by the flush-on-close.
+- `createInstance()` **throws** if an instance already exists (`VoxyCommon.java:78-80`)
+  and silently **no-ops** when the factory is null — GPU-unsupported / never enabled
+  (`:74-77`). `isAvailable()` (`:85-87`) is the discriminator.
+- **Renderer must go down BEFORE the instance** — and the failure mode is worse than a
+  throw (review correction): `VoxyInstance.shutdown` busy-waits `while
+  (world.isWorldUsed()) Thread.sleep(10)` (`VoxyInstance.java:248-255`) before
+  `free()`. With the renderer still holding acquired sections and its release path
+  unable to run (we ARE the main thread), that is an **unbounded main-thread freeze**,
+  not an exception. This is why `/voxy reload` shuts the renderer down first, and why
+  the abort-if-holder-unresolvable rule below is non-negotiable.
+- **`VoxyClientInstance.getStorageBasePath()` is public in all three versions**
+  (javap-verified in both shipped jars; dev `VoxyClientInstance.java:73-75`) and
+  returns the path the live instance is ACTUALLY using — including the Flashback
+  replay override (`:33-38`), where the basePath is the replay's storage, not the
+  server's. The wipe root must come from it (read reflectively BEFORE
+  `shutdownInstance()`); a hand-duplicated `getBasePath` derivation would wipe the
+  real server's cache while the user watches a replay.
+- The renderer holder is **the one unstable name**: mixin interface on vanilla
+  `LevelRenderer`, `me.cortex.voxy.client.core.IGetVoxyRenderSystem.shutdownRenderer()`
+  in 0.2.11/dev vs `IVoxyRenderSystemHolder.voxy$shutdownRenderer()` in 0.2.18-beta.
+  Needs a two-rung resolver (repo precedent: `MoonriseSendStateCompat`'s two-rung
+  ladder, `AntiXrayCompat`'s carrier ladder).
+- `levelRenderer.allChanged()` is **pure vanilla MC** (direct class literal per the
+  CLAUDE.md MC-type rule) and re-triggers Voxy's own renderer rebuild via
+  `MixinLevelRenderer` (`allChanged` RETURN → shutdownRenderer + createRenderer).
+- Voxy's per-server disk cache: multiplayer `<gameDir>/.voxy/saves/<serverIp with
+  ':'→'_'>/<32-hex worldId>/…`, singleplayer `<world dir>/voxy`, realms
+  `.voxy/saves/realms`, null server info → `.../UNKNOWN`
+  (`VoxyClientInstance.getBasePath`, `research/voxy/.../client/VoxyClientInstance.java:94-119`).
+  NOTE: Voxy's ip-keying differs from LSS's `serverAddress` resolution
+  (`LSSClientNetworking.java:156-170`) — the wipe must mirror **Voxy's** keying.
+- Re-ingest after a wipe: `WorldUpdater.insertUpdate` re-meshes only on
+  `didStateChange`, and **nothing in Voxy drops loaded geometry on ingest** — which is
+  exactly why the instance teardown (not just a disk wipe + re-serve) is required for
+  the "LODs visibly disappear" requirement.
+- Gating: `rawIngest` returns false when Voxy ingest is disabled
+  (`VoxyClientInstance.isIngestEnabled` — config toggle / Flashback replay). A reset
+  with ingest off produces LSS ingest-failure reports, not repopulation — report it in
+  the command feedback if detectable, otherwise let the normal containment handle it.
+
+### Command design
+
+**Name:** `/lss reset` (branded root, same tree as `clearcache`/`diag`/`trace` in
+`LSSClientCommands.registerCommands`). `clearcache` stays unchanged (LSS-only,
+documented behavior, soak-scripted).
+
+**Sequence** (main client thread — same thread Voxy's own command and login/disconnect
+mixins run on, so no concurrent-lifecycle race):
+
+1. **Drain the LSS decode queue AND await the in-flight column**:
+   `columnProcessor.reportUndispatched(manager)` (`ClientColumnProcessor.java:562-572`,
+   epoch bump + drain) — then **wait, bounded, for the `processing` flag**
+   (`ClientColumnProcessor.java:91`) to clear. The javadoc at `:558-560` is explicit
+   that a column an in-flight drain already polled "still dispatches normally" on the
+   `LSS-ColumnProcessor` thread — concurrently with step 2 — and `VoxyCommon.INSTANCE`
+   is a plain non-volatile static, so that dispatch can open a fresh store INSIDE the
+   directory being wiped (on Windows, an open handle partially fails the recursive
+   delete). A polled column decodes in milliseconds, so the await is cheap and closes
+   the race deterministically.
+2. **Voxy teardown + wipe + rebuild** (new bridge entry point, see below):
+   a. read the wipe root from the live instance's `getStorageBasePath()` (reflective,
+      BEFORE shutdown — the only source that is correct under a Flashback replay);
+      fall back to the hand-derived `getBasePath` logic only when the instance is
+      null (config-disabled case, no live path to ask);
+   b. two-rung holder resolve → null-check `Minecraft.getInstance().levelRenderer`
+      (as Voxy's own reload does, `VoxyCommands.java:86-89`) → `shutdownRenderer()` —
+      **if the holder is unresolvable, ABORT the Voxy half with a once-warn**
+      (skipping renderer-first teardown risks the `isWorldUsed` busy-wait freezing the
+      main thread — see the facts above; fail-safe direction), still run step 3;
+   c. if `getInstance() != null` → `shutdownInstance()` inside its own containment:
+      **if it throws** (e.g. the world-cleaner join interrupt,
+      `VoxyInstance.java:220-223`), the instance is already nulled and storage may
+      hold open handles — SKIP the wipe (deleting over open handles is the Windows
+      partial-wipe trap), still attempt `createInstance()` (recovery — Voxy itself is
+      instanceless at that point), and report "Voxy reset incomplete — rejoin to fully
+      clear". If the instance was null, skip 2e's create (never create an instance
+      Voxy itself didn't have — config-disabled/GPU cases) but still wipe (no live
+      storage);
+   d. recursively delete the resolved per-server directory, with containment:
+      normalize + assert the target is under `.voxy`/the world dir before deleting
+      (a replay path failing containment → skip wipe = fail-safe); any IO failure is
+      contained + logged, never thrown;
+   e. `System.gc()` (parity with `/voxy reload` — native storage handles), then
+      `createInstance()`, then `Minecraft.getInstance().levelRenderer.allChanged()`
+      (vanilla literal; rebuilds the renderer against the new instance exactly as
+      Voxy's own reload does). **If `createInstance()` throws** (contained): the
+      renderer stays down and every re-served column will fail ingest (bounded by the
+      ingest-failure parking caps) — feedback must say "Voxy failed to restart —
+      rejoin to recover", not the happy-path line.
+3. **LSS fresh-join reset**: `manager.flushCache()` — after the new Voxy instance is
+   live, so every re-served column lands in the fresh engine. Voxy-AFTER-drain,
+   LSS-LAST ordering means columns that arrive over the wire during step 2 enqueue and
+   dispatch into the NEW instance, and their stamps are cleared at step 3 → re-served →
+   duplicate ingest, which is idempotent by protocol design (`LSSApi.java:88-93`).
+   (Mid-command wire arrivals cannot slip into the queue during the command itself:
+   both the stamp and the queue offer hop through `context.client().execute`,
+   `LSSClientNetworking.java:224-227` — same thread as the command.)
+4. **Feedback**: chat lines per BRANCH — happy path "Voxy LODs cleared (disk +
+   memory)" + "LSS cache cleared — re-requesting from server" (the scanner is primed
+   to fire immediately); holder-unresolvable "Voxy reset unavailable on this Voxy
+   version — LSS cache cleared and re-requested" (LODs do NOT visibly disappear on
+   this branch — the message must not claim they did); the two step-2 failure branches
+   per 2c/2e above.
+
+**No-manager fallback** (LSS inactive on this server, mirroring `clearcache`'s `:27`
+fallback): `ColumnCacheStore.clearAll()` + the Voxy half if in-game — but this branch
+is destructive with NO re-stream (no LSS server to refill Voxy; it repopulates only
+from vanilla chunk loading), so it requires a confirm step (`/lss reset confirm`) and
+its feedback says exactly that. With an active LSS session the single-step command
+stands — the wipe is recoverable by construction.
+
+### New `VoxyCompat` surface
+
+- New handles, resolved lazily in their **own all-or-nothing failure domain**
+  (pattern: `initBacklogProbe`, `VoxyCompat.java:191-215`): `VoxyCommon.isAvailable`,
+  `getInstance` (reuse existing), `shutdownInstance`, `createInstance`,
+  `VoxyClientInstance.getStorageBasePath` (the wipe-root source — public in all three
+  versions), plus the two-rung renderer-holder resolve
+  (`IVoxyRenderSystemHolder.voxy$shutdownRenderer` →
+  `IGetVoxyRenderSystem.shutdownRenderer`; the interface Class is `Class.forName`-safe
+  — it's a Voxy class, not an MC class). A failed resolve = the reset command reports
+  "Voxy reset unavailable" once and does only the LSS half — it must never cost the
+  existing ingest bridge (same isolation contract as the backlog probe).
+- `VoxyCompat` is **package-private** (`dev.vox.lss.compat`); the command lives in
+  `dev.vox.lss.networking.client`, so the entry point is a public facade on
+  `ModCompat` (mirroring `getVoxyViewDistanceChunks`, `ModCompat.java:23-26`), gated
+  on `voxyLoaded`.
+- The orchestration body lives in a package-visible, seam-injected method (holder
+  supplier, instance handles, wipe-root resolver, `Runnable allChanged`) so JUnit can
+  drive the full ladder without MC — the `AntiXrayCompat.buildEngineProbe` injectable
+  shape.
+- Wipe-path derivation duplicated from `VoxyClientInstance.getBasePath` survives ONLY
+  as the instance-null fallback (comment pinning the source file+line in
+  `research/voxy`); the live path always comes from `getStorageBasePath()`. Drift in
+  the fallback degrades to "wipes nothing / wrong-but-contained subdir of `.voxy`",
+  never data loss outside `.voxy` — and a Flashback replay path failing the
+  containment assert skips the wipe, the fail-safe direction.
+
+---
+
+## Part 2 — LSS client cache relocation (`config/lss/cache` → `.lss/cache`)
+
+### Current state (all from `ColumnCacheStore.java`)
+
+- Root is a static final: `FabricLoader.getInstance().getConfigDir().resolve("lss").resolve("cache")`
+  (`:46`) → `config/lss/cache/<sanitized-server>/<sanitized-dim>.bin` (`:361-371`),
+  `.tmp` sibling during save (`:115`). Deliberately **unbranded** (jar-swap continuity,
+  `docs/planning/ci-dual-publish.md:88`) — keep `.lss` unbranded for the same reason.
+- The client JSON config is fully independent (`LSSClientConfig.java:13-16` →
+  `config/lss-client-config.json` via `brandedConfigCandidates`) — **no change there**.
+
+### Design
+
+- New root: `<gameDir>/.lss/cache/` via `FabricLoader.getInstance().getGameDir()`.
+  Everything below the root (per-server dirs, sanitization, format v4, tmp+atomic
+  moves) is unchanged.
+- **Adoption rule, resolved once**: extract a pure function
+  `static Path resolveCacheRoot(Path configDir, Path gameDir)` — if
+  `configDir/lss/cache` **exists as a directory**, return it (existing installs keep
+  their cache and their path; no migration, per the user decision); otherwise return
+  `gameDir/.lss/cache`. Production caches the result lazily (replacing the eager
+  static-final at `:46`) so tests can exercise both branches of the pure function;
+  a directory-exists check is deliberately the whole test (an empty old dir still
+  adopts — harmless, deterministic).
+- Expose the resolved root package-visibly (e.g. `ColumnCacheStore.cacheRoot()`) for
+  the two test sites that currently rebuild the path by hand.
+
+### Blast radius (from exploration — complete list)
+
+- **Tests**: `ColumnCacheStoreTest.java` hardcodes the old path at `:35-40`
+  (`getCacheFile` helper) and `:381` (`hostileServerAddressCannotEscapeCacheDir`) —
+  switch both to `cacheRoot()`; add unit tests for `resolveCacheRoot` (old-dir-exists →
+  old; absent → `.lss`). The other cache-touching tests
+  (`ClientColumnProcessorTest.java:795-820`, `LodRequestManagerTest.java:1010`,
+  `SpiralScannerTest`, `ColumnStateMapTest`) go through the store's own API and follow
+  automatically.
+- **Harness scripts** that hardcode `config/lss/cache`: `scripts/soak.sh` (`:349,
+  :352, :360-362, :366, :369, :545-548` — including the `cache-platform` marker file),
+  `scripts/benchmark.sh:94` (also clears `config/vss/cache` — dead path, may drop),
+  `scripts/benchmark_compare.sh:60` AND `:133` (two sites — review), and
+  `scripts/profile_disk_read.sh:165`. Clearing must cover BOTH roots, and — review
+  point — soak.sh's base-world cache **collection** (`:545-548`) must CHECK both roots
+  too, or the first post-relocation fresh-backfill saves to `.lss/cache`, collection
+  finds nothing at the old path, and every warm scenario silently goes cold (a premise
+  red). Note also that the warm-restore staging (`:360-362`) *creates*
+  `config/lss/cache`, which under the adoption rule forces the old root for that run —
+  load-bearing and correct, but it deserves a comment in the script.
+- **Docs**: `docs/planning/ci-dual-publish.md:88` ("config paths are hardcoded…
+  `config/lss/…`") needs a caveat; `soak-test-design.md:183` /
+  `timestamp-store-unification-design.md:331` are historical — one-line update or leave.
+- The only existing game-root write is `ClientTraceLog` (`logs/`), so `.lss/` is the
+  first game-root LSS directory — README should mention it (users ask what new dot-dirs
+  are).
+
+---
+
+## Tests
+
+- **`VoxyCompat` reset ladder** (extend `VoxyCompatTest` + stubs under
+  `fabric/src/test/java/me/cortex/voxy/`): add `shutdownInstance`/`createInstance`/
+  `isAvailable`/`getStorageBasePath` to the stubs (call-recording + throw injection),
+  a stub for each holder-interface name. Pins: happy-path ORDER (drain + await the
+  `processing` flag → wipe-root read from `getStorageBasePath` BEFORE shutdown →
+  shutdownRenderer (with the levelRenderer null-check) → shutdownInstance → wipe →
+  createInstance → allChanged); unresolvable holder aborts BEFORE shutdownInstance and
+  warns once; null instance skips shutdown+create, still wipes via the FALLBACK
+  derivation; `shutdownInstance` throw → wipe SKIPPED, create still attempted, the
+  "incomplete" feedback branch; `createInstance` throw contained → the "failed to
+  restart" feedback branch; all-or-nothing handle resolution (partial chain = absent);
+  the existing ingest bridge and backlog probe unaffected by a dead reset domain; the
+  no-manager fallback requires the `confirm` token.
+- **Wipe containment**: temp-dir tests — deletes only under the resolved `.voxy`
+  server dir; refuses a path that normalizes outside it (mirror
+  `hostileServerAddressCannotEscapeCacheDir`).
+- **Command orchestration**: keep the command body thin; put the sequence in a
+  seam-injected coordinator so JUnit pins the ordering and both fallbacks (no manager;
+  Voxy half unavailable). `LSSClientCommands` itself stays uncovered (status quo —
+  only `BrandTest` pins literals).
+- **`ColumnCacheStoreTest`** updates + `resolveCacheRoot` branch tests, per Part 2.
+- **Soak**: untouched — `clearcache-mid-session`, `store-second-join`,
+  `store-save-storm`, `paper-store-unfired-event` all script `clearcache`, whose
+  semantics don't change; soak clients have no Voxy. The soak.sh cache-clearing edits
+  keep staging correct under either root.
+
+## Docs / release notes
+
+- README command list (currently documents `clearcache` at `:45`): add `/lss reset`
+  with the one-line "wipes Voxy + LSS LOD state for this server and re-streams
+  everything" description + the `.lss/` folder note.
+- CLAUDE.md: client-side section — `/lss reset` + the cache-root adoption rule.
+- Release notes (New Features + Configuration): the reset command; the new `.lss/`
+  location for fresh installs (existing installs keep `config/lss/cache`).
+
+## Risks / accepted constraints
+
+- **Voxy version drift**: the instance-lifecycle statics are stable across 0.2.11 →
+  0.2.18 → dev; the renderer holder is not (two-rung + abort-fail-safe covers known
+  versions; an unknown future rename degrades to LSS-only reset with a warn, never a
+  broken Voxy).
+- **`fabric.mod.json` suggests `voxy >=0.2.17-alpha`** — the 0.2.18 rung
+  (`voxy$shutdownRenderer`) is the primary; 0.2.11-era rung is best-effort.
+- **Wipe-path drift**: the live wipe root comes from `getStorageBasePath()` (no drift
+  possible); the duplicated `getBasePath` logic survives only as the instance-null
+  fallback, contained to `.voxy` subtrees by construction. A Flashback replay's
+  override path fails containment → wipe skipped (fail-safe).
+- **Ingest-disabled Voxy** (config off / replay): reset leaves LODs empty until the
+  user re-enables — LSS's ingest-failure containment reports and re-declares; document
+  in the README line.
+- Deleting the whole `.voxy/saves/<ip>` dir wipes ALL dimensions for that server
+  (matches "fresh client"); singleplayer wipes `<world>/voxy`.
+
+## Verification
+
+1. Tier 1: `./gradlew :fabric:test -x runGameTest -x runClientGameTest` (new
+   VoxyCompat/coordinator/cache-root pins; updated ColumnCacheStoreTest).
+2. Tier 2 + 3 unchanged behavior: `./gradlew :fabric:build -x runClientGameTest`, then
+   `:fabric:runClientGameTest`. NOTE (review): Tier 3 lands on the `.lss` root only in
+   a CLEAN run dir (CI) — a dev box's persisted Loom run dir with a pre-relocation
+   `config/lss/cache` adopts the old root and never exercises the new branch. The
+   `resolveCacheRoot` unit tests are the real gate for the `.lss` branch; a local
+   Tier-3 green is not proof of it.
+3. One full soak (`./scripts/soak.sh clearcache-mid-session`) to prove the soak.sh
+   cache-staging edits under the new root.
+4. Live smoke with real Voxy (the lss-multi-test Prism profile has 0.2.18-beta):
+   join the local test server (`./test-server.sh run-fabric`), let LODs build, run
+   `/lss reset` — LODs visibly vanish, then rebuild from ring 0; check `.voxy/saves/<ip>`
+   was recreated fresh and `latest.log` for exactly one warn if any rung failed.
+   Repeat once on a server WITHOUT Voxy installed client-side (LSS-only half + clean
+   feedback), and once with an existing `config/lss/cache` present (adoption keeps the
+   old root).

--- a/docs/planning/dirty-broadcast-interval-zero-plan.md
+++ b/docs/planning/dirty-broadcast-interval-zero-plan.md
@@ -1,0 +1,184 @@
+# `dirtyBroadcastIntervalSeconds: 0` = disable client dirty pushes — plan
+
+**Status: PLANNED, unimplemented** (2026-08-12). No code has changed; this documents the
+agreed design for supporting `0` as an "off" value for the dirty-broadcast interval.
+**Reviewed 2026-08-12** (1 Fable subagent, all citations re-verified against the code):
+verdict IMPLEMENT WITH FIXES, 0 MAJOR / 7 MINOR — all folded into this revision. The
+review independently confirmed the per-player clears are REQUIRED (not optional) for
+the mid-session heal promise, via the duplicate-rung-before-timestamp-rung order.
+
+## Context
+
+Today `dirtyBroadcastIntervalSeconds` is clamped to `[1, 300]`
+(`ServerConfigBase.validate()`, `MIN_DIRTY_BROADCAST_INTERVAL = 1`), so a configured `0`
+silently becomes `1` — the *fastest* broadcast cadence, the opposite of what an operator
+writing `0` means. The goal: `0` becomes a supported "off" value — the server stops
+pushing `DirtyColumnsS2CPayload` to clients, and clients pick up changed terrain only
+through their natural re-asks (fresh rejoin, a re-declaration after
+movement/clearcache/ingest-failure, etc.).
+
+The trap this plan is built around: **the dirty-broadcast tick is not just a send.** Its
+drain carries the entire server-side invalidation fan-out — one call,
+`offThreadProcessor.invalidateTimestamps(dim, dirty)` (`DirtyColumnBroadcaster.java:94`,
+`PaperDirtyColumnBroadcaster.java:65`), which downstream (in
+`OffThreadProcessor.applyInvalidations`) invalidates LOD-store rows (the store's
+correctness backstop), invalidates the `ColumnTimestampCache`, taints in-flight
+reads/generations, and marks stale generations. If `0` skipped the whole tick:
+
+- stale LOD-store rows would keep serving until an independent mechanism catches them
+  (Fabric's save-hook DELETE-only bridge closes the store hole broadcast-independently;
+  Paper's periodic resweep bounds it at ~lodStoreResweepSeconds — but the tscache leg
+  below has no such backstop, so the fan-out must still run);
+- `ts>0` re-asks would answer `up_to_date` off stale tscache stamps for the rest of the
+  boot (the shutdown `drainAll()` invalidates before the final tscache save, so the
+  damage is until-restart, not forever) — still breaking the "heals on rejoin"
+  semantics the feature is for;
+- `DirtyColumnTracker` would grow unboundedly (marks never drained — matches the
+  tracker's own in-source wording);
+- `dirty.pending` is a `SERVER_DRAINS` member in `check_soak.py` — quiescence would
+  break in any future scenario running interval 0.
+
+(Review note, 2026-08-12: the per-player clears are additionally REQUIRED for this
+plan's own "mid-session re-ask heals" promise — the router's duplicate/done-bit rung
+fires BEFORE the timestamp rung, so an uncleaned done-bit answers a returning player's
+`ts>0` re-ask with a stale `up_to_date` even though the tscache was invalidated.)
+
+## Chosen semantics
+
+**`0` disables ONLY the wire send. The drain, the invalidation fan-out, and the
+per-player done-bit/probe-stamp clears all keep running on an internal fallback
+cadence.** The only behavior change is that no `DirtyColumnsS2CPayload` leaves the
+server. A rejoin heals fully (per-player state dies at disconnect; tscache/store were
+invalidated), and any mid-session re-ask re-resolves honestly (done-bits were cleared).
+
+Accepted, documented consequences:
+
+- mid-session, connected clients keep stale LOD until they re-ask;
+- `NOT_GENERATED`-parked positions lose their one mid-session revival path (the dirty
+  broadcast) and heal only on reconnect.
+
+Negative values normalize to `0` (the `lodStoreMaxMB` "0 and negative nonsense" idiom);
+`1` stays the *nonzero* floor and `300` the ceiling.
+
+## Changes
+
+### 1. Constants — `common/.../LSSConstants.java`
+Next to `MIN_DIRTY_BROADCAST_INTERVAL`/`MAX_DIRTY_BROADCAST_INTERVAL` (both unchanged):
+add `DIRTY_DRAIN_ONLY_INTERVAL_SECONDS = 10` — the drain cadence used when sends are
+disabled (matches the field's default, so "off" costs the same server-side as default).
+
+### 2. Config — `common/.../config/ServerConfigBase.java`
+- Clamp switches to the `lodStoreMaxMB` idiom:
+  `dirtyBroadcastIntervalSeconds = dirtyBroadcastIntervalSeconds <= 0 ? 0 : Math.clamp(..., MIN, MAX)`.
+- Field javadoc: `0` = dirty pushes disabled; the drain + invalidation fan-out still run
+  every `DIRTY_DRAIN_ONLY_INTERVAL_SECONDS`; clients refresh only on rejoin/re-request;
+  note the `NOT_GENERATED` revival consequence AND the flip-back consequence: edits
+  drained during an off window left the tracker — re-enabling never retroactively
+  pushes them (they surface via re-ask only).
+- One `LSSLogger.info` in `validate()` when the value is 0 (precedent: PaperConfig's
+  Folia store warn) so an operator sees the mode in the log. (This line also fires
+  during the config test suites' extreme-value clamp sweeps — harmless, expected.)
+
+### 3. Fabric broadcaster — `fabric/.../server/DirtyColumnBroadcaster.java` (tick)
+- Read the config field **once per tick** into a local (avoids a torn read between
+  cadence and send-gate; the live-read-per-tick contract is pinned by
+  `midRunConfigIntervalChangeTakesEffectImmediately` on the Paper twin).
+- `boolean sendsEnabled = intervalSeconds > 0; int cadence = sendsEnabled ? intervalSeconds : DIRTY_DRAIN_ONLY_INTERVAL_SECONDS;`
+  — note today `0` would compute `intervalTicks = 0` and drain *every* tick, so the
+  fallback cadence is required, not optional.
+- Leave the rest untouched (drain, `invalidateTimestamps`, per-player gates, range
+  filter, pagination, `clearDiskReadDone`, `clearProbeSuppress`). Gate **only** the
+  `playerView.send(...)` (and its failure handling — `failedPlayers` is send-scoped) on
+  `sendsEnabled`.
+- Do not move the tick call site — `flushSendQueues → dirtyBroadcaster.tick` ordering is
+  load-bearing (`AbstractPlayerRequestState.clearProbeSuppress` javadoc).
+
+### 4. Paper broadcaster — `paper/.../PaperDirtyColumnBroadcaster.java` (tick)
+Textual twin of change 3. Same single-read, same gate placement.
+
+### 5. Client comment fix — `fabric/.../client/LodRequestManager.java` (onDirtyColumns)
+Comment-only: the handler reasons about "the legal `dirtyBroadcastIntervalSeconds` floor
+(1 s)". Reword to "the floor for a *sending* interval (1 s); 0 disables sends entirely
+(this handler simply never fires then)".
+
+## Tests
+
+### Config
+- `fabric/src/test/.../config/ConfigValidationTest.java`
+  - Rewrite `dirtyBroadcastIntervalSecondsClamped` (currently asserts `0 → 1`): `0`
+    stays `0`, `-5 → 0`, `1` stays `1` (nonzero floor), `9999 → 300`. Mirror the
+    naming/shape of `lodStoreMaxMBZeroStaysUncappedAndNonzeroFloorsAt64`.
+  - Add `"dirtyBroadcastIntervalSeconds"` to the 0-floor `case` list in the reflective
+    sweep's `switch` (`everyNumericServerFieldClampedAtIntExtremes`) with a one-line
+    rationale in the comment block above it.
+- `paper/src/test/.../PaperConfigValidationTest.java`
+  - `SHARED_BOUNDS` row → `new Bounds(0, MAX_DIRTY_BROADCAST_INTERVAL)` + the same
+    comment pattern the `lodStoreMaxMB`/`outboundBufferCeilingKB` rows use ("real floor
+    applies to nonzero only, pinned by named test"). The sweep's "exact minimum kept"
+    leg then passes with 0.
+  - Add a named test pinning `0` kept / negative → 0 / nonzero floor 1 (twin of the
+    Fabric named test).
+
+### Broadcasters (the behavior pins)
+- `fabric/src/test/.../DirtyColumnBroadcasterTest.java` — the existing `Rig` +
+  `RecordingProcessor`/`FakeView` seams record `invalidateTimestamps`,
+  `clearDiskReadDone`, and sends in one ordered log. NOTE (review): neither broadcaster
+  suite currently observes `clearProbeSuppress`, and `probeSuppressCountForTest()` is
+  package-private to `common.processing` — pin it through the PUBLIC state instead
+  (`stampProbeSuppress(...)` beforehand, then assert `isProbeSuppressed`/`skipProbe`
+  false after the fallback tick), or extend the rig's recording. Add:
+  1. interval 0: after `DIRTY_DRAIN_ONLY_INTERVAL_SECONDS * 20` ticks, the tracker is
+     drained (`pendingCount() == 0`), `invalidateTimestamps` fired, `clearDiskReadDone`
+     + `clearProbeSuppress` applied for the in-range player — and **zero sends**
+     recorded.
+  2. interval 0 fires on exactly the fallback-cadence tick, not before (twin of
+     `firesOnExactlyTheIntervalTickAndCounterRestartsFromZero`).
+  3. mid-run flips BOTH ways: `0 → 1` resumes sends on the next interval, and
+     `nonzero → 0` stops sends while the drain continues at the fallback cadence
+     (live-read pins, twin of the Paper mid-run test).
+- `paper/src/test/.../PaperDirtyColumnBroadcasterTest.java` — same three, using its
+  Mockito rig + `setDirtySender` recorder. `zeroEligiblePlayersStillInvalidatesTimestamps`
+  is the shape to copy for test 1.
+- `fabric/src/gametest/.../LSSGameTests.java:137` (`allConfigFieldsInValidRange`) —
+  asserts the loaded interval is within `[MIN, MAX]` = `[1, 300]`; stays green today
+  (gametest run dirs ride the default 10) but must learn the new value set:
+  `== 0 || (>= MIN && <= MAX)`.
+
+### Untouched by design (sanity, not edits)
+- Tier 2 `TwoPlayerGameTests` fan-out and all soak scenarios run at explicit/default
+  nonzero intervals — no changes needed; they must stay green as the proof the nonzero
+  path is byte-identical.
+- `ExporterContractTest`'s `marked_total == broadcast_positions + pending` identity
+  holds (the drain still runs; `broadcast_positions` is `getTotalDrained()` — a drain
+  counter, so it keeps climbing with sends off; no counter/schema changes).
+- `scripts/check_soak.py` needs nothing: defaults unchanged, and 25 of 26 scenario
+  configs pin the interval explicitly (`store-offline-mutate-config.json` omits it and
+  rides the unchanged default; the checker's window math falls back to
+  `DEFAULT_DIRTY_BROADCAST_SECONDS = 5`). Caveat for the future: the dirty-family
+  named checks size their windows as `2 * interval` — any FUTURE scenario that stages
+  interval 0 needs checker work first, not just the quiescence note above.
+
+## Docs
+- CLAUDE.md: in the Configuration section's server-config bullet, note "dirty broadcast
+  interval (`0` = disable client dirty pushes; the server-side invalidation drain still
+  runs)".
+- `docs/planning/config-defaults-and-clamps-review-2026-08-02.md:159` documents the
+  clamp as `1..300` and CLAUDE.md cites that doc as the full clamp audit — append an
+  erratum (the doc already carries a 2026-08-08 one for the D0 tile redesign).
+- Release-notes item for the next release (Configuration category): `0` now disables
+  dirty broadcasts; previously it clamped to 1 s. Mention the rejoin-only refresh
+  tradeoff.
+
+## Verification
+1. `./gradlew :fabric:test -x runGameTest -x runClientGameTest` — Tier 1 incl. the new
+   broadcaster + config pins (note: no CI retry on Tier 1).
+2. `./gradlew :paper:test` — Paper twins.
+3. `./gradlew :fabric:runGameTest` — Tier 2 unchanged-behavior proof
+   (TwoPlayerGameTests fan-out still green at default interval).
+4. Optional live smoke: `./test-server.sh run-fabric` with
+   `dirtyBroadcastIntervalSeconds: 0` — NOTE (review): `/lsslod diag` does NOT render
+   the interval (`collectDiagData` takes no dirty-related config), so the receipt is
+   the new `validate()` info line in the boot log. Then a `setblock` near a joined
+   client: no client re-serve mid-session; rejoin shows the edit; `/lsslod store
+   status` confirms the store row for the edited column was invalidated (re-deposited
+   on the rejoin serve).

--- a/docs/planning/disk-read-concurrency-gate-plan.md
+++ b/docs/planning/disk-read-concurrency-gate-plan.md
@@ -1,0 +1,393 @@
+# Disk-read concurrency gate — decoupling server-CPU limiting from bandwidth — plan
+
+**Status: PLANNED, unimplemented** (2026-08-12). Mechanism selected by the user from a
+reviewed options brief: **an expensive-path concurrency cap** (option A below).
+
+**Reviewed 2026-08-12** (2 Fable subagents — mechanism lens + accounting/harness lens):
+both verdicts IMPLEMENT WITH FIXES, all findings folded into this revision. The two
+reviews CONVERGED independently on the headline MAJOR: an unconditional half-pool
+AUTO would bind on store-OFF servers, where no cheap path exists to protect and the
+plan's motivating asymmetry doesn't apply — fixed with **store-conditional AUTO**
+(no store attached → K = pool = no-op). Other headlines: the mechanism review
+verified the central pool-reservation claim holds (emergent invariant: ≤K threads in
+the expensive phase ⇒ the rest drain the queue at cheap-task speed); the bounce now
+REUSES the `saturated` result flavor (zero processor-side diff); the timeout/permit
+prose was corrected to per-path reality; and the checker-registration list was
+replaced with the real one (the plan's KNOWN_SERVER_KEYS item was a no-op —
+`SERVER_CONFIG_INT_KEYS` is the registration that actually gates the pinning
+strategy).
+
+## Context — the problem
+
+The bandwidth caps (`mbPerSecondLimitPerPlayer`/`Global`) are RAW-byte-denominated
+because they bound **client decode work** — deliberately, and that remains correct.
+But since the LOD store landed they are also the only throughput governor on the
+serve path, and the two serve flavors they gate have wildly different **server CPU**
+costs:
+
+- **Store serve**: SQLite blob read + frame reuse — measured ~44 µs
+  (`avg_read=44us` on the live rig), no inflate, no parse, no recompress.
+- **Disk-read serve**: region read → zlib inflate → NBT parse → transcode → zstd
+  compress — milliseconds of real CPU per column on the reader pool.
+
+An operator who raises bandwidth so warm store serves flow fast (the store's whole
+point) also uncaps the disk path: a player walking into a cold-but-generated region
+turns the raised limit into an unbounded CPU bill. There is no mechanism to limit
+the expensive path without also limiting the cheap one.
+
+**Goal**: bound the disk-read path's CPU independently, with a default that needs no
+operator tuning (auto-derived), plus a manual override.
+
+## Options brief (presented 2026-08-12; user selected A)
+
+- **A. Expensive-path concurrency cap (SELECTED)** — K permits gating the
+  store-miss → region-read boundary; a miss with no permit resolves as a silent
+  drop healed by re-declaration. Direct CPU ceiling (≤K threads of
+  inflate/parse/transcode at any instant), self-adapting to per-column cost,
+  platform-uniform (no tick signal needed), smallest diff. Trade-off: permits are
+  held across IO wait too, so a slow disk throttles harder than CPU alone requires
+  — which doubles as protection against the documented A7 read-timeout storms.
+- **B. Rate cap (columns/sec)** — same seam; rejected: auto-derivation needs a
+  per-column cost assumption (only aggregate wall-clock `avg_read_time_ms` exists),
+  bursts less bounded, strictly weaker than A for a CPU goal.
+- **C. MSPT-feedback governor** — rejected as the core mechanism: NO production
+  tick-health signal exists on Paper/Folia (only Fabric's
+  `getCurrentSmoothedTickTime`; the soak `mspt_avg_window` is harness-only,
+  computed from wall clock in the exporters). Kept as a compatible **future phase**:
+  Fabric-only modulation of K (generous when healthy, tighter under tick pressure)
+  — the `AdaptiveReadThrottle` AIMD class is already a generic scalar controller
+  that could drive it.
+- **D. Split cheap/heavy pools with a bounded queue** — retention instead of
+  drop-churn, but a real refactor of in-flight accounting, dedup groups, and
+  shutdown for the same ceiling A gives. Rejected on risk/benefit.
+- **E. Source-weighted bandwidth buckets** — dead on arrival: bandwidth is charged
+  at flush AFTER serialization (`AbstractPlayerRequestState.flushSendQueue`,
+  `recordSend` at `:747-748`), so the CPU is already spent, and `QueuedPayload`
+  carries no source field at all (the `COLUMN_SOURCE_*` byte is inside the opaque
+  serialized body).
+
+**Why fail-fast-drop, not retain**: retention would have to happen at the router's
+pre-submission gates — but store hit/miss is unknowable until the store lookup runs
+INSIDE the pool task (`AbstractChunkDiskReader.readAndDeliver:430`), so pre-submit
+retention would hold back would-be store hits, recreating the exact problem this
+plan fixes. The drop-churn cost is bounded: a re-declared position re-runs a ~44 µs
+store lookup once per scan, and the adaptive scan cadence already holds 1 Hz when
+drops exceed 5% of a declaration.
+
+## Ground truth (exploration 2026-08-12, verified file:line)
+
+- The enforcement seam is single and clean: `readAndDeliver` — store rung first
+  (`storeServedHit`, `AbstractChunkDiskReader.java:430`), store MISS falls through
+  to the NBT path at `:432-438` (`recordSubmitted` at `:438` — "the NBT path begins
+  here — store hits never count"), `operation.read()` at `:442` (read + inflate +
+  parse + transcode, one aggregate `recordRealCompletion` window). All on
+  reader-pool threads — the gate must be atomic (CAS), not single-writer.
+- **The `saturated` outcome is the routing template** for the new deferred flavor:
+  `deliverDiskResult` routes `saturated()` to `addSuperseded(1)` + silent drop
+  (`OffThreadProcessor.java:977-986`) — no memo seed, no generation escalation, no
+  wire answer, no timestamp stamp/store deposit (the `:904` gate), dedup fan-out
+  handled per-attachment. Pinned by
+  `OffThreadProcessorDiskResultTest.saturatedResultDropsSilentlyAndCountsSuperseded:241`.
+- **Counter identities**: law A5's second clause derives
+  `successful == completed − not_found − all_air − errors − saturated`
+  (`check_soak.py:779-786`), and `successful` is an explicit counter — so a gated
+  read **must not count into `disk.submitted`/`completed` at all** (the store-hit
+  exclusion precedent, `AbstractChunkDiskReader.java:55-58`), only into a new
+  dedicated counter. `superseded` is NOT an A5 term (deliberately, `:751-753`), so
+  the drop side is free. Law A1: a dropped-no-wire-answer entry needs exactly the
+  `superseded` disposition it will get.
+- **Backfill auto-bypasses**: `readColumnBytesSyncForBackfill` is a separate entry
+  point that never touches `submitRead`/`readAndDeliver`
+  (`ChunkDiskReader.java:150-166`); its restraint stays `hasHeadroom` +
+  MSPT-ceiling, unchanged.
+- **`hasHeadroom()` must NOT be narrowed** by this feature — it gates submissions
+  pre-classification (both cheap and expensive), and the C2ME
+  `AdaptiveReadThrottle` already narrows it on that path; the two mechanisms
+  compose (throttle bounds total submissions on degraded IO stacks; the gate bounds
+  the expensive phase everywhere).
+- Auto-with-override precedent: the three-part `0 = AUTO` pattern
+  (`diskReaderThreads` field doc + `effectiveDiskReaderThreads(runtime param)` +
+  validate clamps-nonzero-only, `ServerConfigBase.java:392-407,577-580`), with the
+  resolved value logged in the startup summary (`:451-466`).
+
+## Design
+
+### The gate
+
+`DiskReadGate` (new, `common/processing/`): an `AtomicInteger` permit counter with
+`tryAcquire()`/`release()`, capacity K, plus a monotonic `gated` counter and an
+in-use gauge for diag. Placement in `readAndDeliver`, immediately after
+`storeServedHit` returns false and BEFORE `recordSubmitted`:
+
+- `tryAcquire()` fails → deliver a bounce result and return. The read never starts;
+  `disk.submitted`/`completed` untouched (store-hit exclusion precedent);
+  `DiskReadGate` bumps its own `gated` counter → `DiskReaderDiagnostics.recordGated()`.
+- Acquired → `try { existing :432-504 body } finally { release() }`.
+
+**Permit coverage, per read path (review-corrected — the first draft's uniform
+"spans read+inflate+parse+transcode" and "timeout keeps the permit held" were wrong):**
+- Every read shape blocks on `future.get(DISK_READ_TIMEOUT_SECONDS)`; a 10 s
+  timeout THROWS, the pool thread unblocks, and the `finally` releases the permit
+  at error triage — while the orphaned downstream task keeps running OUTSIDE the
+  permit. The escape is bounded (the vanilla IOWorker executor is single-threaded;
+  Moonrise self-prioritizes at LOW), but during an A7-class storm permits recycle
+  every ≤10 s while orphan work accumulates downstream — the gate does not bound
+  that queue. Documented, accepted.
+- Fabric split path (`useBackgroundReadSplit`, the default): fetch on the IOWorker
+  executor, inflate+parse+transcode on the permit-holding pool thread — full span.
+- Moonrise rung (Paper default; Fabric-with-Moonrise): inflate+parse run on
+  Moonrise's IO threads; the permit covers the synchronous wait + pool-side
+  transcode, bounding Moonrise-side work transitively (≤K blocked waiters ⇒ ≤K
+  outstanding `loadDataAsync`).
+- Non-split rollback: parse concurrency is 1 by construction (single IOWorker
+  thread), permit or not.
+The CPU ceiling holds on every path; `DiskReadGateTest`'s timeout case pins
+release-at-triage-while-the-fetch-continues, not "thread stays blocked".
+
+### The bounce outcome — REUSE the `saturated` flavor (review simplification)
+
+The bounce delivers the existing `ChunkReadResult.saturated(...)` flavor — the
+mechanism review established the entire processor-side diff then disappears:
+`deliverDiskResult` already routes it to `addSuperseded(1)` + silent drop with
+dedup fan-out per recipient, the `:904` stamp/deposit gate already excludes it, no
+16th record component, and the existing pins
+(`OffThreadProcessorDiskResultTest.saturatedResultDropsSilentlyAndCountsSuperseded:241`,
+`DedupFanoutTest:510` per-recipient) cover it for free. Counter distinctness is
+preserved because `disk.saturated` is recorded at the SUBMIT bounce site — never
+derived from the flavor — so the gate site records `gated` instead and
+`disk.saturated` stays 0. The saturated branch's debug message gets a wording tweak
+to cover both bounce sources. (Recorded alternative: a distinct `gated` component
+buys only debug clarity, at the cost of constructor sprawl and making the
+`:904 && !gated` edit a store-corruption single point of failure — a missed edit
+would deposit a FABRICATED all-air store row per gated position. Not worth it.)
+
+Explicitly NOT: memo-seeded (the data likely EXISTS on disk — a memo entry would
+falsely skip to generation), generation-escalated, `NOT_GENERATED`-answered, or
+`diskReadDone`-stamped — all inherited from the saturated routing. Heal: the
+position stays in the client's want-set and re-declares within ≤1 s.
+
+### Auto-derivation of K — STORE-CONDITIONAL (both reviews' convergent MAJOR)
+
+`effectiveMaxConcurrentDiskReads(int resolvedReaderThreads, boolean storeAttached)`
+on `ServerConfigBase` (three-part pattern; the resolver takes runtime-discovered
+parameters like `effectiveDiskReaderThreads` does):
+
+- Override: `maxConcurrentDiskReads > 0` → `clamp(value, 1, resolvedReaderThreads)`.
+- AUTO (0, the default), **no store attached** → `resolvedReaderThreads` (a no-op
+  gate). With `lodStore=off` there are no store lookups to reserve threads for and
+  the plan's motivating asymmetry does not exist — and per the split default,
+  every UPGRADING server (key absent from an existing file) runs store-off, so an
+  unconditional half-pool would hand that population pure downside on exactly the
+  workloads where disk reads dominate (fresh worlds, elytra over
+  generated-but-unvisited terrain). Mirrors the absent-key-never-arms philosophy.
+- AUTO, **store armed** → `clamp(ceil(resolvedReaderThreads / 2.0), 1,
+  resolvedReaderThreads)`: pool 8 (Moonrise auto) → 4, pool 3 (vanilla auto) → 2,
+  pool 1 → 1. Deriving from the RESOLVED pool inherits the read-path-aware sizing
+  and reserves the other half for store lookups — the structural fix for
+  "expensive reads starve the cheap rung on the shared pool". (Note at pool 1 and
+  at override ≥ pool there is NO reservation — exactly today's behavior; nothing
+  regresses.)
+- Disable idiom: set the override ≥ `diskReaderThreads` (e.g. 64). Spelled out in
+  the javadoc because 0=OFF keys live in the same file (`outboundBufferCeilingKB`,
+  `missMemoTtlSeconds`); the correct large-value-inert precedent is the client
+  `lodColumnsPerSecondLimit` (~3200+ inert), NOT `lodStoreMaxMB` (whose uncapped is
+  a first-class 0). The adjacent `diskReaderThreads` is the 0=AUTO precedent, and
+  its "negative normalizes to AUTO, not 1" test is mirrored.
+
+Constants: `MIN_MAX_CONCURRENT_DISK_READS = 1`, max rides
+`MAX_DISK_READER_THREADS`; `AUTO_DISK_READ_GATE_DIVISOR = 2` with the rationale
+comment. Startup summary APPENDS the resolved K (the config echo is a fixed-order
+append contract with exact-string pins in both platform config tests — those pins
+get updated; appending is script-safe, per-key substring matching).
+
+### Config
+
+`maxConcurrentDiskReads = 0` (AUTO) in `ServerConfigBase` — shared by both
+platforms; validate clamps nonzero to `1..MAX_DISK_READER_THREADS`; field javadoc
+states the CPU-vs-bandwidth separation ("bandwidth bounds the client; this bounds
+the server") and the OFF idiom. Test-table entries: Fabric reflective sweep's
+0-floor `case` list + Paper `SHARED_BOUNDS` row (`Bounds(0, MAX...)`) + the named
+auto/override resolver tests + clamp-audit doc erratum.
+
+### Observability
+
+- DiskReader diag line gains `read_gate=<inuse>/<K> gated=<n>` (formatter golden
+  update).
+- Exporters (both platforms) gain `disk.gated` — full registration set in the
+  Harness section (SERVER_MONOTONIC makes it a required field; contract literal +
+  selftest fixture land in the same commit).
+- **Operator signal (review)**: a pegged gate emits one THROTTLED WARN naming the
+  remedy (the saturation-bounce WARN precedent) — "disk reads are being
+  concurrency-gated (read_gate=K/K); raise maxConcurrentDiskReads if server CPU
+  headroom allows". README documents the client-visible symptom: LOD holes filling
+  at a bounded rate while `read_gate=K/K, gated=` climbs.
+- **Fairness, accepted behavior**: permits are global first-come; fairness inherits
+  the M4 router rotation + pool-queue interleaving, and a losing entry re-declares —
+  no structural single-player starvation, but no per-player permit accounting
+  either.
+- **A7 flake-catalog note**: the catalog's live-triage signatures key timeout-storm
+  magnitudes to the pool size ("exactly +5 = diskReaderThreads — one stall expiring
+  all five blocked readers"); with the gate, at most K readers can be blocked, so
+  live signatures become "+K". Direction is favorable and worth claiming: gated
+  asks never enter the IOWorker queue during a gen-save flood, and at most K
+  expiries per stall event — the gate likely REDUCES timeout storms.
+
+## Interactions (each verified against the exploration)
+
+- **Miss memo**: synergy, not conflict — memo hits skip reads entirely at the
+  router rung, so gen-waiting positions don't churn the gate; gated results never
+  seed the memo (authoritative-only rule preserved).
+- **AdaptiveReadThrottle / C2ME**: composes; two independent upper bounds (throttle
+  pre-submit on `tasksInFlight`, gate in-task); gated bounces never call
+  `recordRealCompletion`, so the throttle's EWMA is unpoisoned.
+- **Generation DISCOVERY rides through the gate** (review — the first draft's "out
+  of scope" understated the coupling): the disk miss IS the generation trigger, and
+  a gated bounce produces neither a miss nor a memo entry, so a needs-generation
+  position cannot be DISCOVERED while permits are busy with real reads of existing
+  chunks. Mitigations are real — authoritative misses are cheap reads (fast permit
+  recycle), the memo suppresses repeat discovery reads, re-declaration heals — so
+  this is throughput shaping in mixed terrain, not a stall. Under store-conditional
+  AUTO it also mostly evaporates at defaults (store-off fresh worlds run K = pool).
+  Generation EXECUTION stays out of scope (its own concurrency caps).
+- **Backfill**: bypasses by construction; its pacing already has MSPT + headroom
+  gates.
+- **Dedup attachments**: a gated result fans out to attachments as superseded drops
+  — the saturated path already does this.
+- **Duplicate-serve grace / probeSuppress**: untouched — gated positions were never
+  served, no stamps exist.
+
+## Harness / baseline protection
+
+- **All existing soak scenario configs pin the gate to a no-op** (explicit
+  `maxConcurrentDiskReads` = that scenario's `diskReaderThreads` value, or the
+  resolved default pool size when unset) — the `lodStore: "off"` pinning rationale
+  verbatim: their law baselines and churn ceilings (e.g. rate-limit-storm's 1500)
+  were calibrated without gating, and re-baselining buys nothing.
+  **Pinning-necessity analysis (review)**: 24 of 26 configs pin
+  `diskReaderThreads: 5`, where auto-K would be 3 — a REAL behavior change, so the
+  pins are genuinely needed, not ceremony; `disk-saturation` runs threads:1 where
+  K=1 is structurally a no-op (one pool thread serializes `readAndDeliver`, so
+  `tryAcquire` can never contend — its pin is belt only); `store-offline-mutate`
+  has no client traffic. Recorded so a future "simplification" doesn't delete the
+  wrong pin.
+- **Checker/registry work — the ACTUAL set (review-corrected; the first draft's
+  KNOWN_SERVER_KEYS item was a no-op — that list holds top-level row keys only and
+  `disk` is already known):**
+  - `maxConcurrentDiskReads` joins `SERVER_CONFIG_INT_KEYS` — without it
+    `--validate` REJECTS every pinned scenario config (the thrice-burned "R4
+    lesson" in the checker's own comments; this is the registration the whole
+    pinning strategy gates on).
+  - `disk.gated` into `SERVER_MONOTONIC` — which makes it a REQUIRED snapshot field,
+    so both exporters, the `_srv` selftest base fixture, AND the shared exporter
+    contract literal (`fabric/src/test/resources/exporter-contract/
+    server-snapshot.contract`, byte-asserted by both platform contract tests) must
+    land in the SAME commit.
+  - **A7 anomaly with a `gated` opt-in, opted in ONLY by the new scenario** (review
+    — the `saturated` precedent verbatim: "the gate should hold it at 0, so a hit
+    is a stronger signal"). This makes every pinned no-op scenario SELF-VERIFY its
+    pin — any `gated > 0` under a no-op pin is a red — answering "should the
+    checker validate pin presence" behaviorally.
+  - `soak_report.py`: `disk.gated` into `SERVER_MECHANISM` (beside "gen-miss
+    drops") or the digest never surfaces it.
+  - The in-use permit gauge stays diag-line-only — NEVER in `SERVER_DRAINS`, where
+    a nonzero gauge would kill quiescent windows during gating (the store.queue
+    trap documented in the checker).
+- **New soak scenario `disk-read-gate`**: prebuilt world (fresh-backfill base,
+  built at distance 24), `lodStore: "off"`, `lodDistanceChunks: 24` (stay inside
+  the base — review), `diskReaderThreads: 2`, `maxConcurrentDiskReads: 1`, duration
+  budgeting a ≥25 s converged tail (the MIN_CLIENT_WINDOWS floor needs ≥4 quiescent
+  5 s pairs). Asserts `disk.gated > 0` (premise), `disk.saturated == 0`, laws A1/A5
+  green, convergence by scenario end, and a `superseded >= floor` term proving the
+  drop-heal loop ran. Convergence is self-consistent: a 2112-column annulus at K=1
+  on prebuilt superflat converges in well under a minute, and gating is
+  self-limiting (K ≥ 1 always drains). Registrations: `ALL_SCENARIOS`, the soak.sh
+  scenario case + `CLIENT_RUNS`/`EXPECTED_SECONDS`, base-world staging,
+  `ANOMALY_OPT_INS`, `MIN_CLIENT_WINDOWS`, a CHECKS-registry named check with
+  `required_fields`. Noted follow-up: a store-ON variant (store-second-join staging
+  + K=1) would pin the headline "store hits keep flowing while the gate binds"
+  end-to-end; at ship time it's pinned at unit level.
+- **Gametest run dirs**: the fabric/build.gradle `doFirst` staged config (which
+  already pins `lodStore: "off"`) additionally pins `maxConcurrentDiskReads` to a
+  large no-op value — Tier 2 parity/fault tests expect every submitted read to
+  resolve, and a surprise gate drop would flake them.
+- **benchmark.sh neutral staging**: same no-op pin, so CPU-optimization baselines
+  stay comparable across the change.
+- **The three perf-profile harnesses (review MAJOR — missed by the first draft)**:
+  `profile_disk_read.sh`, `compress_gate.sh`, and `backfill_profile.sh` all stage
+  `diskReaderThreads: 5` and A/B against pre-gate reference runs — un-pinned, their
+  arms silently run at auto-K=3-of-5 and every ref-vs-ref comparison is invalidated
+  (the exact failure mode the effective-config echo contract exists to catch). Pin
+  the no-op in all three staged configs and assert the new echo key tolerantly (the
+  "ref predates the key" pattern already in profile_disk_read.sh).
+
+## Tests
+
+- **`DiskReadGateTest`** (Tier 1, common): capacity semantics, CAS under
+  concurrent acquirers, release-on-every-outcome — the timeout case pins
+  **release-at-triage-while-the-fetch-continues** (per the corrected coverage
+  prose), not "thread stays blocked"; fail-fast delivers the `saturated`-flavor
+  bounce without touching submitted/completed while `gated` increments (and
+  `disk.saturated` does NOT); gauge/counter accounting.
+- **`AbstractChunkDiskReaderTest`**: gate wired at the post-store-miss seam — a
+  store HIT never consumes a permit (the load-bearing property); zero-permit
+  scenario delivers bounces while store hits keep flowing.
+- **`OffThreadProcessorDiskResultTest` / `DedupFanoutTest`**: with the flavor
+  reuse, the existing saturated pins (`:241` silent-drop + `:510` per-recipient
+  fan-out) already cover routing — add one gate-site wiring pin (a gated bounce
+  reaches the processor AS the saturated flavor) rather than a parallel suite.
+- **Config**: resolver table (store-conditional auto per pool size incl. pool 1;
+  override clamp; override-above-pool = no-op; negative normalizes to AUTO — the
+  `diskReaderThreads` test mirror), both platform clamp-table updates, the
+  **config-echo exact-string pins on both platforms** (append contract),
+  `JsonConfigLoadTest` default.
+- **Diag/exporter**: formatter golden with the `read_gate=` token; exporter
+  contract twins + the shared contract literal file; `check_soak.py --selftest`
+  cases (config key validation, A7 `gated` opt-in, monotonicity).
+- Paper twin coverage rides the shared `common/` classes (the gate and routing are
+  platform-agnostic; `PaperChunkDiskReader` inherits the seam) — one Paper config
+  test + the exporter twin suffice.
+
+## Docs / release notes
+
+- CLAUDE.md: Configuration bullet + a line in the disk-reader architecture section
+  (the seam, the store-hit exclusion, the drop-heal).
+- `config-defaults-and-clamps-review-2026-08-02.md` erratum.
+- Release notes (Configuration + Performance): "Disk-read CPU is now bounded
+  independently of bandwidth — `maxConcurrentDiskReads` (default auto: half the
+  reader pool) caps concurrent expensive region reads; store-served LODs are never
+  throttled by it. Raise bandwidth freely on store-heavy servers."
+
+## Verification
+
+1. Tier 1 both platforms; Tier 2 (`:fabric:build -x runClientGameTest`).
+2. New + existing soaks: `./scripts/soak.sh disk-read-gate`, then `fresh-backfill`
+   and `disk-saturation` (pinned no-op — must be byte-identical behavior).
+3. Benchmark arms (review-corrected — the first draft never measured the shipped
+   default anywhere):
+   a. no-op-pinned `no-cache` — must match baseline (proves the pin).
+   b. **store-OFF true defaults** — with store-conditional AUTO this must resolve
+      K = pool (echo shows it) and match baseline exactly; a deviation means the
+      conditional AUTO is broken.
+   c. **store-ON + AUTO K** (the arm where halving actually binds — a store-armed
+      run dir on the no-cache world): record `sections_per_second` vs baseline
+      with a stated acceptance threshold; this is the number that justifies the
+      half-pool divisor, or forces revisiting it.
+   d. `maxConcurrentDiskReads: 1` — shows the bounded-CPU trade visibly.
+4. Live on the test rig (`run-fabric-store`, store warm): raise
+   `mbPerSecondLimitPerPlayer` high, rejoin for a warm burst (store serves flow at
+   full rate — `read_gate` in-use stays ~0), then fly into a cold-but-generated
+   region: `read_gate=<K>/<K> gated=` climbing, server CPU bounded (compare `top`
+   with a control run), client convergence still completing via re-declaration,
+   and the pegged-gate WARN fires once.
+5. Optional Folia spot-check (`SOAK_PLATFORM=folia` fresh-backfill with the no-op
+   pin) — the gate classes are common-side and pump-free, but the experimental
+   label rules apply to the release note.
+
+## Future phase (recorded, not planned)
+
+Fabric-only MSPT modulation of K: feed `getCurrentSmoothedTickTime` into an
+AIMD controller (the `AdaptiveReadThrottle` class is already sample-in/limit-out
+generic) so K rides between auto-K and the pool size when the tick is healthy, and
+below auto-K under tick pressure. Needs its own design round (recovery clocking —
+the throttle only re-opens on samples — and a Paper story if Bukkit's
+`getAverageTickTime` is ever adopted).

--- a/docs/planning/far-player-proxies-plan.md
+++ b/docs/planning/far-player-proxies-plan.md
@@ -1,0 +1,365 @@
+# Far-player proxies in LSS ("SeeU-native") — plan
+
+**Status: PLANNED, unimplemented** (2026-08-12). Design for rendering distant players
+beyond vanilla entity-tracking range as a native LSS feature — the player-entity
+complement to LOD terrain. Informed by a full source read of SeeU 0.7.3 (clone at the
+session scratchpad; upstream https://github.com/cat4blep/SeeU) and a live compat test
+on the LSS rig (2026-08-12: both mods coexist cleanly — so this feature competes on
+merit, not necessity; shipping it must also play nice with SeeU installed, see §6).
+
+**Reviewed 2026-08-12** (1 Fable subagent, verified against BOTH source trees):
+verdict IMPLEMENT WITH FIXES, 4 MAJOR / 9 MINOR — all folded into this revision.
+Headlines: the send-queue-reuse idea was structurally impossible on Paper (replaced
+with a dedicated send lane); delta suppression and the adaptive lerp were mutually
+hostile (replaced with server-declared cadence); the roster needs epoch armor (this
+codebase's own race history demands it); and SeeU's renderer ships TWO visibility
+crutches the plan had missed — a global fog-disable mixin and `setGlowingTag(true)`
+on every proxy (through-wall outlines) — forcing an explicit visibility decision.
+The review also confirmed the wire premises are direct in-repo precedent
+(`CHANNEL_CLIENT_INFO` sidecar doctrine, masked capability gate).
+
+---
+
+## 1. How SeeU does it (verified from source, 0.7.3)
+
+~1,800 lines total across common/fabric/paper. The architecture:
+
+**Wire** (`common/protocol/`, hand-rolled varint codec, own channels `seeu:hello` /
+`seeu:players`, protocol version 3):
+- C2S `ClientHelloPacket`: version + client prefs (enabled, max render distance, min
+  proxy distance, name tags, `shareSelf`, share max distance). Version mismatch =
+  silent unsubscribe.
+- S2C `FarPlayersPacket`: dimension key string + the viewer's COMPLETE visible-player
+  list, every update. Each `FarPlayerSnapshot`: UUID + **name as a string**, position
+  as **3 doubles**, 3 floats rotation, 3 booleans (sneak/glide/swim), **six equipment
+  slots as registry-id strings + count**, optional vehicle (UUID + entity-type string
+  + pos/rot). No deltas, no quantization, no dictionary — every string resent every
+  update.
+
+**Server** (`FabricFarPlayerService`, 216 lines): on `END_SERVER_TICK`, every
+`updateIntervalTicks` (default 10 = 2 Hz), for **each subscribed viewer iterate all
+online players** and filter: same dimension, alive, spectator (config), invisible,
+a reflective vanish bridge (`melius-vanish`'s `VanishAPI.canSeePlayer`), min/max
+distance ring (client pref ∩ server cap, default max 8192 blocks), and the target's
+own `shareSelf`/share-distance prefs when the target runs the mod. Then it builds a
+fresh snapshot list per viewer and sends. Complexity is **O(viewers × players) with
+full snapshot construction per pair** — fine at 5 players, quadratic pain at 100.
+
+**Client** (`FarPlayerTracker`/`TrackedFarPlayer`/`FarPlayerRenderer`):
+- Tracker: generational latest-wins map (a new packet bumps a generation; entries not
+  refreshed are swept) — structurally the same idea as LSS's want-set replace.
+- Interpolation: lerp position/yaws/pitch over a **fixed 550 ms window**
+  (`INTERPOLATION_WINDOW_NANOS`) from `System.nanoTime`. Matched to the default 500 ms
+  cadence; raise the server interval and proxies stutter — the window does not adapt,
+  and there is no velocity extrapolation. (Review correction: `apply()` re-lerps from
+  the current RENDERED position, so an elytra player is a continuous sawtooth lagging
+  ~one cadence behind — not per-update teleporting, but still ~16 m adrift at 30 m/s.)
+- Renderer: client-side `RemotePlayer`-style proxy entities (IDs allocated from
+  1_000_000_000), submitted through Fabric's `LevelRenderContext` + the
+  `EntityRenderDispatcher` each frame; skins come free via TAB-list `PlayerInfo`;
+  walk animation under a config distance; vehicles are client-spawned entities with
+  passengers ejected/re-seated **every frame**. Handoff: skip the proxy when the real
+  entity is present AND its chunk is loaded AND distance ≤ vanilla render distance
+  + 16 — a hysteresis-free boundary (flicker risk at the tracking edge).
+- **Two visibility crutches the first draft of this plan missed (review MAJOR):**
+  (a) `FogRendererMixin` is a config-gated (default OFF) **global vanilla-fog
+  disable** — all fog distances to `Float.MAX_VALUE` outside fluid/blindness — not
+  per-proxy fog handling; without it a proxy beyond fog-end renders fog-colored into
+  invisibility. (b) **Every proxy gets `setGlowingTag(true)`**
+  (`FarPlayerRenderer.java:260`) — the outline shader, i.e. visible THROUGH terrain.
+  Both are load-bearing for SeeU's "you can actually see it" experience, and both
+  are decisions LSS must make deliberately (§3.3).
+
+**Paper** (`VoxySeeUPaperPlugin`): `Bukkit.getScheduler().runTaskTimer(...)` —
+BukkitScheduler; plugin.yml lacks `folia-supported`, so on Folia SeeU **never loads
+at all** (review correction: not a runtime crash — the flag absence keeps it off).
+Also: the Paper version-mismatch unsubscribe logs a warning (not silent as on
+Fabric). Total ~2,150 lines across common/fabric/paper, plus a NeoForge module LSS
+does not need to consider.
+
+**What SeeU gets right** (adopt, don't reinvent): the proxy-entity rendering approach
+(proven against 26.2's rendering API, skins-via-TAB free), latest-wins client state,
+the same-dimension-only scope, the min/max ring with client∩server caps, the target-
+controlled `shareSelf` privacy pref, spectators-hidden default, and the reflective
+vanish-mod bridge.
+
+## 2. Scope decision
+
+This is in-product: LSS's pitch (just re-worded in the description change plan) is
+"see the world beyond vanilla range" — terrain today, players are the natural
+complement, and the live test showed exactly that composition (a distant player
+standing on Voxy LOD terrain). It becomes an LSS feature behind a capability bit +
+config toggles, in the existing jars — no new mod, no new channels beyond the `lss:*`
+namespace, NeoForge stays out of scope (LSS ships Fabric + Paper only).
+
+The genuinely NEW surface for LSS is client-side **rendering** — everything else
+(handshake, per-player state, batching, bandwidth, config discipline, Folia patterns,
+diag, release) reuses infrastructure LSS already has and SeeU lacks.
+
+## 3. Design
+
+### 3.1 Wire (additive, no protocol bump)
+
+- New capability bit `CAPABILITY_FAR_PLAYERS` in the existing handshake bitmask
+  (`CAPABILITY_VOXEL_COLUMNS` precedent). The server sends far-player payloads only to
+  sessions that declared it; legacy clients never see them — **no compat rung
+  needed**, no version bump. Review-verified as direct in-repo precedent: the
+  handshake gate MASKS capability bits (`HandshakeGate.java:151`), so an OLDER v20
+  server ignores the unknown bit and registers normally, and the
+  `CHANNEL_CLIENT_INFO` sidecar carries the explicit doctrine ("legacy servers
+  silently discard unregistered channels", `LSSConstants.java:45-51`); Paper S2C
+  bypasses the Bukkit messenger via NMS `DiscardedPayload` (no outgoing registration
+  needed), a new C2S channel needs only `registerIncomingPluginChannel` + a dispatch
+  case. Caveat (review): the 4-field SessionConfig carries no server-capability echo,
+  so the client cannot distinguish "older server ignored my bit" from "nobody in
+  range" — if UX wants an ack, the v20-only append arm of `encodeSessionConfig` is
+  the available slot.
+- C2S `FarPlayerPrefsC2SPayload` (sent after session config, re-sendable at runtime):
+  enabled, max distance, min distance, shareSelf, share distance — the SeeU hello
+  fields minus the version (LSS's handshake owns versioning). Server-side prefs and
+  roster state follow the **v18-rung lifecycle checklist** (review MAJOR — this
+  codebase's own race history: the v0.8.0 deferred-reply fix, the dialect tracker's
+  quit-race drain): Paper marks pump-only, dropped at disconnect AND the
+  quit-originated mailbox Remove, survives the dimension-change remove+register.
+- S2C **two-payload split** (the main wire improvement over SeeU):
+  - `FarPlayerRosterS2CPayload` — carries a **roster epoch** (review MAJOR) and, per
+    player, a compact index ↔ UUID + name binding (+ leave events). A FULL roster is
+    sent on subscribe, on (re)handshake, and on the viewer's dimension change; index
+    reuse is only valid within an epoch. Names/UUIDs cross the wire once per
+    join/leave, not 2× per second.
+  - `FarPlayerUpdatesS2CPayload` — the periodic batch, stamped with the roster epoch
+    (the client DROPS updates whose epoch it hasn't seen — the misbinding armor) and
+    the viewer's dimension (SeeU ships dimensionKey per packet; ours rides the
+    epoch'd roster + a dimension check, and the client clears on mismatch). Per
+    visible player: roster index (varint), **quantized position** (fixed-point 1/16
+    block, int32 — covers ±134M blocks vs the ±30M border; sub-block precision is
+    invisible at proxy distances), yaw/head-yaw/pitch as bytes (1.4° steps), a pose
+    flags byte, **equipment only when its hash changed** (dictionary indices via the
+    v20 identity-dictionary pattern, not registry-id strings per update), optional
+    vehicle (type via the same dictionary), and a **velocity hint** (3 shorts,
+    blocks/s × 256, clamped ±64 m/s — elytra ≈ 40 m/s) for client extrapolation.
+  - The updates payload also carries the **server-declared nominal cadence for the
+    player's tier** (one varint) — the client's interpolation window derives from
+    the DECLARED interval, not a measured one (review MAJOR — see §3.3).
+- Both platforms encode via the shared `common/` codec twins with the established
+  Fabric/Paper wire-parity test discipline (`WireParityTest` pattern), and the
+  protocol-constant envelope pin gains the new channel ids.
+
+### 3.2 Server service (`common/` core + platform adapters)
+
+- One `FarPlayerBroadcastService` in `common/`, ticked from the existing service tick
+  (Fabric server thread / Paper GlobalRegionScheduler pump — Folia-safe by
+  construction, and `FoliaWiringContractTest` covers the new classes for free).
+- **Invert SeeU's loop**: per broadcast tick, build each ONLINE PLAYER's snapshot
+  ONCE (position/rotation/pose/equipment-hash — O(P)), then run the per-viewer
+  filter over the shared snapshots (O(V×P) *filter*, but comparisons only — no
+  per-pair snapshot construction or string encoding).
+- **Distance-tiered cadence**: full-rate updates (default 2 Hz) inside a near band,
+  half/quarter rate beyond (e.g. >2048 blocks). A stationary far player costs a
+  position-unchanged skip (delta suppression: unchanged players are omitted from the
+  update payload entirely — the roster keeps them alive client-side).
+- Filters, in SeeU's proven order plus LSS additions: same dimension → alive/removed →
+  spectator (config) → invisible → vanish bridge (reuse the `AntiXrayCompat`-style
+  reflective ladder; melius-vanish on Fabric, a Paper vanish-meta check on Paper) →
+  ring (client ∩ server) → target privacy (below).
+- **Privacy, server-authoritative** (the ESP-oracle fix — SeeU's biggest gap): SeeU
+  only honors `shareSelf` for targets *running the mod*; vanilla players are broadcast
+  with no say and no knowledge. LSS adds: `farPlayersMaxDistanceBlocks` server cap
+  (default **2048**, not 8192 — admins raise it consciously), a server-side
+  `farPlayersExclude` list + Paper permission node (`lss.farplayers.hidden`), and a
+  `farPlayers` mode config: `off` / `opt-in` / `on` (default `on`, documented in the
+  README's privacy note). Target-client `shareSelf` still honored on top.
+- **Bandwidth — a DEDICATED far-player send lane, NOT the column send queue**
+  (review MAJOR — the first draft's queue reuse was structurally impossible: the
+  queue is column-position-keyed with load-bearing `packedPos` semantics — the
+  relevance prune, send-failure done-bit clears — and Paper's flush sender is
+  hard-bound to the `ID_VOXEL_COLUMN` channel; FIFO behind megabytes of backfill
+  would also delay 2 Hz pose data by seconds). The lane: send immediately at
+  broadcast time, but CONSULT the same channel-writability/yield gate before
+  sending, and charge `SharedBandwidthLimiter.recordSend` so the governor sees the
+  bytes. Far-player bytes get their OWN diag counters — never folded into
+  `service.bytes_sent`/`wire_bytes`, which feed soak_report's cross-identity audits
+  against client received counters.
+- Honesty note on cost (review): the per-viewer delta/equipment-hash bookkeeping is
+  still O(V×P) MEMORY with per-pair rows — the win over SeeU is eliminating per-pair
+  snapshot/string construction and unchanged-player bytes, not the asymptotic shape.
+- **Folia cross-region reads** (review): positions are plain-field stale-tolerant
+  (matches how the pump already reads `player.chunkPosition()` — precedent in
+  `PaperRequestProcessingService`), but equipment/pose/vehicle reads are a NEW
+  cross-region read class (potentially torn ItemStack reads). Decision:
+  accept-and-document for display-only data rather than EntityScheduler hops;
+  contained per player (a torn read renders one wrong frame of gear); the Folia
+  experimental label covers it in release notes.
+- Diag: a `FarPlayers:` line in `/lsslod diag` (subscribers, snapshots/s, bytes/s,
+  suppressed-unchanged count) + exporter fields on both platform exporters, added to
+  `check_soak.py`'s `KNOWN_SERVER_KEYS` with `--selftest` cases and the
+  `DiagnosticsFormatter` golden updates (review: additive fields WARN as unknown
+  until registered — register them, don't ship warnings).
+
+### 3.3 Client (tracker + renderer)
+
+- Tracker mirrors SeeU's generational latest-wins map, plus the roster layer
+  (index→identity, epoch-guarded) and per-player equipment cache.
+- **Interpolation from the DECLARED cadence** (review MAJOR — the first draft's
+  measured EWMA was mutually hostile with delta suppression: a suppressed-stationary
+  player's measured gap grows unbounded, so their first movement would slow-motion
+  glide over an inflated window, and tier migration shifts the gap under the
+  filter). The lerp window = the server-declared tier interval + 20% margin;
+  measurement survives only as a correction clamped to ≤2× declared. **Velocity
+  extrapolation** for moving players (dead-reckon from the velocity hint, clamped to
+  ~1.5 windows) — the elytra lag case.
+- **Handoff with hysteresis**: use the real `RemotePlayer`'s client-side
+  `ClientEntityEvents.ENTITY_LOAD/UNLOAD` (fabric-lifecycle-events-v1 — review
+  confirmed these fire for player adds/removes) as EDGE TRIGGERS, but keep SeeU's
+  conjuncts in the steady-state formula — the review's caveat: entity-add can
+  precede the client having a renderable chunk, which is exactly why SeeU's
+  `chunkLoaded` term exists. ±16-block hysteresis band + a 1-frame crossfade guard.
+- Renderer: adopt SeeU's `RemotePlayer`-proxy + `LevelRenderContext` submission
+  approach (proven on 26.2), with: entity-ID allocation guarded against collision
+  with real entity IDs, poses (sneak/glide/swim) mapped as SeeU does,
+  TAB-`PlayerInfo` skins, name-tag toggle, animation-distance cap. Vehicles:
+  phase C — render the vehicle model at the snapshot pose directly rather than
+  spawning rideable client entities and re-seating every frame (SeeU's eject/re-seat
+  per frame is the hackiest part of their renderer).
+- **Visibility decision (review MAJOR — do NOT copy SeeU blind here):**
+  - **No glow, ever, by default.** SeeU sets `setGlowingTag(true)` on every proxy —
+    a through-wall outline that contradicts this plan's own privacy stance. LSS
+    proxies render as normal entities; if an outline option is ever wanted it is a
+    separate opt-in with its own privacy note.
+  - **Fog stance:** LSS ships NO fog mixin in phase B. Voxy users overwhelmingly run
+    with extended/disabled fog already (the LOD mod owns the horizon); a proxy
+    beyond vanilla fog-end on a fog-default client simply fades like terrain would —
+    documented, with a client-config `farPlayersMaxRenderDistanceBlocks` the user
+    can align with their fog. If live testing shows it matters, a fog *option*
+    follows the tracer's non-required-mixin discipline in a later phase.
+- Client config (`lss-client-config.json`): `farPlayersEnabled` (default true),
+  distance overrides, name tags, shareSelf + share distance — plus Sodium option
+  screen rows next to the existing LSS entries.
+- **Concrete capability gate** (review — "renderer viable" was not a real
+  predicate): the bit is sent when `farPlayersEnabled` AND `-Dlss.soak` /
+  `-Dlss.benchmark` are absent. The soak/benchmark clients are full Loom clients
+  distinguished only by those properties, and they DO register LSSApi consumers +
+  send `CAPABILITY_VOXEL_COLUMNS|zstd` — without the explicit property check they
+  would subscribe and shift soak baselines. In Phase A (no renderer yet) this same
+  gate applies — the bit does not wait for the renderer (review: the draft's
+  renderer-viability wording made Phase A unverifiable by its own gate).
+
+### 3.4 Config (server, shared `ServerConfigBase` — both platforms)
+
+`farPlayers` (`on`/`opt-in`/`off`, default `on`), `farPlayersUpdateIntervalTicks`
+(default 10, clamp 2..100), `farPlayersMaxDistanceBlocks` (default 2048, clamp
+128..16384), `farPlayersMinDistanceBlocks` (default 0), `farPlayersSendSpectators`
+(default false), `farPlayersExclude` (name/UUID list, default empty —
+`xrayHiddenBlocks` is the shared-List precedent). All clamped in `validate()` with
+the standard test-table entries (Fabric switch + Paper `SHARED_BOUNDS`), plus an
+erratum in the clamp-audit doc.
+
+**VSS branding interaction (review)**: the new Paper permission node
+(`lss.farplayers.hidden`) lands in plugin.yml, whose LSS↔VSS pair diff is pinned
+line-by-line by `release_check.py` and whose rebrand set today is exactly the
+command key + `lss.admin`→`vss.admin`. The vssJar rewrite (paper/build.gradle) AND
+the release_check token lists must be extended together for the new node
+(`vss.farplayers.hidden`), or the release gate reds / the VSS jar ships an `lss.*`
+node. Wire channels stay `lss:*` verbatim (the wire-compat contract); config keys
+need nothing.
+
+## 4. Concretely better than SeeU (the checklist)
+
+1. **Server cost**: per-target snapshot built once per tick, not per viewer×target;
+   unchanged players omitted; distance-tiered cadence. SeeU: full rebuild per pair
+   at fixed cadence.
+2. **Wire cost**: roster split (names once), quantized positions/rotations,
+   equipment-on-change with dictionary ids, delta suppression. SeeU: full doubles +
+   full strings for every player every 500 ms.
+3. **Folia**: runs on the existing pump; contract-test enforced. SeeU: BukkitScheduler
+   — crashes on Folia.
+4. **Privacy**: server-authoritative modes + exclude list + permission node +
+   conservative 2048 default. SeeU: 8192 default, opt-out only for modded targets.
+5. **Motion quality**: adaptive interpolation window + velocity extrapolation.
+   SeeU: fixed 550 ms lerp, elytra players teleport-lag.
+6. **Handoff**: event-driven swap with hysteresis. SeeU: distance formula, flicker
+   possible at the boundary.
+7. **Governance**: bandwidth-limited, diag-instrumented, config-clamped, wire-parity
+   + Tier-2 tested, release-gated — the LSS operational envelope SeeU has none of.
+8. **Versioning**: capability-gated additive payloads — old LSS clients need no
+   compat rung; SeeU drops the subscription on any protocol-version mismatch (all
+   we can verify from the one cloned version — protocol 3 — is that mismatch means
+   no service, with a warn on Paper and silence on Fabric).
+
+## 5. What we deliberately copy (credit where due)
+
+Proxy-entity rendering via `LevelRenderContext` + `EntityRenderDispatcher`;
+latest-wins generational tracker; same-dimension scope; min/max ring semantics with
+client∩server caps; spectator/invisible/vanish filter ladder (incl. the reflective
+vanish bridge pattern); TAB-based skin resolution; walk-animation distance cap;
+name-tag toggle. SeeU is MIT-licensed; we reimplement in LSS idiom rather than
+vendoring, and credit SeeU in the release notes as prior art.
+
+## 6. Coexistence with SeeU
+
+Both installed = double proxies (two renderers drawing the same distant player) —
+but ONLY when the **server** also runs SeeU. Review caveat on the blunt gate: a
+client-static `isModLoaded("seeu")` default-off means a SeeU-installed client on an
+LSS-only server gets ZERO far players — the worst outcome. Actually observing "SeeU
+traffic present" client-side is not cleanly feasible (its channels are another mod's
+registration). Decision: keep the `isModLoaded` default-off gate for safety, but (a)
+log the INFO line naming the override every session ("SeeU detected — LSS far
+players disabled; set farPlayersEnabled=true to prefer LSS"), (b) document the
+LSS-only-server case explicitly in the README row, and (c) surface the state in the
+Sodium screen (a "disabled: SeeU present" tooltip) so the fix is discoverable where
+the user looks. Server side needs nothing (a client subscribes to at most one
+system).
+
+## 7. Phasing
+
+- **Phase A — wire + server service + client tracker** (no rendering): payloads,
+  capability bit (the §3.3 property-gated form — active from Phase A), broadcast
+  service with filters/tiers/privacy, client-side tracked state exposed via a debug
+  HUD line + `/lss diag` counters. Tier 1 twins (codec parity, filter ladder via
+  seams, prefs/roster lifecycle incl. the epoch resync paths). Tier 2 asserts the
+  SERVER EGRESS surface (review correction — client tracker state is not reachable
+  from a server gametest): a crafted-handshake mock player with the capability bit
+  receives roster + updates for a far player and nothing for a near one — the
+  `ServiceLifecycleGameTests` crafted-frame pattern. Tracker state itself is Tier 3
+  / live territory.
+- **Phase B — renderer**: proxy entities, interpolation/extrapolation, handoff,
+  name tags, poses, skins. Live-verified on the test rig (the SeeU session's exact
+  setup, minus SeeU).
+- **Phase C — polish**: vehicles, Sodium config rows, opt-in mode UX, SeeU-coexist
+  default, exporter/soak-report fields, README + release notes.
+
+## 8. Risks / open questions
+
+- **Rendering is new territory for LSS** — the one area with no existing test
+  discipline; Phase B leans on live verification and keeps the renderer strictly
+  client-side/optional (a renderer crash must degrade to "no proxies", contained
+  like every LSS compat surface).
+- 26.2's `LevelRenderContext`/submit API is what SeeU targets today; MC rendering
+  APIs churn per version — the renderer needs the same per-MC-line porting budget as
+  the rest of the client (support-line backports likely skip Phase B initially).
+- Folia cross-region position reads from the pump are stale-tolerant by design
+  (positions are plain fields; a 1-tick-stale snapshot is invisible at 500 ms
+  cadence) — document rather than synchronize, matching the Folia experimental
+  labeling rules.
+- ESP concern is real and worth the README privacy note regardless of design — even
+  the 2048 default reveals positions far beyond vanilla; `opt-in` mode exists for
+  servers that care.
+- Open: should Phase A data also be exposed through `LSSApi` (a
+  `FarPlayerConsumer`) so other mods can consume the feed? Cheap to add, matches the
+  LSSApi philosophy — leaning yes, decide at implementation.
+
+## 9. Verification
+
+1. Tier 1: codec/parity/filter/prefs/clamp tests both platforms, PLUS (review):
+   `DiagnosticsFormatter` golden updates for the `FarPlayers:` line, exporter twins
+   with `KNOWN_SERVER_KEYS` + `check_soak.py --selftest` case registration, and the
+   protocol-constant envelope pin for the new channel ids.
+2. Tier 2: server-egress gametests per §7 Phase A (crafted-handshake mock player;
+   NOT client-tracker assertions); handoff behavior is Tier 3/live.
+3. `SOAK_PLATFORM=paper` + Fabric `soak.sh all` — baselines must be untouched (soak
+   clients never set the capability bit; assert `FarPlayers:` counters stay 0).
+4. Live: the SeeU test-rig session repeated with LSS-native proxies — two real
+   clients + the SoakPlayer dummy, elytra flight for the extrapolation case, walk
+   across the tracking boundary for handoff, vanish/spectator checks via RCON.
+5. Folia: one manual `run-folia` session with two clients (experimental label rules
+   apply to release notes).

--- a/docs/planning/runtime-settings-commands-plan.md
+++ b/docs/planning/runtime-settings-commands-plan.md
@@ -1,0 +1,346 @@
+# Runtime settings commands + backfill remaining-estimate + `/lsslod help` + package descriptions — plan
+
+**Status: PLANNED, unimplemented** (2026-08-12). **Reviewed 2026-08-12** (1 Fable
+subagent, all load-bearing citations re-verified): verdict IMPLEMENT WITH FIXES,
+2 MAJOR / 9 MINOR — all folded into this revision. Headlines: the SessionConfig
+re-push must enumerate + send on the pump/main thread AFTER the mailbox drain (a
+command-thread iteration can read an unflipped dialect and push a protocol-20 config
+at a legacy client, which kills its session until rejoin), and `genSlotCap` must be
+volatile (the router reads it on the processing thread — a plain-field tick-poll write
+has no happens-before). Four items, one plan:
+
+1. Server admin commands to change LSS settings at runtime — minimum keys: the
+   generation concurrency caps, the bandwidth rate limits, and `lodDistanceChunks`.
+2. Side fix: `/lsslod store backfill status` additionally shows an estimate of
+   remaining regions/columns, not just processed counts.
+3. `/lsslod help` — a brief description of every subcommand.
+4. Update the embedded package descriptions (fabric.mod.json + plugin.yml) to:
+   *"Voxy multiplayer support (unofficial). Enables players with Voxy to see fully
+   rendered terrain out to hundreds of chunks on multiplayer servers without needing
+   to explore the world first."*
+
+---
+
+## Ground truth from exploration (what the design must respect)
+
+**No runtime config mutation exists anywhere today.** `LSSServerConfig.CONFIG` is a
+`static final` singleton with public mutable fields (`LSSServerConfig.java:7-8`);
+Paper's `PaperConfig` is a plugin instance field the service shares by reference.
+`JsonConfig.save()` (`JsonConfig.java:91-109`, tmp + atomic move, drops
+`@HiddenFromFile` keys at default) is production-ready but only ever called inside
+`load()`. `validate()` also only runs at load — and is pinned idempotent
+(`ConfigValidationTest.java:558-571`), which makes "mutate field → re-run validate()"
+a safe application step (it also handles the cross-field clamp: per-player gen cap
+clamps against the configured global, `ServerConfigBase.java:599-600`).
+
+**Per-field runtime verdicts** (from the consumption trace):
+
+| Field | Verdict | What runtime application needs |
+|---|---|---|
+| `mbPerSecondLimitPerPlayer` | LIVE | Nothing — read per tick at the flush (`RequestProcessingService.java:588`, Paper `:1005`). Must be clamped before storing (an unclamped huge value overflows the `(int)` cast to negative and throttles to zero; a negative resets to the compiled default via `resolveMb`). `validate()` covers both. |
+| `mbPerSecondLimitGlobal` | CAPTURED | `SharedBandwidthLimiter.maxBytesPerSecond` is final (`SharedBandwidthLimiter.java:27,44`), no setter; the live re-reads at `/lsslod stats` are display-only — mutation alone makes stats lie. Limiter is tick-thread-only by contract (`:22-24`). |
+| `generationConcurrencyLimitGlobal` | CAPTURED | Final `maxConcurrent` in `ChunkGenerationService` (`:58,77`) / `PaperChunkGenerationService` (`:69,108`); admission gate at `:105`/`:132`. A service rebuild would strand outstanding force-load tickets — must be a field update, not a rebuild. |
+| `generationConcurrencyLimitPerPlayer` | MIXED | Captured in the gen service (`maxPerPlayerActive`) AND per player at registration (`AbstractPlayerRequestState.genSlotCap`, `:159,177`, admission at `:984-990`) — `computeIfAbsent` means new joins would pick up a change while existing sessions keep the boot value; that split needs fixing, not accepting. Live only in the v16 SessionConfig advertisement. |
+| `lodDistanceChunks` | MIXED | LIVE: handshake replies (all dialects), ingress range filter (`RequestProcessingService.java:381`, Paper `:774`), v16 declare pass, dirty broadcaster, yield prune, stats echo. CAPTURED: `OffThreadProcessor.diskReadDoneSweepRadiusChunks` (`:171-173,193` — **the in-source warning says a future reload path must re-derive it; an under-sized radius destroys still-declarable done-bits, the corrupting direction**) and the AUTO `ColumnTimestampCache` byte budget (`effectiveTimestampCacheMB()`, captured at `ColumnTimestampCache.java:82,111`). Connected clients keep their handshake-time distance: Fabric has NO mid-session SessionConfig push; Paper's only one is the v16 re-attach prompt (heals by re-handshake). Client-side, a same-rung mid-session SessionConfig already works: `ClientSessionGate.onSessionConfig:344-357` retires and rebuilds the manager. |
+
+**Command surfaces**: Fabric `LSSServerCommands` — Brigadier tree behind one
+`Permissions.COMMANDS_GAMEMASTER` requires (`:18-19`), no help literal, no unit tests
+(only Tier 2 `CommandGameTests` + the `DiagnosticsFormatter` goldens). Paper
+`PaperCommands` — arg-switch CommandExecutor with exact-string golden tests
+(`PaperCommandsTest`, incl. tab-completion pins at `:242`) and usage strings as
+de-facto help; permission is plugin.yml's `lss.admin`. `PluginYmlContractTest:82` pins
+**exactly one command key** — everything new must live under the `/lsslod` root.
+Runtime-mutation precedent: `store invalidate all` / `backfill start|stop` already
+mutate service state behind the same gates.
+
+**Backfill status**: everything needed for a remaining-estimate already exists inside
+`StoreBackfill.run()` but as thread-locals — `plan.size()` (regions remaining at walk
+start, done-marks pre-skipped at `enumerate():425`), loop index `ri`, and
+`describePlan`'s planned-bytes sum (`:442-460`, logged once at `:209` then discarded).
+The `running:` statusLine form (`:348-350`) is pinned by NO test; the terminal forms
+ARE pinned (`terminalStatusLineIsAScriptConsumedContract`, regex over
+`complete: N regions, ...`) and script-consumed by `scripts/backfill_profile.sh:216-234`
+— extend `running:`, leave the terminal lines byte-stable.
+
+**Descriptions**: current strings live in exactly two files —
+`fabric/src/main/resources/fabric.mod.json:6` and
+`paper/src/main/resources/plugin.yml:17`. No test or release gate pins the old
+wording (`release_check.py` only requires LSS/VSS descriptions to *differ*, which the
+independent VSS constants in the vssJar tasks preserve). Constraints: plugin.yml's
+description must stay ONE line starting at column 0 (the VSS rewrite regex
+`^description:.*$` is single-line), and the string must avoid `$`/`\`/`": "` (Gradle
+`expand()` + YAML plain scalar) — the proposed wording satisfies all three as-is. Do
+NOT touch plugin.yml lines 22/27 (command/permission descriptions — release_check
+token-pinned).
+
+---
+
+## Part 1 — `/lsslod set` runtime settings
+
+### Command shape
+
+- `/lsslod set <key> <value>` — apply + persist; replies with the effective (clamped)
+  value and an "applies …" note per key.
+- `/lsslod set` (no args) — list the supported keys with current effective values.
+- Same admin gates as today (root `.requires(gamemaster)` on Fabric; `lss.admin` on
+  Paper). Tab completion for keys on both platforms.
+
+### Shared key registry (`common/`)
+
+A small registry class (e.g. `common/config/RuntimeSettings`) mapping key name →
+type, getter, setter, and a short "when it applies" note, over `ServerConfigBase` —
+shared by both command surfaces so Fabric/Paper cannot drift (the `HandshakeGate`
+parity precedent). Initial keys, exactly the user's minimum:
+
+| Key | Type | Application |
+|---|---|---|
+| `lodDistanceChunks` | int | immediate server-side; connected clients via the SessionConfig re-push (below) |
+| `generationConcurrencyLimitGlobal` | int | immediate (tick-poll, below) |
+| `generationConcurrencyLimitPerPlayer` | int | immediate incl. existing sessions (tick-poll) |
+| `mbPerSecondLimitPerPlayer` | double | immediate (already live) |
+| `mbPerSecondLimitGlobal` | double | immediate (limiter reconfigure, below) |
+
+Apply sequence per `set`: parse → **clamp on a scratch value and assign the final
+post-clamp value ONCE** (review fix: Paper's ingress and handshake paths read config
+off non-pump threads, so raw-assign-then-validate leaves a transient-unclamped window
+— one read of an out-of-band distance, or an mb value whose `(int)` cast goes negative;
+Fabric is safe by construction, command thread = tick thread) →
+**`config.validate()`** (idempotent, pinned; performs the cross-field work, e.g. the
+per-player-vs-global gen-cap cross-clamp) → **`config.save()`** (first post-startup
+caller; hidden-key dropping and the bandwidth-legacy `-1` sentinels already make the
+written file correct — and every boot already does load→validate→save, so runtime
+saves lose nothing new) → reply with the post-validate value. Threading: Fabric
+commands run on the server thread (= tick thread) — direct. Paper marshals the
+mutation through the GlobalRegionScheduler pump (`FoliaWiringContractTest` disciplines
+apply; command may arrive on a region thread on Folia).
+
+### Making the captured consumers follow (the tick-poll pattern)
+
+Rather than plumbing command→service callbacks, each service applies config at the
+top of its own tick — the thread that owns the state (precedent: the broadcaster
+re-reads config per tick, pinned by `midRunConfigIntervalChangeTakesEffectImmediately`):
+
+1. **`SharedBandwidthLimiter`**: add `reconfigure(long newMax)` (tick-thread only,
+   per the class contract) — update the ceiling, clamp `availableTokens` down to it,
+   keep `lastRefillNanos`. Service tick calls
+   `limiter.reconfigure(config.bytesPerSecondGlobal())` (cheap no-op compare inside).
+2. **Generation caps**: add `ChunkGenerationService.updateCaps(int global, int
+   perPlayer)` (and Paper twin) — plain field updates called from the owning
+   service's tick before admission (same thread as the gate reads; the final
+   modifiers come off `maxConcurrent`/`maxPerPlayerActive`). Lowering a cap never
+   cancels in-flight generations — it only gates new admissions (document in the
+   command reply).
+3. **Per-player `genSlotCap`**: make it a **`volatile`** field with
+   `updateGenSlotCap(int)`, applied to every registered state in the same tick pass —
+   removes the "new joins only" split the trace flagged. Volatile is REQUIRED, not
+   plain (review MAJOR): `tryAdmit` reads it on the PROCESSING thread
+   (`AbstractPlayerRequestState.java:984-990`; the field comment says "caps are
+   immutable" precisely because of this) while the tick pass writes from the
+   main/pump thread — a plain field has no happens-before and the change may never
+   become visible. Match the `heldSyncSlots`/`heldGenSlots` volatiles beside it. (The
+   gen-SERVICE caps in item 2 are genuinely same-thread — submit/tick are
+   main-thread-only — so plain fields are fine there.)
+4. **M3 sweep radius** (`OffThreadProcessor.diskReadDoneSweepRadiusChunks`): becomes
+   volatile, re-derived each lifecycle tick as
+   **`max(currentValue, derive(config.lodDistanceChunks))`** — a monotonic max.
+   Rationale (corrected by review): an under-radius sweep of a still-declarable
+   done-bit is documented as semantically free — worst case one redundant read/serve
+   (`AbstractPlayerRequestState.java:1043-1056`; in-pipeline/grace entries are kept
+   regardless of radius) — so monotonic max avoids REDUNDANT SERVES, not corruption;
+   do not let a future reader treat it as a data-integrity constraint. The
+   lowered-distance leak (done-bits beyond the new ingress filter that the sweep can
+   no longer cull) is bounded by the previously-served area and dies as players move
+   or disconnect; the cost of a too-large radius is only memory already bounded by
+   M3's trim.
+5. **AUTO timestamp-cache budget**: deliberately NOT rebuilt (captured final byte
+   budget). Raising the distance leaves the cache sized for the boot distance —
+   correctness-safe (eviction only causes redundant serves). The `set
+   lodDistanceChunks` reply notes "timestamp cache stays at boot sizing until
+   restart" when the config is in AUTO mode.
+
+### Pushing the new distance to connected clients
+
+Changing the distance is only user-visible if connected Voxy clients learn it. The
+client already handles a same-rung mid-session SessionConfig (retire + rebuild the
+manager, full rescan — `ClientSessionGate.onSessionConfig:344-357`). Add a
+server-side re-push after a `lodDistanceChunks` set:
+
+- For each registered player whose dialect is **current (v20)** — via
+  `WireDialectTracker` — send a fresh SessionConfig built exactly like the handshake
+  reply (Fabric: the `LSSServerNetworking.java:301` shape; Paper: the
+  `LSSPaperPlugin.java:474` encoder, sent from the pump).
+- **Ordering invariant (review MAJOR — state it and pin it):** the re-push must
+  enumerate registered players and send **on the pump/main thread, AFTER the mailbox
+  drain**. `WireDialectTracker.dialectOf` defaults untracked → CURRENT, and on Paper
+  the dialect mark applies only in the pump drain's `beforeRegister` — an enumeration
+  from the command thread (a region thread on Folia) can catch a registered player
+  whose dialect flip is still pending, read CURRENT, and push a protocol-20 config at
+  a legacy client, whose gate hard-requires its own version and silently sets
+  `serverEnabled=false` — LOD dead until rejoin. Pin on Paper: a
+  registered-but-flip-pending player is NOT pushed.
+- **Legacy sessions (v19/v18/v16) are skipped** — their clients' mid-session-config
+  behavior is release-frozen and unverified; they keep the handshake distance until
+  rejoin. Say so in the command reply ("N legacy clients update on rejoin").
+- Shrinking note: until a client rebuilds, it may declare beyond the new distance;
+  those asks are range-filtered (counted `range_filtered`) — self-limiting for
+  current-dialect clients (one round-trip via the re-push). For LEGACY sessions a
+  shrink is worse than "update on rejoin" (review): their want-set positions beyond
+  the new filter are never answered and never satisfied, so the client re-declares
+  the out-of-range tail at 1 Hz for the rest of the session — `range_filtered` /
+  `superseded` climb permanently and the client never converges (v16 is softer: its
+  synthetic want-set entries expire on the 75 s TTL). Bounded work, but the command
+  reply and release notes must say "legacy clients keep re-asking beyond the new
+  distance until rejoin".
+
+## Part 2 — backfill remaining estimate
+
+Expose the worker's thread-locals as volatile progress fields on `StoreBackfill`,
+written by the worker, read by the command:
+
+- At walk start (`run()` after `enumerate()` + `describePlan`): `planRegionsTotal =
+  plan.size()`, `planEstimatedBytes` — NOTE (review): `describePlan` returns a
+  formatted string; the byte sum is internal, so exposing it is a small refactor
+  (return/record the sum), not just a field write. Reset `planRegionsWalked` here so a
+  second `start()` never shows the prior run's progress.
+- Per region: bump `planRegionsWalked` (place the bump AFTER the `presentChunks()`
+  null-check so an unreadable region doesn't count as walked-with-zero and bias the
+  average low — review); accumulate `presentChunksSeen` from the table the walk
+  already reads (`:477-493` — currently discarded), giving a measured avg
+  columns/region. Definitional note (review): `walked` is the VISITED count — it
+  deliberately differs from the terminal lines' `regionsDone`, which counts only
+  done-MARKED regions (error/shed/undrained regions are excluded); the status line
+  should show the visited count for progress and leave `regionsDone` semantics to the
+  terminal lines. Estimate bias caveat: the walk is nearest-spawn-first, so the
+  observed average over the walked (denser, near-spawn) prefix overestimates
+  columns-left for the sparse frontier — acceptable for a `~` estimate, worth one
+  comment.
+- Extend the **`running:`** statusLine (unpinned) to:
+  `running: <walked>/<total> regions, <deposited> deposited, <skipped> skipped,
+  <errors> errors, <pauses> pauses, ~<remaining> regions / ~<columns> columns left`
+  — columns-left = remaining × observed avg present-chunks (before the first region
+  completes, fall back to `≤ remaining × 1024`). Terminal lines (`complete:` /
+  `stopped:` / `capped:` / shutdown) stay **byte-identical** —
+  `backfill_profile.sh` and `terminalStatusLineIsAScriptConsumedContract` pin them.
+- `/lsslod store backfill status` needs no rendering change (it prints
+  `statusLine()`); after a completed/stopped run the terminal line already carries
+  the outcome, and `idle` (never started) stays `idle` — no idle-time enumeration
+  (region `isDone` probes are store-thread-confined; not worth marshaling for a
+  pre-start estimate the start log already prints).
+
+## Part 3 — `/lsslod help`
+
+- Shared help text builder in `common/` (e.g. `CommandHelp.lines(String rootLabel,
+  boolean backfillAvailable)`) — one line per verb: stats, diag, store status,
+  store invalidate all, store backfill start|stop|status (Fabric only), set, help.
+  Both platforms render the same lines; the root label flows from
+  `Brand.serverCommand()` / the Bukkit label, so VSS jars print `/vsslod` for free.
+- Fabric: `help` literal + `.executes` on the bare root (today a bare `/lsslod` is a
+  Brigadier parse error). Review-verified safe: the Tier 2 permission gametest
+  (`lsslodRequiresGamemasterPermission`) still passes — the `.requires` gate sits on
+  the ROOT literal, so a permissionless parse consumes zero nodes with or without a
+  root `.executes`.
+- Paper: `help` case; extend the no-arg/unknown usage strings to
+  `<stats|diag|store|set|help>` and add `set`/`help` (+ key names at level 2) to
+  `onTabComplete`. Also update `plugin.yml:23` (`usage: /lsslod <stats|diag|store>`)
+  — unpinned by tests, and the VSS overlay's blanket `lsslod→vsslod` replace handles
+  an extended line fine (review).
+
+## Part 4 — package descriptions
+
+Replace the `description` values in `fabric/src/main/resources/fabric.mod.json:6` and
+`paper/src/main/resources/plugin.yml:17` with the new string (verbatim, one line).
+Nothing else moves: the VSS overlay replaces descriptions wholesale with its own
+constants, and no test pins the old wording. Precision note (review): the Fabric pair
+check requires only the NAME to differ (`release_check.py:375-376`; description is
+merely in the allowed-diff set), while Paper's check requires the description LINE to
+have been rebranded (`:419-425`) — both stay green because the VSS constants differ
+from the new LSS wording.
+
+---
+
+## Tests
+
+- **Registry + apply (common/Tier 1)**: key parse/clamp round-trips (incl. the
+  overflow case: a huge mb value must clamp, never go negative through the `(int)`
+  cast; negative resets to compiled default — pin both), cross-clamp (lowering the
+  global gen cap drags per-player down via validate()), save() round-trip (file
+  reflects the set; hidden keys still dropped — extend `JsonConfigLoadTest`).
+- **`SharedBandwidthLimiter.reconfigure`**: ceiling raise/lower, token clamp-down,
+  refill honors the new ceiling.
+- **Gen cap tick-poll**: extend the existing generation-service tests (Fabric +
+  `PaperChunkGenerationServiceTest`) — `updateCaps` mid-run gates the next admission;
+  in-flight tickets unaffected. Per-player: `updateGenSlotCap` visible to
+  `tryAdmit` on an existing state.
+- **Sweep radius monotonic max**: `OffThreadProcessor` test — raising distance grows
+  the radius next tick; lowering never shrinks it within the run.
+- **SessionConfig re-push**: unit-test the dialect gating (v20 pushed, v19/v18/v16
+  skipped) through the existing service seams, PLUS the ordering-invariant pin
+  (review MAJOR): on Paper, a registered player whose dialect flip is still pending
+  in the mailbox must NOT be pushed — the enumeration runs pump-side after the drain.
+  One Tier 2 gametest (a registered handshaken player receives a fresh SessionConfig
+  after `set lodDistanceChunks`, mutate-and-restore in `finally` per the
+  `ServiceLifecycleGameTests:902-910` precedent). NOTE (review): driving the real
+  `set` handler calls `config.save()`, which mutates the gametest run dir's staged
+  config file — contained (fabric/build.gradle's doFirst re-stages each run), but the
+  test should restore-and-resave or the file-side effect gets chased as a "dirty run
+  dir" mystery later.
+- **Commands**: Paper — extend `PaperCommandsTest` goldens (new USAGE constants, help
+  output, `set` happy/parse-error/unknown-key, tab completion lists). Fabric — add
+  dispatch coverage to `CommandGameTests` (`lsslod help`, `lsslod set ...` through the
+  real tree with permission gate intact); optionally the first Tier 1
+  `LSSServerCommandsTest` if the set-handler is extracted to a testable body (match
+  the PaperCommands supplier-seam shape). Refactor constraint (review):
+  `ChannelAccessorContractTest:212-214` source-regex-pins that `showDiagnostics`
+  feeds the LIVE `lodYieldsToVanillaTransport` flag to `yieldDiagLineOrNull` — any
+  handler extraction must preserve that call shape.
+- **Backfill**: extend `StoreBackfillTest` — `running:` line carries `X/Y regions` and
+  the remaining terms (drive via the existing fake-reader rig); terminal-line pins
+  unchanged (the existing contract test doubles as the regression guard);
+  progress-field reset on a second `start()`.
+- **Descriptions**: none needed (no pins exist); `release_check.py` pair checks run
+  in CI as today.
+
+## Docs / release notes
+
+- README: command table gains `set` + `help`; note runtime changes persist to
+  `lss-server-config.json`.
+- CLAUDE.md: command surface bullets (both platforms) + the tick-poll pattern note on
+  the four formerly-captured consumers.
+- Release notes: New Features (runtime settings commands, help, backfill remaining
+  estimate) — mention legacy-dialect clients pick up distance changes on rejoin; the
+  description change needs no notes entry (storefront metadata).
+
+## Risks / accepted constraints
+
+- `validate()`-on-set re-emits the Folia store warning when applicable — cosmetic,
+  accepted (it IS a warning-worthy state).
+- Config file writes now happen at runtime: save() is atomic-move, brand-invariant
+  filename; a concurrent hand-edit loses (last writer wins) — same as any
+  command-managed config.
+- Legacy-dialect sessions keep the old LOD distance until rejoin (deliberate — their
+  mid-session config handling is unverified in released clients).
+- AUTO tscache budget stays boot-sized until restart (correctness-safe; noted in the
+  command reply).
+- The Folia path: the set-apply is marshaled to the pump; the tick-poll consumers all
+  run on the pump already. Folia stays experimental — mention in release notes if any
+  item ships Folia-visible behavior.
+
+## Verification
+
+1. `./gradlew :fabric:test -x runGameTest -x runClientGameTest` + `./gradlew :paper:test`
+   (new registry/limiter/gen-cap/sweep/commands/backfill pins).
+2. `./gradlew :fabric:runGameTest` (new CommandGameTests dispatches + existing tree).
+3. `python3 scripts/release_check.py` after `:paper:shadowJar` + `:fabric:build` — the
+   description change must keep the VSS pair checks green.
+4. Live smoke (`./test-server.sh run-fabric-store` + a real Voxy client):
+   `/lsslod help`; `/lsslod set mbPerSecondLimitPerPlayer 5` → visible throughput drop
+   in `/lsslod stats`; `/lsslod set lodDistanceChunks 128` → client rescans to the new
+   distance without rejoin (watch the SessionConfig re-push + `range_filtered` settle);
+   `/lsslod store backfill start` → `store backfill status` shows `X/Y regions ... left`.
+   Persistence check (review correction): `test-server.sh` REWRITES the staged config
+   on every invocation, so do NOT verify persistence by re-running the script —
+   inspect `lss-server-config.json` before re-staging, or restart the server process
+   directly.
+5. One soak (`./scripts/soak.sh fresh-backfill`) to confirm the tick-poll additions
+   didn't disturb the law baselines (defaults unchanged → should be byte-identical
+   behavior).


### PR DESCRIPTION
Five feature plans, each written from a codebase exploration round and revised through Fable subagent review rounds (findings folded into the docs; review records in each header):

1. **dirty-broadcast-interval-zero** — `dirtyBroadcastIntervalSeconds: 0` disables client dirty pushes while the drain + invalidation fan-out keep running (0 MAJOR / 7 MINOR).
2. **client-reset-command-and-cache-relocation** — `/lss reset` wipes Voxy (disk + in-memory, `/voxy reload`-equivalent via reflection) + LSS client state; cache moves to game-root `.lss/` with adopt-old-if-present (3 MAJOR / 7 MINOR).
3. **runtime-settings-commands** — `/lsslod set` for gen caps / bandwidth / lodDistanceChunks with validate()+save() and tick-poll application, backfill remaining-estimate, `/lsslod help`, new package descriptions (2 MAJOR / 9 MINOR).
4. **far-player-proxies** — SeeU-style distant players native to LSS, from a full SeeU 0.7.3 source analysis + live compat test (4 MAJOR / 9 MINOR).
5. **disk-read-concurrency-gate** — decouples server CPU limiting from bandwidth via a K-permit gate at the store-miss→region-read seam, store-conditional AUTO (2 reviewers: mechanism + accounting lenses).

Docs only — no code. These are the source specs for the upcoming v0.11.0 mega plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)