### PR TITLE
docs: v0.11.0 mega plan (v1.1, five-Opus reviewed) + progress skeleton

### DIFF
--- a/docs/planning/v0.11.0-mega-plan.md
+++ b/docs/planning/v0.11.0-mega-plan.md
@@ -1,0 +1,530 @@
+# v0.11.0 mega plan — operator controls + client reset + far players + CPU gate (2026-08-12, v1.1)
+
+One release plan combining five reviewed plans into a single sequenced program:
+
+| source plan (normative spec for its content) | short name | state |
+|---|---|---|
+| `dirty-broadcast-interval-zero-plan.md` | **DIRTY0** | 1-Fable reviewed (0 MAJOR / 7 MINOR folded) |
+| `disk-read-concurrency-gate-plan.md` | **GATE** | 2-Fable reviewed (mechanism + accounting lenses folded) |
+| `runtime-settings-commands-plan.md` | **SET** | 1-Fable reviewed (2 MAJOR / 9 MINOR folded) |
+| `client-reset-command-and-cache-relocation-plan.md` | **RESET** | 1-Fable reviewed (3 MAJOR / 7 MINOR folded) |
+| `far-player-proxies-plan.md` | **FARP** | 1-Fable reviewed (4 MAJOR / 9 MINOR folded) |
+
+The five source plans remain the detailed specs. This document owns three things:
+(1) the **cross-plan reconciliations** — where combining the plans changes their
+details, recorded as explicit amendments each implementation PR must follow over
+the source text; (2) the **master landing order** with its rationale; (3) the
+consolidated release / re-port / notes obligations. Where this doc and a source
+plan disagree, THIS DOC WINS — each amendment says exactly what it overrides.
+
+**v1.1 (same day): revised after a five-Opus review round of v1.0** (integration /
+fidelity / process / tri-version / sequencing lenses — full record in §7).
+Headline outcomes: **E1 ships inert** (`farPlayers` compiled default `off`, client
+bit unarmed until E2 — all five lenses converged on the v1.0 E2-slip story being
+false); **stage G becomes a delta-port onto the current `-v0.10` support branches
+with the support base cut from main at the D merge** (the fresh-re-port rationale
+expired at v0.10.0 — the branches are one docs commit behind main, and cutting the
+base pre-E1 means FARP never needs subtracting from six pinned shared artifacts);
+R-2/R-3/R-5 were re-scoped as the two-sided amendments they actually are; the §6
+practices lost in v1.0's compression were restored from the v0.10.0 record; and §5
+is re-denominated as agent-executable vs user-gated work (the predecessor's actual
+wall clock was ~1.6 days against its stated 8–10 weeks — estimates anchored to that
+estimate inherit its error).
+
+**Release shape:** v0.11.0 ships everything on the 26.2 main line: the dirty-push
+off switch, the disk-read CPU gate (store-conditional auto), the runtime settings
+commands + help + backfill estimate + new package descriptions, the client
+`/lss reset` + `.lss/` cache relocation, and far-player proxies (capability-gated,
+LSS's first client-side renderer; ARMED only at E2). The 26.1 and 1.21.11 support
+lines get **everything except FARP** via stage G's delta-port — tri-release at the
+end, no tag pushed before G. **Unlike v0.10.0 there is NO protocol bump**: every
+stage is additive and default-safe (FARP rides a masked capability bit + new
+`lss:*` channels old clients silently discard), so there is **no integration
+branch** — every stage PRs to main directly and main stays releasable throughout.
+
+**Recorded alternative (user decision pending, raised by the review round):** ship
+A–D as v0.11.0 (a perfectly symmetric tri-release — the support lines get the same
+four features) and FARP as a 26.2-only v0.12.0. This dissolves the E2-slip risk and
+gives the first LSS renderer its own release window; the cost is far players
+waiting one release. This plan keeps all five in v0.11.0 per the original
+direction, with E1-inert as the safety; flipping to the alternative later costs
+nothing before E1 starts.
+
+---
+
+## 1. Cross-plan reconciliations
+
+### R-1 — Shared pinned-surface accretion order (the five plans touch the same goldens)
+
+Six shared, test-pinned surfaces are touched by multiple stages:
+
+1. **Config clamp test tables** (Fabric reflective-sweep floor switch + Paper
+   `SHARED_BOUNDS`) — DIRTY0, GATE, FARP.
+2. **The config-echo append contract** — GATE (appends resolved K). Note the
+   echo's ARGUMENT SHAPE is source-regex-pinned by
+   `ChannelAccessorContractTest:142-152` (`effectiveConfigEcho(readerThreads,
+   wireCompressionLive)`) — GATE's third argument reds that pin and must update it
+   same-commit. The same file's `showDiagnostics` live-flag pin (`:208-218`) is
+   SET's already-recorded refactor constraint. (FARP touches no echo; SET's Part 4
+   needs no release_check token change — both v1.0 over-listings corrected.)
+3. **`DiagnosticsFormatter` golden line list** — GATE (`read_gate=` token), FARP
+   (`FarPlayers:` line).
+4. **The shared exporter contract literal**
+   (`fabric/src/test/resources/exporter-contract/server-snapshot.contract`,
+   byte-asserted by both platform contract tests) + `check_soak.py` registries —
+   GATE, FARP.
+5. **`plugin.yml` + the vssJar rewrite + `release_check.py` token lists** — SET
+   (description line 17 + usage line 23; the blanket `lsslod→vsslod` replace
+   covers usage), FARP (the permission node — and note the correction to FARP
+   §3.4: per the code a missed rewrite does NOT red the gate, it silently ships an
+   un-rebranded node, which is why E1's gate runs `release_check.py`).
+6. **The harness scripts** (missing from v1.0 — review): stage B edits
+   `scripts/soak.sh` (scenario case, `ALL_SCENARIOS`, staging) + the FIVE
+   `diskReaderThreads`-staging scripts (see stage B row); stage D rewrites cache
+   roots in `soak.sh:349-369,:545-548`, `benchmark.sh:94`,
+   `benchmark_compare.sh:60,133`, `profile_disk_read.sh:165`. B→D ordering means D
+   must extend both-roots handling to B's new scenario.
+
+Rule: **each stage lands its own accretion complete and same-commit** (goldens +
+contract literal + `--selftest` cases + echo pins + vssJar/release_check extensions
++ any NEW gametest class added to the `fabric-gametest` entrypoint listing — never
+split, never batched to stage F). Later stages rebase on the accreted state. Stage
+F's docs sweep is consolidation and stale-text cleanup, not the first write.
+
+### R-2 — The SET registry absorbs the program's new tunables (amends SET's key list AND GATE's §Design)
+
+SET's `/lsslod set` registry gains two keys beyond its plan's minimum, which is why
+stage C lands after A and B:
+
+- **`maxConcurrentDiskReads`**: this amends GATE — `DiskReadGate`'s capacity
+  becomes a volatile read at `tryAcquire()` (B ships it that way; C makes it
+  mutable), with `updateCapacity(...)` living **on the reader**, which already owns
+  both facts the store-conditional resolver needs (`store` and `threadCount` —
+  review: the service retains neither, and store-attachment must be the
+  post-degrade `lodStore != null`, never `config.lodStore != "off"`, or half-pool K
+  re-arms on exactly the store-less servers GATE's convergent MAJOR carved out).
+  **Lowering semantics** (specified, mirroring SET's gen-cap rule): in-use may
+  transiently exceed the new K until permits drain — new acquisitions refuse, the
+  counter never goes negative, no permit sticks, and the pegged WARN does not fire
+  spuriously on the transient. Pinned by a lower-capacity-while-permits-held test.
+- **`dirtyBroadcastIntervalSeconds`** (with DIRTY0's new 0-semantics): already
+  LIVE per-tick, so a runtime `set … 0` disables pushes live and nonzero
+  re-enables. The reply for `0` names the off semantics.
+
+**Registry clamp rule (review MAJOR):** registry rows carry a per-key **clamp
+function** (reusing the exact helpers `validate()` calls), never a bare `(min,max)`
+band — SET's pre-clamp-on-scratch sequence would otherwise turn
+`set dirtyBroadcastIntervalSeconds 0` into 1 s (re-breaking DIRTY0) and
+`set maxConcurrentDiskReads 0` into K=1 instead of AUTO. Stage C pins `0`
+round-tripping unchanged for both keys, plus negative→normalized.
+
+The "written once" rationale is corrected: it is **A+B's keys** that are written
+once; the registry is extended again at E1 (R-9).
+
+### R-3 — Prefs re-send is the far-player re-subscribe (amends RESET **and** FARP §3.1)
+
+Two-sided amendment (v1.0 labeled only the RESET half — review):
+
+- **FARP server side (new obligation)**: ANY received `FarPlayerPrefsC2SPayload`
+  on a subscribed session — changed or byte-identical — answers with a **full
+  roster at a bumped epoch**. (FARP §3.1's trigger list gains this fourth entry;
+  the "prefs unchanged → no-op" implementation would silently break reset.)
+  Server-side rate bound: at most one full-roster answer per session per
+  `REATTACH_PROMPT_INTERVAL_MS`-class interval (it is client-triggerable — a chat
+  command must not be a roster-flood lever). Pinned server-side at E1.
+- **RESET client side**: after `flushCache()`, the reset coordinator clears the
+  far-player tracker + seen-epoch state AND re-sends prefs; the bumped-epoch full
+  roster repopulates. (Clearing without the epoch bump would strand the client —
+  the reason a bare tracker clear was rejected.) Before E1 lands this step is
+  absent; the RESET PR leaves a marked seam.
+
+### R-4 — Package descriptions vs far players (recorded decision, no text change)
+
+SET ships the new description at stage C; FARP later makes LSS render players
+natively. The description stands for v0.11.0; release notes carry the feature.
+Revisit only if far players becomes the headline of a later release.
+
+### R-5 — Cross-feature interactions (corrected from v1.0's "non-collisions" — two were wrong)
+
+- **SET's SessionConfig re-push ∩ FARP — a REAL interaction, requirement recorded**
+  (review, three lenses independently): a same-rung mid-session config retires and
+  rebuilds the client manager (`ClientSessionGate.onSessionConfig` teardown path).
+  E1 must therefore either (a) own the far-player tracker OUTSIDE the manager
+  lifecycle, or (b) run R-3's re-subscribe helper on manager rebuild — decided and
+  pinned at E1. If the prefs send is wired to the session-config handler, note the
+  consequence: one `set lodDistanceChunks` on an N-player server triggers N
+  rebuilds + N full rosters — R-3's rate bound covers the roster half; the rebuild
+  half is SET's already-accepted behavior.
+- **GATE ∩ FARP**: genuinely none — FARP has no disk path and its own send lane.
+- **RESET's decode-drain await ∩ FARP**: genuinely none — FARP does not route
+  through `ClientColumnProcessor` (column-only).
+- **DIRTY0 ∩ FARP**: genuinely none — far-player updates are not dirty-driven.
+- **RESET ∩ the harness scripts**: v1.0's "client-cache-path only; no
+  interaction" was true of the feature, false of its blast radius — see R-1
+  surface 6.
+- **DIRTY0 ∩ SET logging (new)**: DIRTY0's `validate()`-time INFO (interval 0)
+  would re-fire on every `set` once C lands, alongside the Folia store warn.
+  Reconciliation: advisory `validate()` log lines become log-on-CHANGE (or a
+  quiet-validate variant for the runtime path) — landed at C, one-line each.
+- **Runtime mutation ∩ the config-echo contract (new)**: the boot echo is a
+  script-consumed "resolved values" contract; after C it can go stale for the
+  boot. Rule: harness arms never runtime-`set` (their staging owns config), the
+  `set` reply is the runtime receipt, and R-8's deploy-log entries record the
+  live `read_gate=`/diag line rather than trusting the boot echo (the rig's
+  config era must be attributable — review).
+
+### R-6 — Soak/checker registry work is per-stage, self-testing where possible
+
+Generalizing GATE's review lesson, WITHOUT the v1.0 losses (review): every stage
+that adds a config key a scenario might pin registers it in the checker's typed
+key lists — `SERVER_CONFIG_INT_KEYS` for ints, **`SERVER_CONFIG_STRING_KEYS` /
+string-list registries for FARP's `farPlayers` mode + `farPlayersExclude`**;
+every stage that adds a snapshot counter lands both exporters + the contract
+literal + the `_srv` selftest fixture + `--selftest` cases same-commit; new
+top-level snapshot blocks (FARP's) register in `KNOWN_SERVER_KEYS`;
+**`soak_report.py`** registration rides along (`SERVER_MECHANISM` for `disk.gated`
+— GATE's own list, dropped in v1.0) — and FARP's dedicated lane breaks
+`soak_report.py`'s zero-tolerance `bandwidth.total_bytes == service.bytes_sent`
+identity audit, so E1 updates that audit (a new `farplayers.bytes` term or a
+documented tolerance) in the same commit. Gauges NEVER enter `SERVER_DRAINS` (the
+store.queue trap). GATE's A7 `gated` opt-in makes every pinned scenario
+self-verify its no-op pin; FARP's soak-client property gate
+(`-Dlss.soak`/`-Dlss.benchmark` present → bit NOT sent) is pinned as a unit test
+at E1 (its review demanded Phase-A self-verifiability) and re-asserted by the
+stage-F gauntlet's counters-stay-zero check.
+
+### R-7 — Re-port scope: far players is 26.2-only in v0.11.0
+
+The support lines receive DIRTY0 + GATE + SET + RESET, **not FARP**. Obligations
+this decision creates (review — v1.0 asserted these; they are now gates):
+
+- **The FARP wire is MC-version-neutral from E1** (identity strings via the v20
+  dictionary pattern for equipment/vehicle types — never numeric registry ids).
+  The 26.2-only scope is a SHIPPING decision, not a wire decision; an E1 reviewer
+  must not read "26.2-only" as license for version-locked encoding.
+- **The C2S prefs frame gets the `lss:client_info` sidecar guard pattern**
+  (try/catch containment + send-once-per-session-unless-changed/reset): a 26.2
+  client sends prefs at every pre-v0.11.0 server and every support-line server —
+  populations that never registered the channel. Version-mix cell recorded: 26.2
+  client + support-line server → capability bit masked (verified:
+  `HandshakeGate:151` masks) AND prefs send contained → silence.
+- **Privacy asymmetry documented**: a support-line client on a 26.2 v0.11.0
+  server is a far-player TARGET with no client-side `shareSelf` (the pref exists
+  only in the 26.2 client config); its protections are the server-side mode /
+  exclude list / permission node. Goes in the README privacy note + release
+  notes.
+- **RESET vs per-line Voxy is a stage-G GATE, not an assumption** (v1.0's
+  "0.2.11-era, old rung" claim was wrong for the 26.1 line — the locally available
+  0.2.18-beta-26.1.2 jar exports the NEW `IVoxyRenderSystemHolder`; the README
+  floors are 0.2.14/0.2.15, unverified points on the rename timeline): before
+  declaring RESET line-identical, download each line's actual Voxy floor build and
+  `javap` the `VoxyCommon` statics + `getStorageBasePath` + both holder
+  interfaces; then the per-line live smoke. A both-rungs-unresolvable outcome
+  degrades to LSS-only reset by design — acceptable, but discovered before the
+  tag, not after.
+- Standard backport gotchas apply on top (the `mc-version-backport-gotchas`
+  catalogue + v0.10.0's D3 record — Fabric API symbol renames hit
+  `LSSClientCommands` directly (`ClientCommands` → `ClientCommandManager` on
+  1.21.11), paperweight/Java 21, per-line release.yml flavors +
+  `ReleaseWorkflowContractTest` twins, per-MC corpus goldens); under the stage-G
+  delta-port most are already carried by the `-v0.10` branches.
+
+### R-8 — Live-deploy cadence (the Modrinth rig is GATE's burn-in) — with the rig realities stated
+
+The live Modrinth server (`lodStore=full`, high bandwidth) is the store-armed
+profile GATE's AUTO binds on. **Rig realities the plan must respect (review — the
+v0.10.0 program staged two deploys and completed ZERO, blocked on an expired
+archon token; and the rig auto-pauses when empty, freezing every counter):**
+
+- **The archon-token refresh (fresh HAR from the user) is a stage-A prerequisite**
+  — front-loaded, not discovered at deploy time. If it cannot be refreshed, R-8's
+  deploys are re-planned as user-driven with agent-prepared artifacts.
+- Rig observations are **post-merge burn-in obligations tracked on the progress
+  doc's manual-verification checklist** — never merge-gate criteria (v1.0 listed
+  them in gate columns while deploying after merge — unsatisfiable).
+- During the B→C window the rig has no runtime knob for K (R-2 lands at C); the
+  documented rollback is the SFTP config edit + Restart flow. Each deploy-log
+  entry records the SHA, date, stage-era, store outcome, AND the live
+  `read_gate=` diag line (config-era attribution, per R-5's echo rule).
+- GATE's **controlled local rig A/B stays a stage-B gate** (v1.0 wrongly
+  substituted the Modrinth eyeball for it): `run-fabric-store`, warm-rejoin burst
+  (store serves at full rate, `read_gate` in-use ~0), cold-region flight
+  (`read_gate=K/K`, `gated=` climbing, CPU bounded vs a control run, convergence
+  completes, WARN fires once).
+- RESET and FARP verify on the local test rig; **E2's live gate needs TWO real
+  GUI clients plus the dummy** (the soak client is capability-gated OUT, so the
+  dummy is a far-player TARGET only) — a user-scheduling constraint, on the
+  checklist. The "SoakPlayer dummy rig" gets a short doc section (it is currently
+  folklore from the 2026-08-12 session, not documentation).
+
+### R-9 — FARP's privacy keys join the SET registry at E1 (new; resolves an unrecorded scope decision)
+
+`farPlayers` (mode) and `farPlayersMaxDistanceBlocks` are registered at E1 — an
+admin answering a privacy complaint must not need a restart. This requires the
+registry's one string-typed row (mode) — a real but small registry extension.
+`farPlayersExclude` (list-typed) stays restart-only for v0.11.0, recorded in
+§3.3. The registry/help/tab-completion goldens are therefore touched twice
+(C and E1) — accepted, R-1's accretion rule covers it.
+
+---
+
+## 2. Master landing order
+
+| stage | content | source spec | gates to merge |
+|---|---|---|---|
+| **A** | `dirtyBroadcastIntervalSeconds: 0` = sends off (drain + fan-out + clears keep running at the 10 s fallback cadence). **Program prerequisites ride along: archon-token refresh (R-8), progress doc created** | DIRTY0 | Tier 1 both platforms (all three broadcaster pins — zero-sends drain, exact fallback tick, both-way flips — clamp tables, `LSSGameTests` bounds), Tier 2 green; one `dirty-broadcast` + one `paper-dirty-falling-block` soak (A touches both broadcasters' tick shape; minutes of cost, prevents an A-caused red being mis-triaged environmental at F); clamp-audit erratum |
+| **B** | Disk-read concurrency gate (store-conditional AUTO, volatile-capacity K per R-2, `saturated`-flavor bounce, `disk.gated`) + `disk-read-gate` soak scenario + ALL harness pins (26 scenario configs, gametest run dirs, benchmark.sh, **all FIVE `diskReaderThreads`-staging scripts: profile_disk_read, compress_gate, backfill_profile, benchmark_compare, store_gate** — review; store_gate is the store-armed A/B where AUTO actually binds) + the A7-catalog "+K" amendment + CLAUDE.md scenario-count update + **live deploy to the Modrinth rig post-merge (R-8)** | GATE | Tier 1+2; `disk-read-gate` soak green (duration sized for DEGRADED WSL2 IO — K=1 at 107-131 ms/read serializes the annulus to ~4-5 min; budget it or run threads:4/K:2); `fresh-backfill` + `disk-saturation` under no-op pins: **`disk.gated == 0` + all laws green + no new violations** (v1.0's "byte-identical" was untestable — soak runs are never byte-comparable); benchmark arms a–d with **arm c's acceptance threshold PRE-REGISTERED in the PR description before the run** (fallback pre-agreed: AUTO = pool even when store-armed); the controlled local rig A/B (R-8); `ChannelAccessorContractTest` echo-shape pin updated (R-1.2) |
+| **C** | `/lsslod set` (registry incl. R-2's two keys, per-key clamp functions) + tick-poll appliers + SessionConfig re-push (v20-only, pump-side) + `/lsslod help` + backfill remaining-estimate + package descriptions + the R-5 log-on-change reconciliation | SET as amended by R-2/R-5 | Tier 1 **both platforms** (registry incl. the 0-round-trip pins, limiter/gen-cap/sweep/echo pins, `genSlotCap` volatile pin, **the Paper pump-side re-push ordering pin — a registered-but-flip-pending player is NOT pushed** (SET's second threading MAJOR, dropped in v1.0), `PaperCommandsTest` goldens + tab completion), Tier 2 (CommandGameTests dispatches + the re-push gametest with run-dir config restore), **one `fresh-backfill` soak** (SET's own required gate — C mutates the limiter, gen caps, admission caps, and sweep radius on the live tick path; v1.0 dropped it), `release_check.py` green, live smoke on the rig post-merge (R-8 checklist) |
+| **D** | `/lss reset` (decode-drain await → Voxy teardown/wipe/rebuild via `getStorageBasePath` → `flushCache`; confirm-gated no-manager fallback) + `config/lss/cache` → `.lss/cache` relocation + harness both-roots STAGING AND COLLECTION (incl. B's new scenario) | RESET | Tier 1 (VoxyCompat reset ladder incl. both throw paths, coordinator ordering, `resolveCacheRoot` branches, wipe containment, **the confirm-token pin**), **Tier 2** + Tier 3; soaks: `clearcache-mid-session` AND **`fresh-backfill` then `cold-restart-resync`** (the decisive both-roots proof — collection at `soak.sh:545-548` and restore at `:360-362` are the dangerous sites; clearcache alone only exercises the clear path); live smokes ×3 (real Voxy 0.2.18 LODs-visibly-rebuild; a no-Voxy server; an existing `config/lss/cache` proving adoption) |
+| **E1** | Far players phase A, **INERT**: `farPlayers` compiled default **`off`** + client capability bit NOT sent (both flipped at E2 — the v0.10.0 transport-yield default-FALSE pattern; all five review lenses converged on this). Wire (version-neutral per R-7, C2S guard per R-7) + prefs/v18-rung lifecycle + R-3's server-side full-roster-on-prefs + epoch'd roster/updates + broadcast service (tiers, filters, privacy, dedicated lane) + client tracker + debug HUD + R-3's RESET seam filled + R-5's tracker-ownership decision + R-9 registry rows + VSS permission-node rewrite | FARP §3.1-3.2, §7-A as amended | Tier 1 (codec parity twins, filter ladder, roster-epoch resync incl. the R-3 server pin + rate bound, prefs lifecycle, **the soak/benchmark property-gate pin**, the R-5 manager-rebuild pin), Tier 2 server-egress crafted-handshake gametests, **one Paper soak** (the pump-side prefs marks + quit-race drop are Paper-only code paths otherwise ungated until F), `FarPlayers:` diag + exporter + checker + `soak_report` bandwidth-audit registrations same-commit (R-1/R-6), envelope pin for the new channels, clamp tables, `release_check.py` green |
+| **E2** | Far players phase B: renderer (proxy entities, declared-cadence lerp + velocity extrapolation, event-triggered handoff with SeeU's conjuncts, NO glow, NO fog mixin), Sodium rows; **defaults flipped ON** (server `on`, client bit armed) | FARP §3.3, §7-B | Tier 1 tracker math; **live gate on the test rig — two real GUI clients + the dummy** (elytra extrapolation, tracking-boundary handoff, vanish/spectator via RCON) — rendering has no test tier, the live gate is THE gate (user-scheduled, R-8 checklist) |
+| **E3** | Far players phase C: vehicles (pose-rendered), coexist default (`isModLoaded("seeu")` off + INFO + Sodium tooltip), README privacy note (incl. R-7's asymmetry), exporter/soak-report fields final, **the `run-folia` two-client session** (FARP's own Folia gate — the new cross-region equipment/pose read class; v1.0 dropped it) | FARP §7-C | Tier 1 additions; full-suite soak with counters-stay-zero (R-6); the Folia session (user-assisted, checklist) |
+| **F** | Docs consolidation (CLAUDE.md sweep, READMEs incl. version table rows, clamp-audit errata), release notes all three lines + **three `release-tag-v0.11.0*.txt` drafts + the short Modrinth changelog variant** (three lines carry DIFFERENT notes — FARP main-only — and Modrinth is hand-fix-only), **the pre-G whole-program review round** (scope: the full A..E3 diff — the v0.10.0 pre-D3 round found 5 MAJORs; v1.0 had no program-level round at all), pre-flight | this doc §3.2 | **full `soak.sh all` on all three platforms** (count NOT frozen — B made it 20 Fabric), Tier 3 green **discharged against the last code-carrying commit** (docs-only PRs skip CI — cite E3's runs), `release_check.py` OK, `CI=true` pre-flight build, the review round's findings dispositioned |
+| **G** | **Delta-port onto the current support branches** (review — the fresh-re-port rationale expired: the `-v0.10` branches ARE the released v0.10.0 trees, current to one docs commit): cut `support/mc<ver>-v0.11` from `support/mc<ver>-v0.10`, then merge/cherry-pick **main at the D merge** (pre-E1, so FARP never needs subtracting from the six R-1 artifacts) + the non-FARP parts of F. Fresh re-port survives only as the documented escape hatch with its cost stated (the 90-file 1.21.11 adaptation set would be re-derived). Per-line: R-7's Voxy-rung javap gate, the gotcha catalogue, staging/smoke, **archive the stale v0.8.1-era `support/mc*` branches** (recorded convention gap). Then tri-release | R-7 + this row | per-line pre-flights green; R-7 gates discharged; tags pushed ONLY here, `--cleanup=verbatim`, annotation verified via `git for-each-ref` BEFORE push, rendered notes verified on GitHub AND Modrinth after; never re-run a partially published release; no throwaway `v*` tags ever |
+
+**Ordering rationale, compressed:** A first — smallest, and it exercises the exact
+config/clamp/test-table discipline every later stage repeats. B second — early
+landing gives the gate the program's longest **plumbing** burn-in (see below) and
+starts the Modrinth store-armed live evidence at week one. C after A+B so A+B's
+keys enter the registry once (R-2, rationale as corrected). D before E — R-3's
+seam direction (D writes the seam, E1 fills it) is the only order that doesn't
+author RESET against unlanded FARP code, and both touch the client
+command/lifecycle surfaces. E last-large: new wire surface + LSS's first renderer,
+phased internally, inert until its renderer exists. F/G are release mechanics.
+
+**The burn-in claim, stated honestly (review):** the no-op harness pins mean **no
+later soak, gametest, or benchmark ever exercises a BINDING gate** — what they
+burn in is leak/plumbing coverage (the A7 `gated` opt-in makes every pinned
+scenario red on a permit leak), which is real but narrower than v1.0 claimed. The
+only BINDING burn-in is the Modrinth rig (store-armed AUTO) — the channel with a
+0-for-2 completion record, hence R-8's front-loaded prerequisite.
+
+**Parallelism:** stages are sequential (v0.10.0's record: its one sanctioned
+overlap never actually happened, and serial execution was not the bottleneck —
+the critical path is user-gated verification). The ONE sanctioned overlap — E1's
+common-module wire/codec work during D's review — is **code-only**: no concurrent
+builds, soaks, or rig sessions. Box discipline: **every soak, benchmark arm, and
+live-rig session owns the box exclusively** (not just "measurement sessions" —
+the A7 catalog's six-forgotten-servers lesson was a SOAK lesson); `pgrep` sweep
+first.
+
+---
+
+## 3. Consolidated obligations
+
+### 3.1 Testing (delta view — each source plan's suite stands; these are merge-created)
+
+- R-2: the volatile-capacity + `updateCapacity` tests (B ships the shape, C ships
+  the mutation path incl. lower-below-in-use), the registry clamp-function
+  round-trip pins (`0` stays `0` for both keys).
+- R-3: the server-side full-roster-on-prefs pin + rate bound (E1); the RESET-seam
+  client test (prefs re-send after flushCache).
+- R-5: the manager-rebuild ∩ far-players pin (tracker survives or re-subscribes —
+  whichever E1 decides); the log-on-change validate() behavior.
+- R-6: FARP's `soak_report.py` bandwidth-identity audit update.
+- Stage-F: the counters-stay-zero gauntlet check; the accreted goldens asserted
+  final-form; the pre-G whole-program review round.
+- Every pin touched by two stages (echo shape, formatter goldens, exporter
+  literal, registry goldens) is re-verified at each touching stage.
+
+### 3.2 Release notes (v0.11.0; format per CLAUDE.md; three lines, FARP main-only)
+
+- **New Features**: far players (26.2 line only, explicitly; privacy modes + the
+  2048 default + R-7's support-line-targets asymmetry; **SeeU credited as MIT
+  prior art** — an attribution obligation from FARP §5, dropped in v1.0);
+  `/lss reset`; `/lsslod set` + `help` (legacy-dialect distance-shrink wording per
+  SET: "legacy clients keep re-asking beyond the new distance until rejoin");
+  backfill remaining-estimate.
+- **Configuration**: `dirtyBroadcastIntervalSeconds: 0` semantics incl. the
+  rejoin-only refresh tradeoff (DIRTY0's required wording); `maxConcurrentDiskReads`
+  (auto; store-conditional; the CPU-vs-bandwidth separation sentence); FARP's
+  server keys (main line); the `.lss/` cache location for fresh installs.
+- **Performance**: the disk-read gate headline.
+- Folia-affecting items carry the experimental-status mention: GATE (common-side),
+  SET's pump marshaling, **and FARP** — the largest Folia-affecting change in the
+  release (new cross-region read class; the E3 session is its evidence). v1.0
+  omitted FARP from this list.
+
+### 3.3 Explicitly OUT of v0.11.0 (recorded so nothing silently re-enters)
+
+- FARP on the support lines (R-7); FARP's fog/glow options and "smart" SeeU
+  detection; `farPlayersExclude` as a runtime-settable key (list-typed; R-9 scoped
+  it out).
+- GATE's MSPT modulation of K; the store-ON gate soak variant (follow-up — noting
+  honestly that the live rig, its stand-in, is the program's least reliable
+  channel).
+- SET's legacy-dialect SessionConfig re-push; the AUTO-tscache-stays-boot-sized
+  constraint (lives in the `set` reply).
+- DIRTY0's future interval-0 soak scenario (needs checker window-math work first
+  — its named checks size windows as `2 * interval`).
+- A `FarPlayerConsumer` LSSApi feed — DECIDE AT E1 and log it.
+- Paper backfill parity (standing deferral; the backfill estimate is Fabric-only
+  where backfill exists).
+
+---
+
+## 4. Risks (merge-level; source-plan risks stand)
+
+- **E2 has no test tier** — LSS's first renderer is gated by live verification
+  only, and that gate needs two real GUI clients (user-scheduled). Mitigation:
+  E1 is INERT (the v1.0 story — "v0.11.0 goes without FARP, other rows
+  unaffected" — was false: E1's defaults would have shipped a live position
+  broadcast rendering nothing). With E1 inert, a slipped E2 ships dead code, not
+  exposure; the pre-declared fallback states are (i) ship inert, flip in
+  v0.11.1/v0.12.0, or (ii) revert E1 from the release branch. The E1→E2 go/no-go
+  is the user's call, recorded in the decisions log.
+- **User-gated work is the critical path** (review): B/C rig observations, D's
+  three live smokes, E2's live gate, E3's Folia session, the archon token. The
+  fallback discipline: merge with live verification logged PENDING on the
+  checklist; **G is the named point where a pending checklist item blocks the
+  release**.
+- **Shared-surface rebase churn** — R-1's subject; sequential stages + the
+  code-only overlap contain it.
+- **GATE's arm-c number** could force the divisor revisit — pre-registered
+  threshold + pre-agreed fallback (AUTO = pool) make it a stage-B decision, before
+  C.
+- **RESET's per-line Voxy surface** — now a G gate (R-7), worst case a diminished
+  feature on old lines, never breakage.
+- **Flake exposure** (review): Tier 1 has NO CI retry and `MemoryLodStoreTest`'s
+  tombstone race fired on both v0.10.0 re-ports; the Tier 3 silent client hang and
+  A7 storms are documented. Rule (also in §6.4): a red soak or Tier-1/3 failure
+  gets the catalog triage FIRST (counter check → branch A/B → `pgrep` sweep)
+  before any code hunt; re-run budget is explicitly non-zero in §5.
+
+## 5. Effort (re-denominated — review: v0.10.0's ACTUAL wall clock was ~1.6 days
+against its stated 8-10 weeks; anchoring to that estimate inherits its error)
+
+Two columns: **agent-executable** (bounded by review cadence + gate runs, not
+calendar weeks) and **user-gated** (scheduling-dependent, the real critical path).
+
+| stage | agent-executable | user-gated |
+|---|---|---|
+| A | small (one clamp + broadcaster gates + tables) + two soaks | archon-token HAR refresh |
+| B | medium-large: gate + scenario + 30+ staged-config pins + 4 benchmark arms + 3 soaks | rig deploy + burn-in observation |
+| C-set (registry + appliers + re-push) | medium; carries SET's two threading MAJORs | — |
+| C-aux (help + estimate + descriptions) | small | rig smoke |
+| D | medium + Tier 3 + 3 soaks | three live Voxy smokes |
+| E1 | **large** (three payloads + broadcast service + two platform adapters + tracker + six keys + full registration set — comparable to v0.10.0's C1) | — |
+| E2 | medium | **the two-client live gate** |
+| E3 | small-medium | the Folia session |
+| F | small + the gauntlet (~2.5 h measured for v0.10.0's 28) + the program review round | — |
+| G | medium ×2 lines (delta-port, much smaller than fresh — M1) | per-line Voxy smokes |
+| contingency | soak/tier re-runs per the catalog (v0.10.0 measured ~1.5 h of re-runs inside ~9 h of measurement) | — |
+
+C and E1 are the two rows that will absorb the variance; split C's PRs if C-set
+runs long.
+
+## 6. Implementation practices (program-wide — v0.10.0 §6, carried forward WITH the v1.0 losses restored)
+
+### 6.1 Progress tracking — `docs/planning/v0.11.0-progress.md`
+
+Created at program start, before stage A's first commit. This plan stays the
+frozen spec; the progress doc carries the living state. **A plan deviation is
+legal only as a PAIR: a dated decisions-log entry AND an edit to the overridden
+text — in THIS plan or in the SOURCE plan that carries it (v0.10.0's dominant pair
+case was source-plan edits; v1.0 bound only this doc) — with a back-pointer to the
+log entry.** Sections:
+
+- **Stage table**: one row per stage — status (pending / in-progress / PR #N in
+  review / merged / gate-passed), **planned/started/merged dates** (v0.10.0's
+  table had no dates — its retrospective needed git archaeology), PR links, gate
+  verdicts with evidence run-stamp dirs. The stage table is the single source of
+  stage status, updated in the merge commit itself (v0.10.0's went stale at its
+  final stages).
+- **Decisions log**: dated entries, logged when made, not batched; user decisions
+  as "user decision YYYY-MM-DD". Open points registered now: B's arm-c number,
+  E1's LSSApi-feed question, E1's tracker-ownership choice (R-5), the E1→E2
+  go/no-go, the A-D-vs-all-five release-shape alternative (§0).
+- **Review-round findings tables**: per-PR findings + dispositions land HERE in
+  the source plans' §-table shape, when the round closes (v1.0's skeleton had no
+  home for them).
+- **Manual-verification checklist** (review — five human-dependent gates): `[ ]`
+  rows for the rig deploys/observations (B, C), D's three live smokes, E2's
+  two-client gate, E3's Folia session, G's per-line Voxy smokes — each labeled
+  user-assisted where true, with an escalate-to-user rule when blocked >1 stage.
+- **Measurement ledger** (FULL v0.10.0 schema — v1.0 thinned it): per session —
+  date, box-state confirmation (`pgrep` clean + exclusivity), **arms/refs (pinned
+  commits), pooled numbers, verdict**; noise floor / A-A spread recorded before
+  B's acceptance number is read.
+- **Live-deploy log**: SHA, date, stage-era, **store outcome** (the rig runs
+  `lodStore=full` — registry drift still drops it), and the live `read_gate=`
+  diag line (R-5/R-8 config-era attribution).
+- **Flake/anomaly notes**: a dated POINTER list into CLAUDE.md's catalog (the
+  v0.10.0 section read "none yet" while eight-plus re-run events lived in other
+  sections); third sighting graduates to the catalog.
+
+### 6.2 Review discipline — grouped-lens rounds per implementation PR
+
+Every code-carrying stage PR gets a review round before merge: **grouped lenses,
+1-3 subagents scaled to stage risk** (stated honestly — v0.10.0 mandated three and
+ran one in 8 of 17 rounds as an unrecorded divergence; the budget rule is the real
+practice). Three for C, E1, E2; **D gets a destructive-operation/data-loss lens**
+(recursive deletion under a reflectively-resolved path — v1.0 gave it the default
+triple); B adds perf-gate methodology; E1 adds wire/format; E2 adds
+rendering/client-lifecycle (verified against the SeeU clone); F takes the
+program-level round (§2); G takes a single per-line porting pass. **Restored
+clauses (v1.0 dropped both): reviewers verify claims against real code/bytecode
+before reporting — unverified findings are marked PLAUSIBLE, not asserted; and
+where a fix is non-trivial, the original finder re-verifies the fix (continue the
+same agent).** Findings tables land in the progress doc when the round closes. The
+review-findings-vs-pinned-decisions rule stands: a finding contradicting a
+deliberate pin escalates to the user with the pin cited. Usage gating stands:
+above ~85% consumed, hold the round until reset.
+
+### 6.3 PR / branch / evidence discipline
+
+One PR per stage (C may split per §5; E lands as three), carrying its gate
+evidence in the description: benchmark numbers + pre-registered thresholds for B,
+golden/pin diffs for C, live-smoke transcripts for D/E2 (or their PENDING
+checklist entries). All PRs to main directly; merges use `--merge`. Each PR
+re-verifies the pins it touches BEFORE implementation — **and a collision found
+there is a §6.2 escalation before code is written** (the consequence clause v1.0
+dropped). Docs ride the PR that makes them true. Release steps follow CLAUDE.md's
+checklist verbatim — including the pitfalls §2's G row now names inline.
+
+### 6.4 Stage-boundary ritual
+
+At each stage merge: update the progress doc IN the merge commit; run the stage's
+own gate set (F owns the gauntlet — don't burn it early); confirm touched tiers
+green; log deviations. Before each soak/benchmark/rig session: box-exclusivity +
+`pgrep` sweep. On any red: **catalog triage first** (counter check → branch A/B →
+leftover-process sweep) before code investigation. Before G: full release
+pre-flight per line; every checklist item closed or explicitly user-waived.
+
+---
+
+## 7. Review round record (2026-08-12, five Opus agents: integration / fidelity / process / tri-version / sequencing)
+
+All five verdicts: **SOUND WITH FIXES — no resequencing**. v1.1 folds every
+finding; the highlights that changed the plan's shape:
+
+- **Convergent (4-5 lenses): E1's arming.** v1.0's E2-slip mitigation ("v0.11.0
+  goes without FARP") was false — E1 on main with `farPlayers: on` +
+  `farPlayersEnabled: true` ships a live position broadcast rendering nothing.
+  → E1 inert, defaults flipped at E2 (§2, §4). The A-D-as-v0.11.0 alternative is
+  recorded for the user (§0).
+- **Tri-version M1/M2: stage G's mechanic.** The fresh-re-port rationale expired
+  (the `-v0.10` branches ARE the released trees, at parity with main); a fresh cut
+  would re-derive the 1.21.11 line's ~90-file adaptation set. → delta-port, with
+  the support base cut from main at the D merge so FARP is never subtracted (§2 G).
+- **Convergent (3 lenses): R-3/R-5 were mis-scoped.** R-3 imposed an unspecified
+  FARP server behavior (now a two-sided amendment with the full-roster-on-any-prefs
+  obligation + rate bound); R-5's SET-re-push∩FARP "non-collision" was wrong (the
+  manager rebuild destroys session state — now a recorded requirement with an E1
+  decision point).
+- **Integration M1: registry clamp functions.** A `(min,max)` registry row would
+  turn `set … 0` into 1/K=1 — re-breaking DIRTY0 through the command surface one
+  stage after it was fixed (→ R-2's clamp-function rule).
+- **Process M1-M6: the §6 restorations** (verify-before-report/PLAUSIBLE,
+  finder-re-verifies, source-plan deviation pairs, the pre-G program round, the
+  checklist for the five user-gated verifications, the full ledger schema).
+- **Sequencing 11/16/17: measurement honesty** (the predecessor's ~1.6-day actual
+  vs 8-10-week estimate → §5 re-denominated; "byte-identical" → `gated==0`+laws;
+  pre-registered thresholds).
+- **Tri-version M4/M7 + integration M5/m7: verified factual corrections** (the
+  26.1 Voxy jar runs the NEW holder rung; five staging scripts not three; the C2S
+  prefs frame needs the sidecar guard; the echo-shape and bandwidth-identity pins
+  two stages collide with).
+
+Full findings live in the five reviewers' reports (session artifacts); their
+substance is folded above, so this table is the durable record.

--- a/docs/planning/v0.11.0-progress.md
+++ b/docs/planning/v0.11.0-progress.md
@@ -1,0 +1,63 @@
+# v0.11.0 program — progress (living doc)
+
+Created at program start, before stage A's first commit. The frozen spec is
+`v0.11.0-mega-plan.md` v1.1 (+ the five source plans it sequences). A plan
+deviation is legal only as a PAIR: a dated decisions-log entry here AND an edit to
+the overridden text (mega plan OR source plan) with a back-pointer.
+
+## Stage table
+
+Single source of stage status; updated in each stage's merge commit.
+
+| stage | content (short) | status | planned | started | merged | PR | gate verdicts / evidence |
+|---|---|---|---|---|---|---|---|
+| A | dirtyBroadcastIntervalSeconds: 0 (+ program prereqs) | pending | — | — | — | — | — |
+| B | disk-read gate + scenario + 5-script pins + rig deploy | pending | — | — | — | — | — |
+| C | /lsslod set + help + backfill estimate + descriptions | pending | — | — | — | — | — |
+| D | /lss reset + .lss cache relocation | pending | — | — | — | — | — |
+| E1 | far players wire+server+tracker (INERT) | pending | — | — | — | — | — |
+| E2 | far players renderer (+ defaults flipped ON) | pending | — | — | — | — | — |
+| E3 | far players polish + Folia session | pending | — | — | — | — | — |
+| F | docs + notes + pre-G program review + gauntlet | pending | — | — | — | — | — |
+| G | delta-ports onto -v0.10 branches + tri-release | pending | — | — | — | — | — |
+
+## Decisions log
+
+(dated entries, logged when made; user decisions as "user decision YYYY-MM-DD")
+
+- 2026-08-12 — Mega plan v1.0 written; five source plans committed (PR #121);
+  five-Opus review round run same day; v1.1 folds all findings (record in the
+  plan's §7). Open decision points registered: (1) the release-shape alternative
+  (A-D as v0.11.0, FARP as v0.12.0 — user call, costs nothing before E1); (2) B's
+  arm-c acceptance threshold (pre-registered in B's PR before the run); (3) E1's
+  tracker-ownership choice (R-5); (4) E1's LSSApi far-player-feed question;
+  (5) the E1→E2 go/no-go (user call).
+
+## Review-round findings tables
+
+(per-PR findings + dispositions land here when each round closes)
+
+## Manual-verification checklist (user-assisted items — escalate when blocked >1 stage)
+
+- [ ] A: archon-token HAR refresh (user) — prerequisite for every R-8 deploy
+- [ ] B: Modrinth rig deploy + burn-in observation (`read_gate=`, WARN, CPU)
+- [ ] C: rig smoke of `/lsslod set` + `help`
+- [ ] D: live smoke ×3 (real Voxy rebuild; no-Voxy server; old-cache adoption)
+- [ ] E2: two real GUI clients + dummy live gate (elytra, handoff, vanish/RCON)
+- [ ] E3: `run-folia` two-client session
+- [ ] G: per-line Voxy javap + reset smoke (26.1, 1.21.11)
+
+## Measurement ledger
+
+(per session: date, box-state confirmation (`pgrep` clean + exclusivity),
+arms/refs as pinned commits, pooled numbers, verdict; record the noise floor /
+A-A spread BEFORE reading B's acceptance number)
+
+## Live-deploy log
+
+(per deploy: SHA, date, stage-era, store outcome, live `read_gate=` diag line)
+
+## Flake/anomaly notes
+
+(dated POINTER list into CLAUDE.md's Known Test Flakes catalog; third sighting
+graduates to the catalog)


### PR DESCRIPTION
The v0.11.0 program plan: sequences PR #121's five feature plans into one A..G release program modeled on the v0.10.0 mega plan's discipline (cross-plan reconciliations with this-doc-wins amendments, per-stage merge gates, progress doc, review rounds, tri-release at the end, no tag before stage G).

v1.0 was reviewed same-day by five Opus subagents (integration / fidelity / process / tri-version / sequencing lenses) — all five verdicts SOUND WITH FIXES, no resequencing; v1.1 folds every finding. The §7 record carries the round summary; the biggest shape changes: E1 ships inert, stage G delta-ports onto the current -v0.10 support branches (base cut pre-FARP), and the effort table is re-denominated agent-executable vs user-gated.

Docs only — no code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)