### PR TITLE
docs: v0.11.0 mega plan v1.3 (user adjustments + final 3-Fable review)

### DIFF
--- a/docs/planning/v0.11.0-mega-plan.md
+++ b/docs/planning/v0.11.0-mega-plan.md
@@ -1,4 +1,30 @@
-# v0.11.0 mega plan — operator controls + client reset + far players + CPU gate (2026-08-12, v1.1)
+# v0.11.0 mega plan — operator controls + client reset + far players + CPU gate (2026-08-12, v1.3)
+
+**v1.2 (same day, user direction):** four adjustments — (1) `lodDistanceChunks`
+default 512 → **300** (rides stage A); (2) a **Modrinth dev-deploy + manual-testing
+pause** between the 26.2 work (F) and the backports (G), with the rig's config
+refreshed to the new defaults; (3) R-7 re-scoped: **FARP ships on the 26.1 line
+too** (user direction — v1.1 had excluded it from both support lines); 1.21.11
+stays excluded for v0.11.0; (4) new **R-10: mounted-entity rendering** (horses,
+pigs, minecarts, boats under far players, with a graceful-degrade ladder for
+modded/unresolvable mounts). Far-player defaults confirmed: server `farPlayers`
+default **`on`** at E2 for fresh AND upgrading installs (user decision 2026-08-12
+— the deliberate asymmetry vs the lodStore split-default philosophy is recorded;
+the server-authoritative privacy controls are the counterweight).
+
+**v1.3 (same day): final three-Fable review round of the whole program** (two
+whole-program lenses + one R-10 deep-dive that decompiled the MC 26.2/26.1.2 jars
+and read SeeU's full renderer — record in §7). All verdicts READY/SOUND WITH
+FIXES, all folded: the v1.2 revision seams cleaned (the §0 release-shape sentence
+below and the E2-slip fallbacks had kept the v1.1 scope), **R-10 rewritten around
+the SeeU-proven rider-at-own-wire-position model** (deletes the passenger-index
+wire gap and the attachment-offset math outright; seated pose via an
+edge-triggered persistent ride link; mount motion driven by the rider's velocity
+hint), the mounted LIVE check moved to E3 where the rendering ships, the Modrinth
+pause given its test list + found-bug loop, and GATE's resolved-K echo ordered
+AFTER store attachment (the echo currently prints before the store exists — the
+natural wrong implementation would echo K computed store-less on every
+store-armed server).
 
 One release plan combining five reviewed plans into a single sequenced program:
 
@@ -22,9 +48,11 @@ fidelity / process / tri-version / sequencing lenses — full record in §7).
 Headline outcomes: **E1 ships inert** (`farPlayers` compiled default `off`, client
 bit unarmed until E2 — all five lenses converged on the v1.0 E2-slip story being
 false); **stage G becomes a delta-port onto the current `-v0.10` support branches
-with the support base cut from main at the D merge** (the fresh-re-port rationale
-expired at v0.10.0 — the branches are one docs commit behind main, and cutting the
-base pre-E1 means FARP never needs subtracting from six pinned shared artifacts);
+with the support base cut from main at the D merge** *(superseded for the 26.1
+line by v1.2 — its base is main at the F merge; D-merge applies to 1.21.11)* (the
+fresh-re-port rationale expired at v0.10.0 — the branches are one docs commit
+behind main, and cutting the base pre-E1 means FARP never needs subtracting from
+six pinned shared artifacts);
 R-2/R-3/R-5 were re-scoped as the two-sided amendments they actually are; the §6
 practices lost in v1.0's compression were restored from the v0.10.0 record; and §5
 is re-denominated as agent-executable vs user-gated work (the predecessor's actual
@@ -35,20 +63,21 @@ estimate inherit its error).
 off switch, the disk-read CPU gate (store-conditional auto), the runtime settings
 commands + help + backfill estimate + new package descriptions, the client
 `/lss reset` + `.lss/` cache relocation, and far-player proxies (capability-gated,
-LSS's first client-side renderer; ARMED only at E2). The 26.1 and 1.21.11 support
-lines get **everything except FARP** via stage G's delta-port — tri-release at the
-end, no tag pushed before G. **Unlike v0.10.0 there is NO protocol bump**: every
+LSS's first client-side renderer; ARMED only at E2). **The 26.1 support line gets
+ALL FIVE features; the 1.21.11 line gets everything except FARP** (R-7 v1.2) via
+stage G's delta-ports — tri-release at the end, no tag pushed before G. **Unlike
+v0.10.0 there is NO protocol bump**: every
 stage is additive and default-safe (FARP rides a masked capability bit + new
 `lss:*` channels old clients silently discard), so there is **no integration
 branch** — every stage PRs to main directly and main stays releasable throughout.
 
 **Recorded alternative (user decision pending, raised by the review round):** ship
-A–D as v0.11.0 (a perfectly symmetric tri-release — the support lines get the same
-four features) and FARP as a 26.2-only v0.12.0. This dissolves the E2-slip risk and
-gives the first LSS renderer its own release window; the cost is far players
-waiting one release. This plan keeps all five in v0.11.0 per the original
-direction, with E1-inert as the safety; flipping to the alternative later costs
-nothing before E1 starts.
+A–D as v0.11.0 (a perfectly symmetric tri-release — all three lines get the same
+four features) and FARP as a **26.2 + 26.1** v0.12.0 (scope per R-7 v1.2). This
+dissolves the E2-slip risk and gives the first LSS renderer its own release
+window; the cost is far players waiting one release. This plan keeps all five in
+v0.11.0 per the original direction, with E1-inert as the safety; flipping to the
+alternative later costs nothing before E1 starts.
 
 ---
 
@@ -98,11 +127,20 @@ stage C lands after A and B:
 
 - **`maxConcurrentDiskReads`**: this amends GATE — `DiskReadGate`'s capacity
   becomes a volatile read at `tryAcquire()` (B ships it that way; C makes it
-  mutable), with `updateCapacity(...)` living **on the reader**, which already owns
-  both facts the store-conditional resolver needs (`store` and `threadCount` —
-  review: the service retains neither, and store-attachment must be the
-  post-degrade `lodStore != null`, never `config.lodStore != "off"`, or half-pool K
+  mutable), with `updateCapacity(...)` living **on the reader**, which owns both
+  facts the store-conditional resolver needs (`store` and `threadCount` — the
+  service holds the store as a field too, but NOT the resolved thread count,
+  which is a ctor local on both platforms; store-attachment must be the
+  post-degrade `store != null`, never `config.lodStore != "off"`, or half-pool K
   re-arms on exactly the store-less servers GATE's convergent MAJOR carved out).
+  **Echo ordering (v1.3, review MAJOR)**: GATE's resolved-K echo requires the
+  `effectiveConfigEcho` call site to MOVE BELOW store attachment on both
+  platforms — today the echo logs ~70 lines before the store is created, so the
+  natural implementation would echo K computed store-less on every store-armed
+  server, in a script-consumed contract (the same bug class the echo's
+  "deliberately AFTER the zstd probe" comment exists to prevent). The
+  `ChannelAccessorContractTest` shape pin and both exact-string pins update to
+  the new position in B's PR.
   **Lowering semantics** (specified, mirroring SET's gen-cap rule): in-use may
   transiently exceed the new K until permits drain — new acquisitions refuse, the
   counter never goes negative, no permit sticks, and the pegged WARN does not fire
@@ -193,10 +231,20 @@ self-verify its no-op pin; FARP's soak-client property gate
 at E1 (its review demanded Phase-A self-verifiability) and re-asserted by the
 stage-F gauntlet's counters-stay-zero check.
 
-### R-7 — Re-port scope: far players is 26.2-only in v0.11.0
+### R-7 — Re-port scope: far players ships on 26.2 AND 26.1; 1.21.11 excluded (v1.2 — user direction)
 
-The support lines receive DIRTY0 + GATE + SET + RESET, **not FARP**. Obligations
-this decision creates (review — v1.0 asserted these; they are now gates):
+The 26.1 line receives ALL FIVE features (user decision 2026-08-12 — the 26.1.2
+rendering API generation is near-identical to 26.2's, the v0.10.0 D3 record shows
+the 26.1 source delta was ~8 files, and SeeU itself ships 26.1.2 releases, proving
+the renderer approach ports). The 1.21.11 line receives DIRTY0 + GATE + SET +
+RESET, **not FARP**, for v0.11.0 (SeeU's own 1.21.x releases prove feasibility —
+recorded as a candidate v0.11.x/v0.12.0 follow-up, not a permanent exclusion).
+Consequence for stage G's bases: the 26.1 delta-port takes main at the F merge
+(full tree); the 1.21.11 delta-port takes main at the D merge (pre-FARP, so FARP
+is never subtracted). G gains a 26.1 renderer verification (the E2 live-gate
+script re-run once on the 26.1 rig).
+
+Obligations this scope creates (review — v1.0 asserted these; they are gates):
 
 - **The FARP wire is MC-version-neutral from E1** (identity strings via the v20
   dictionary pattern for equipment/vehicle types — never numeric registry ids).
@@ -208,11 +256,24 @@ this decision creates (review — v1.0 asserted these; they are now gates):
   populations that never registered the channel. Version-mix cell recorded: 26.2
   client + support-line server → capability bit masked (verified:
   `HandshakeGate:151` masks) AND prefs send contained → silence.
-- **Privacy asymmetry documented**: a support-line client on a 26.2 v0.11.0
+- **Privacy asymmetry documented**: a 1.21.11 client on a FARP-carrying v0.11.0
   server is a far-player TARGET with no client-side `shareSelf` (the pref exists
-  only in the 26.2 client config); its protections are the server-side mode /
-  exclude list / permission node. Goes in the README privacy note + release
+  only in FARP-carrying client configs); its protections are the server-side mode
+  / exclude list / permission node. Goes in the README privacy note + release
   notes.
+- **Cross-MC sessions (Via) carry far players BY DESIGN — between FARP-carrying
+  lines** (26.2 ↔ 26.1 for v0.11.0; a 1.21.11 client carries no FARP code, so it
+  is target-only): the wire-neutrality obligation above is exactly what makes a
+  FARP-carrying client on one MC version render far players from a v0.11.0
+  server on another (Via translates the MC protocol; the `lss:*` plugin channels
+  pass through; identity strings resolve against the client's own registries).
+  Same-LSS-version cross-MC sessions never select a legacy dialect, so the C5 Via
+  guard does not fire. Unresolvable identities degrade per the FARP fallback
+  rules — a missing equipment piece renders bare, a missing mount renders the
+  player unmounted (R-10; measured: 26.2 adds exactly ONE entity type over
+  26.1.2, so the cross-version mount space is nearly identity). Note: R-7 v1.2
+  also supersedes FARP §8's "support-line backports likely skip Phase B" for the
+  26.1 line (the §6.1 pair — the source-plan pointer edit rides E1's PR).
 - **RESET vs per-line Voxy is a stage-G GATE, not an assumption** (v1.0's
   "0.2.11-era, old rung" claim was wrong for the 26.1 line — the locally available
   0.2.18-beta-26.1.2 jar exports the NEW `IVoxyRenderSystemHolder`; the README
@@ -256,6 +317,24 @@ archon token; and the rig auto-pauses when empty, freezing every counter):**
   dummy is a far-player TARGET only) — a user-scheduling constraint, on the
   checklist. The "SoakPlayer dummy rig" gets a short doc section (it is currently
   folklore from the 2026-08-12 session, not documentation).
+- **The pre-G Modrinth pause (v1.2, user direction; specified v1.3)**: after F's
+  gates pass, the dev build (F-merge SHA) deploys to the Modrinth test server and
+  its `lss-server-config.json` is **rewritten to the new v0.11.0 defaults** — the
+  standing config predates two default rounds (legacy `bytesPerSecondLimit*` byte
+  keys, `lodDistanceChunks: 256`) and must not mask the shipped experience; only
+  genuinely rig-specific keys survive (`lodStoreMaxMB: 10240`, `lodStore: full`).
+  The program then PAUSES for user manual testing; G starts on explicit sign-off
+  (checklist). **Test content** (the user's list, agent-prepared): warm-join LOD
+  flow at the new defaults (store serves + `read_gate=` under real play),
+  `/lsslod set` round-trips + `help`, `/lss reset` (LODs visibly rebuild),
+  backfill status with the remaining estimate, `/lsslod diag` line sanity — and
+  far players ONLY IF a second player joins (one player cannot observe proxies;
+  the rig auto-pauses empty — E2's rig session is the primary FARP evidence, this
+  pause is defense-in-depth). **Found-bug loop**: a fix re-opens the owning
+  stage's gates (its tier set + its soaks), redeploys, and re-enters the pause;
+  **stage G's 26.1 base re-anchors to main at the last pre-G merge** (the "F
+  merge" pin is a floor, not a fixture), and the F gauntlet re-runs only if the
+  fix touched server serve paths (the stage-owner's call, logged).
 
 ### R-9 — FARP's privacy keys join the SET registry at E1 (new; resolves an unrecorded scope decision)
 
@@ -266,21 +345,94 @@ registry's one string-typed row (mode) — a real but small registry extension.
 §3.3. The registry/help/tab-completion goldens are therefore touched twice
 (C and E1) — accepted, R-1's accretion rule covers it.
 
+### R-10 — Mounted-entity rendering (v1.2, user direction; REWRITTEN v1.3 after the dedicated review — amends FARP §3.1 (wire), §3.3 (renderer + one sentence corrected), §7-C)
+
+Far players mounted on entities render WITH their mount — horses, pigs, camels,
+striders, minecarts, boats, and in general **any vanilla-registered EntityType**.
+Feasibility is SeeU-proven in the strongest sense (review, verified in their
+renderer): SeeU's proxies and vehicles are **never level-added** — constructed
+with a level reference only and rendered via `EntityRenderDispatcher.extractEntity`
++ `submit` at explicit camera-relative coordinates. R-10's render-only model is
+their shipped mechanism, not speculation.
+
+- **Positioning model (v1.3 — the SeeU model, replacing v1.2's attachment-offset
+  spec):** the rider renders at the RIDER's OWN interpolated wire position — the
+  server-side seated position already encodes the seat offset, and rider/mount
+  stay glued because both interpolate from snapshots taken together. No passenger
+  index on the wire, no `getPassengerAttachmentPoint` math (protected,
+  seat-index-dependent — the v1.2 spec was unimplementable as written), no
+  fixed-offset fallback rung. **Multi-passenger dedup reduces to vehicle-RENDER
+  dedup**: two riders sharing a vehicle UUID render the vehicle once; each rider
+  renders at their own position.
+- **Server**: the snapshot carries the player's direct `getVehicle()` — entity
+  type as an **identity string via the dictionary** (R-7 wire-neutrality; never a
+  numeric id), vehicle UUID, position/yaw/pitch. Vehicle stacks collapse to the
+  direct mount; a vehicle that is itself a player is dropped to unmounted (never
+  recurse). **Mount/dismount always forces the player into the update payload**
+  — delta suppression is defined over the whole snapshot (position + pose flags
+  + vehicle UUID/type + equipment hash), never position alone (review: a
+  quantized-position-unchanged dismount would otherwise render a stale mount
+  indefinitely).
+- **Seated pose (v1.3)**: an **edge-triggered persistent ride link** between the
+  two render-only instances — `startRiding` once on mount change, `stopRiding` on
+  dismount, never per-frame (the hack FARP §3.3 rejects is SeeU's per-frame
+  eject/re-seat, NOT ride links; §3.3's sentence is amended accordingly). The
+  ride link is what makes `isPassenger()` true at render-state extraction, which
+  is the only vanilla path to seated legs (bytecode-verified:
+  `HumanoidMobRenderer.extractRenderState` → `HumanoidRenderState.isPassenger`).
+- **Mount motion (v1.3)**: the mount is driven by the RIDER's velocity hint
+  (they share a velocity by definition) — otherwise the rider extrapolates ~a
+  window ahead while the mount lerps a window behind and visibly separates at
+  horse/boat speeds, the exact artifact class the feature exists to avoid.
+- **Graceful-degrade ladder** (each rung contained, per-type once-latched
+  logging, never a crash — the user's explicit requirement for modded mounts):
+  1. Identity unresolvable on this client (modded/other-MC-version entity) →
+     render the player UNMOUNTED at their own snapshot position (always
+     well-defined — the player position rides the wire independently).
+     **Resolution MUST use `getOptional`** — `BuiltInRegistries.ENTITY_TYPE` is a
+     DefaultedRegistry, and a plain lookup returns PIG for unknown ids (SeeU has
+     exactly this bug; their null-check is dead code). One NON-injected Tier 1
+     pin against the real registry, so injected-resolver tests cannot mask it.
+  2. Type resolves but `EntityType.create(...)` returns NULL (non-factory types,
+     some modded) or creation/rendering THROWS → per-type once-latch → unmounted,
+     warn once naming the type. A succeeding modded ctor's side effects are
+     accepted residual risk; the namespace gate (vanilla-only mounts) is the
+     recorded fallback lever if it ever bites.
+  3. Ride-link establishment fails → render mounted-position but standing pose
+     (never floating-sit).
+- **Vehicle-instance lifecycle** (review): evicted when no rider references the
+  UUID in the current update generation; invalidated on level change (the
+  instance pins the old ClientLevel), dimension change, and roster-epoch clear;
+  recreated on same-UUID-different-type.
+- **Wire cost**: the vehicle block is optional-per-player (absent for unmounted
+  players — the common case; ~20 bytes + UUID per mounted player at ≤2 Hz);
+  the dictionary amortizes type strings.
+- **Phasing**: the wire fields + server snapshot land at E1 — the honest
+  rationale (review) is "freeze the shape before anything can ARM it" (LSS has no
+  payload-local versioning, so a post-arming addition would need a dialect rung;
+  the insurance is nearly free). Client rendering lands at E3. **The E2 live
+  gate's mounted scenario asserts the PRE-rendering contract** — a mounted target
+  renders as an unmounted player, no crash (rung-1 behavior); **the real mounted
+  LIVE check is an E3 gate** (review — v1.2 had LSS's first mount renderer
+  shipping unwitnessed): a short test-rig session with a mounted target past
+  tracking range, alongside E3's Folia session. E3's Tier 1 pins cover the ladder
+  via injected resolvers PLUS the rung-1 real-registry pin.
+
 ---
 
 ## 2. Master landing order
 
 | stage | content | source spec | gates to merge |
 |---|---|---|---|
-| **A** | `dirtyBroadcastIntervalSeconds: 0` = sends off (drain + fan-out + clears keep running at the 10 s fallback cadence). **Program prerequisites ride along: archon-token refresh (R-8), progress doc created** | DIRTY0 | Tier 1 both platforms (all three broadcaster pins — zero-sends drain, exact fallback tick, both-way flips — clamp tables, `LSSGameTests` bounds), Tier 2 green; one `dirty-broadcast` + one `paper-dirty-falling-block` soak (A touches both broadcasters' tick shape; minutes of cost, prevents an A-caused red being mis-triaged environmental at F); clamp-audit erratum |
-| **B** | Disk-read concurrency gate (store-conditional AUTO, volatile-capacity K per R-2, `saturated`-flavor bounce, `disk.gated`) + `disk-read-gate` soak scenario + ALL harness pins (26 scenario configs, gametest run dirs, benchmark.sh, **all FIVE `diskReaderThreads`-staging scripts: profile_disk_read, compress_gate, backfill_profile, benchmark_compare, store_gate** — review; store_gate is the store-armed A/B where AUTO actually binds) + the A7-catalog "+K" amendment + CLAUDE.md scenario-count update + **live deploy to the Modrinth rig post-merge (R-8)** | GATE | Tier 1+2; `disk-read-gate` soak green (duration sized for DEGRADED WSL2 IO — K=1 at 107-131 ms/read serializes the annulus to ~4-5 min; budget it or run threads:4/K:2); `fresh-backfill` + `disk-saturation` under no-op pins: **`disk.gated == 0` + all laws green + no new violations** (v1.0's "byte-identical" was untestable — soak runs are never byte-comparable); benchmark arms a–d with **arm c's acceptance threshold PRE-REGISTERED in the PR description before the run** (fallback pre-agreed: AUTO = pool even when store-armed); the controlled local rig A/B (R-8); `ChannelAccessorContractTest` echo-shape pin updated (R-1.2) |
+| **A** | `dirtyBroadcastIntervalSeconds: 0` = sends off (drain + fan-out + clears keep running at the 10 s fallback cadence) + **`lodDistanceChunks` default 512 → 300** (v1.2, user decision — default pins both platforms incl. `PaperCommandsTest`'s `lodDist=512` diag golden, AUTO tscache derivation follows automatically, CLAUDE.md's 512 references + the adaptive-cadence "1/16 of the default-512 disc" text + `README.md:54`, test-server.sh knob comment, config-audit erratum). **Baseline note (v1.3, review — the v1.2 "baselines untouched" claim was false on two surfaces): `benchmark.sh`'s neutral staging pins NO distance and rides the default — stage A adds a distance pin there so cross-era benchmark comparability survives; `store-offline-mutate` is the one soak config without a pin (harmless — no client traffic — recorded).** **Program prerequisites ride along: archon-token refresh (R-8), progress doc created** | DIRTY0 + v1.2 | Tier 1 both platforms (all three broadcaster pins — zero-sends drain, exact fallback tick, both-way flips — clamp tables, `LSSGameTests` bounds, the default-value pins for 300), Tier 2 green; one `dirty-broadcast` + one `paper-dirty-falling-block` soak (A touches both broadcasters' tick shape; minutes of cost, prevents an A-caused red being mis-triaged environmental at F); clamp-audit erratum |
+| **B** | Disk-read concurrency gate (store-conditional AUTO, volatile-capacity K per R-2, `saturated`-flavor bounce, `disk.gated`) + `disk-read-gate` soak scenario + ALL harness pins (26 scenario configs, gametest run dirs, benchmark.sh, **all FIVE `diskReaderThreads`-staging scripts: profile_disk_read, compress_gate, backfill_profile, benchmark_compare, store_gate** — review; store_gate is the store-armed A/B where AUTO actually binds) + the A7-catalog "+K" amendment + CLAUDE.md scenario-count update + **live deploy to the Modrinth rig post-merge (R-8)** | GATE | Tier 1+2; `disk-read-gate` soak green (**sizing decided, v1.3: keep GATE's threads:2/K:1 shape and budget the duration for degraded WSL2 IO** — K=1 at 107-131 ms/read serializes the annulus to ~4-5 min + the ≥25 s converged tail; the staged numbers get pinned in the checker registries and must not drift after); `fresh-backfill` + `disk-saturation` under no-op pins: **`disk.gated == 0` + all laws green + no new violations** (v1.0's "byte-identical" was untestable — soak runs are never byte-comparable); benchmark arms a–d with **arm c's acceptance threshold PRE-REGISTERED in the PR description before the run** (fallback pre-agreed: AUTO = pool even when store-armed); the controlled local rig A/B (R-8); `ChannelAccessorContractTest` echo-shape pin updated (R-1.2) |
 | **C** | `/lsslod set` (registry incl. R-2's two keys, per-key clamp functions) + tick-poll appliers + SessionConfig re-push (v20-only, pump-side) + `/lsslod help` + backfill remaining-estimate + package descriptions + the R-5 log-on-change reconciliation | SET as amended by R-2/R-5 | Tier 1 **both platforms** (registry incl. the 0-round-trip pins, limiter/gen-cap/sweep/echo pins, `genSlotCap` volatile pin, **the Paper pump-side re-push ordering pin — a registered-but-flip-pending player is NOT pushed** (SET's second threading MAJOR, dropped in v1.0), `PaperCommandsTest` goldens + tab completion), Tier 2 (CommandGameTests dispatches + the re-push gametest with run-dir config restore), **one `fresh-backfill` soak** (SET's own required gate — C mutates the limiter, gen caps, admission caps, and sweep radius on the live tick path; v1.0 dropped it), `release_check.py` green, live smoke on the rig post-merge (R-8 checklist) |
 | **D** | `/lss reset` (decode-drain await → Voxy teardown/wipe/rebuild via `getStorageBasePath` → `flushCache`; confirm-gated no-manager fallback) + `config/lss/cache` → `.lss/cache` relocation + harness both-roots STAGING AND COLLECTION (incl. B's new scenario) | RESET | Tier 1 (VoxyCompat reset ladder incl. both throw paths, coordinator ordering, `resolveCacheRoot` branches, wipe containment, **the confirm-token pin**), **Tier 2** + Tier 3; soaks: `clearcache-mid-session` AND **`fresh-backfill` then `cold-restart-resync`** (the decisive both-roots proof — collection at `soak.sh:545-548` and restore at `:360-362` are the dangerous sites; clearcache alone only exercises the clear path); live smokes ×3 (real Voxy 0.2.18 LODs-visibly-rebuild; a no-Voxy server; an existing `config/lss/cache` proving adoption) |
-| **E1** | Far players phase A, **INERT**: `farPlayers` compiled default **`off`** + client capability bit NOT sent (both flipped at E2 — the v0.10.0 transport-yield default-FALSE pattern; all five review lenses converged on this). Wire (version-neutral per R-7, C2S guard per R-7) + prefs/v18-rung lifecycle + R-3's server-side full-roster-on-prefs + epoch'd roster/updates + broadcast service (tiers, filters, privacy, dedicated lane) + client tracker + debug HUD + R-3's RESET seam filled + R-5's tracker-ownership decision + R-9 registry rows + VSS permission-node rewrite | FARP §3.1-3.2, §7-A as amended | Tier 1 (codec parity twins, filter ladder, roster-epoch resync incl. the R-3 server pin + rate bound, prefs lifecycle, **the soak/benchmark property-gate pin**, the R-5 manager-rebuild pin), Tier 2 server-egress crafted-handshake gametests, **one Paper soak** (the pump-side prefs marks + quit-race drop are Paper-only code paths otherwise ungated until F), `FarPlayers:` diag + exporter + checker + `soak_report` bandwidth-audit registrations same-commit (R-1/R-6), envelope pin for the new channels, clamp tables, `release_check.py` green |
-| **E2** | Far players phase B: renderer (proxy entities, declared-cadence lerp + velocity extrapolation, event-triggered handoff with SeeU's conjuncts, NO glow, NO fog mixin), Sodium rows; **defaults flipped ON** (server `on`, client bit armed) | FARP §3.3, §7-B | Tier 1 tracker math; **live gate on the test rig — two real GUI clients + the dummy** (elytra extrapolation, tracking-boundary handoff, vanish/spectator via RCON) — rendering has no test tier, the live gate is THE gate (user-scheduled, R-8 checklist) |
-| **E3** | Far players phase C: vehicles (pose-rendered), coexist default (`isModLoaded("seeu")` off + INFO + Sodium tooltip), README privacy note (incl. R-7's asymmetry), exporter/soak-report fields final, **the `run-folia` two-client session** (FARP's own Folia gate — the new cross-region equipment/pose read class; v1.0 dropped it) | FARP §7-C | Tier 1 additions; full-suite soak with counters-stay-zero (R-6); the Folia session (user-assisted, checklist) |
-| **F** | Docs consolidation (CLAUDE.md sweep, READMEs incl. version table rows, clamp-audit errata), release notes all three lines + **three `release-tag-v0.11.0*.txt` drafts + the short Modrinth changelog variant** (three lines carry DIFFERENT notes — FARP main-only — and Modrinth is hand-fix-only), **the pre-G whole-program review round** (scope: the full A..E3 diff — the v0.10.0 pre-D3 round found 5 MAJORs; v1.0 had no program-level round at all), pre-flight | this doc §3.2 | **full `soak.sh all` on all three platforms** (count NOT frozen — B made it 20 Fabric), Tier 3 green **discharged against the last code-carrying commit** (docs-only PRs skip CI — cite E3's runs), `release_check.py` OK, `CI=true` pre-flight build, the review round's findings dispositioned |
-| **G** | **Delta-port onto the current support branches** (review — the fresh-re-port rationale expired: the `-v0.10` branches ARE the released v0.10.0 trees, current to one docs commit): cut `support/mc<ver>-v0.11` from `support/mc<ver>-v0.10`, then merge/cherry-pick **main at the D merge** (pre-E1, so FARP never needs subtracting from the six R-1 artifacts) + the non-FARP parts of F. Fresh re-port survives only as the documented escape hatch with its cost stated (the 90-file 1.21.11 adaptation set would be re-derived). Per-line: R-7's Voxy-rung javap gate, the gotcha catalogue, staging/smoke, **archive the stale v0.8.1-era `support/mc*` branches** (recorded convention gap). Then tri-release | R-7 + this row | per-line pre-flights green; R-7 gates discharged; tags pushed ONLY here, `--cleanup=verbatim`, annotation verified via `git for-each-ref` BEFORE push, rendered notes verified on GitHub AND Modrinth after; never re-run a partially published release; no throwaway `v*` tags ever |
+| **E1** | Far players phase A, **INERT**: `farPlayers` compiled default **`off`** + client capability bit NOT sent (both flipped at E2 — the v0.10.0 transport-yield default-FALSE pattern; all five review lenses converged on this). Wire (version-neutral per R-7, C2S guard per R-7, **R-10's vehicle block: type identity + UUID + pos/yaw/pitch — no seat index, per the v1.3 positioning model**) + prefs/v18-rung lifecycle + R-3's server-side full-roster-on-prefs + epoch'd roster/updates + broadcast service (tiers, filters, privacy, dedicated lane) + client tracker + debug HUD + R-3's RESET seam filled + R-5's tracker-ownership decision + R-9 registry rows + VSS permission-node rewrite. **Prerequisite: vendor the SeeU 0.7.3 clone under `research/seeu/` with the commit pinned** (review — FARP's normative file:line citations currently point at an ephemeral session scratchpad; the `research/voxy` precedent) | FARP §3.1-3.2, §7-A as amended | Tier 1 (codec parity twins, filter ladder, roster-epoch resync incl. the R-3 server pin + rate bound, prefs lifecycle, **the soak/benchmark property-gate pin**, the R-5 manager-rebuild pin), Tier 2 server-egress crafted-handshake gametests, **one Paper soak (baseline-neutrality only — review: the property gate keeps soak clients unsubscribed, so the pump-side prefs/quit-race paths are covered by the Tier 1 seams and first exercised live at E3's Folia session, not by this soak)**, `FarPlayers:` diag + exporter + checker + `soak_report` bandwidth-audit registrations same-commit (R-1/R-6), envelope pin for the new channels, clamp tables, `release_check.py` green |
+| **E2** | Far players phase B: renderer (proxy entities, declared-cadence lerp + velocity extrapolation, event-triggered handoff with SeeU's conjuncts, NO glow, NO fog mixin), Sodium rows; **defaults flipped ON** (server `on` for fresh AND upgrading installs — user decision 2026-08-12; client bit armed — E1's inert shipping deliberately overrides FARP §3.3's "active from Phase A" text, mechanism: client capability composition compiled bit-off until this stage). **Owns the SoakPlayer-dummy-rig doc section** (§6.3 docs-ride rule) | FARP §3.3, §7-B | Tier 1 tracker math; **live gate on the test rig — two real GUI clients + the dummy** (elytra extrapolation, tracking-boundary handoff, vanish/spectator via RCON, **the R-10 PRE-rendering mounted scenario: mounted target renders unmounted, no crash**) — rendering has no test tier, the live gate is THE gate (user-scheduled, R-8 checklist) |
+| **E3** | Far players phase C: **mounted-entity rendering per R-10 v1.3** (rider-at-own-position, persistent ride link, rider-velocity mount motion, the degrade ladder, vehicle lifecycle), coexist default (`isModLoaded("seeu")` off + INFO + Sodium tooltip), README privacy note (incl. R-7's asymmetry), exporter/soak-report fields final, **the `run-folia` two-client session** (FARP's own Folia gate — the new cross-region equipment/pose read class; v1.0 dropped it) | FARP §7-C as amended by R-10 | Tier 1 additions incl. the R-10 ladder pins (injected resolvers + the rung-1 REAL-registry pin); **the mounted LIVE check on the test rig** (review — the stage that ships the mount renderer carries its live evidence); full-suite soak with counters-stay-zero (R-6); the Folia session (user-assisted, checklist) |
+| **F** | Docs consolidation (CLAUDE.md sweep, READMEs incl. version table rows, clamp-audit errata), release notes all three lines + **three `release-tag-v0.11.0*.txt` drafts + the short Modrinth changelog variant** (three lines carry DIFFERENT notes — FARP on 26.2+26.1 only — and Modrinth is hand-fix-only), **the pre-G whole-program review round** (scope: the full A..E3 diff — the v0.10.0 pre-D3 round found 5 MAJORs; v1.0 had no program-level round at all), pre-flight. **Then (v1.2, user direction): deploy the dev build to the Modrinth test server, refresh its config to the new v0.11.0 defaults (R-8), and PAUSE for user manual testing** | this doc §3.2 | **full `soak.sh all` on all three platforms** (count NOT frozen — B made it 20 Fabric), Tier 3 green **discharged against the last code-carrying commit** (docs-only PRs skip CI — cite E3's runs), `release_check.py` OK, `CI=true` pre-flight build, the review round's findings dispositioned; **G does not start until the user signs off the Modrinth manual-testing pause** (checklist item) |
+| **G** | **Delta-port onto the current support branches** (review — the fresh-re-port rationale expired: the `-v0.10` branches ARE the released v0.10.0 trees, current to one docs commit): cut `support/mc<ver>-v0.11` from `support/mc<ver>-v0.10`, then merge/cherry-pick the per-line base — **26.1: main at the F merge (full tree incl. FARP, per R-7 v1.2); 1.21.11: main at the D merge** (pre-E1, so FARP never needs subtracting from the six R-1 artifacts) + the non-FARP parts of F. Fresh re-port survives only as the documented escape hatch with its cost stated (the 90-file 1.21.11 adaptation set would be re-derived). **F-commit discipline serving this row (v1.3, review): F keeps FARP and non-FARP content in separate commits, and pre-G-review fixes to A–D code land as their own PRs — otherwise "the non-FARP parts of F" is not commit-well-defined for the 1.21.11 port.** Per-line: R-7's Voxy-rung javap gate, **the 26.1 renderer verification (the E2 live-gate script once on the 26.1 rig)**, the gotcha catalogue, staging/smoke, **archive the stale v0.8.1-era `support/mc*` branches** (recorded convention gap). Then tri-release | R-7 + this row | per-line pre-flights green; R-7 gates discharged; tags pushed ONLY here, `--cleanup=verbatim`, annotation verified via `git for-each-ref` BEFORE push, rendered notes verified on GitHub AND Modrinth after; never re-run a partially published release; no throwaway `v*` tags ever |
 
 **Ordering rationale, compressed:** A first — smallest, and it exercises the exact
 config/clamp/test-table discipline every later stage repeats. B second — early
@@ -327,18 +479,21 @@ first.
 - Every pin touched by two stages (echo shape, formatter goldens, exporter
   literal, registry goldens) is re-verified at each touching stage.
 
-### 3.2 Release notes (v0.11.0; format per CLAUDE.md; three lines, FARP main-only)
+### 3.2 Release notes (v0.11.0; format per CLAUDE.md; three lines, FARP on 26.2 + 26.1)
 
-- **New Features**: far players (26.2 line only, explicitly; privacy modes + the
-  2048 default + R-7's support-line-targets asymmetry; **SeeU credited as MIT
-  prior art** — an attribution obligation from FARP §5, dropped in v1.0);
-  `/lss reset`; `/lsslod set` + `help` (legacy-dialect distance-shrink wording per
-  SET: "legacy clients keep re-asking beyond the new distance until rejoin");
-  backfill remaining-estimate.
-- **Configuration**: `dirtyBroadcastIntervalSeconds: 0` semantics incl. the
-  rejoin-only refresh tradeoff (DIRTY0's required wording); `maxConcurrentDiskReads`
-  (auto; store-conditional; the CPU-vs-bandwidth separation sentence); FARP's
-  server keys (main line); the `.lss/` cache location for fresh installs.
+- **New Features**: far players (26.2 + 26.1 lines, explicitly — 1.21.11 gets it
+  later; mounted-entity rendering per R-10; privacy modes + the 2048 default +
+  R-7's non-FARP-client-targets asymmetry; **SeeU credited as MIT prior art** —
+  an attribution obligation from FARP §5, dropped in v1.0); `/lss reset`;
+  `/lsslod set` + `help` (legacy-dialect distance-shrink wording per SET: "legacy
+  clients keep re-asking beyond the new distance until rejoin"); backfill
+  remaining-estimate.
+- **Configuration**: **`lodDistanceChunks` default 512 → 300** (v1.2 user
+  decision; AUTO timestamp-cache sizing follows it automatically);
+  `dirtyBroadcastIntervalSeconds: 0` semantics incl. the rejoin-only refresh
+  tradeoff (DIRTY0's required wording); `maxConcurrentDiskReads` (auto;
+  store-conditional; the CPU-vs-bandwidth separation sentence); FARP's server
+  keys (FARP-carrying lines); the `.lss/` cache location for fresh installs.
 - **Performance**: the disk-read gate headline.
 - Folia-affecting items carry the experimental-status mention: GATE (common-side),
   SET's pump marshaling, **and FARP** — the largest Folia-affecting change in the
@@ -347,9 +502,11 @@ first.
 
 ### 3.3 Explicitly OUT of v0.11.0 (recorded so nothing silently re-enters)
 
-- FARP on the support lines (R-7); FARP's fog/glow options and "smart" SeeU
-  detection; `farPlayersExclude` as a runtime-settable key (list-typed; R-9 scoped
-  it out).
+- FARP on the 1.21.11 line (R-7 v1.2 — candidate follow-up, SeeU's 1.21.x
+  releases prove feasibility); FARP's fog/glow options and "smart" SeeU
+  detection; `farPlayersExclude` as a runtime-settable key (list-typed; R-9
+  scoped it out); vehicle STACKS beyond the direct mount (R-10 collapses to the
+  direct vehicle).
 - GATE's MSPT modulation of K; the store-ON gate soak variant (follow-up — noting
   honestly that the live rig, its stand-in, is the program's least reliable
   channel).
@@ -370,9 +527,15 @@ first.
   E1 is INERT (the v1.0 story — "v0.11.0 goes without FARP, other rows
   unaffected" — was false: E1's defaults would have shipped a live position
   broadcast rendering nothing). With E1 inert, a slipped E2 ships dead code, not
-  exposure; the pre-declared fallback states are (i) ship inert, flip in
-  v0.11.1/v0.12.0, or (ii) revert E1 from the release branch. The E1→E2 go/no-go
-  is the user's call, recorded in the decisions log.
+  exposure. **Pre-declared fallback states (re-derived for two-line scope,
+  v1.3)**: (i) ship E1-inert on BOTH FARP lines — v0.11.0 releases with far
+  players compiled dark on 26.2 AND 26.1, flipped in v0.11.1/v0.12.0, and G's
+  "26.1 renderer verification" gate is struck (nothing to verify); or (ii) drop
+  FARP from the release entirely by re-anchoring BOTH G bases to main-at-the-D-
+  merge — NOT a revert-from-main (there is no release branch in this program;
+  subtracting E1 from main's six accreted artifacts is exactly the cost the
+  D-merge base exists to avoid). The E1→E2 go/no-go is the user's call, recorded
+  in the decisions log.
 - **User-gated work is the critical path** (review): B/C rig observations, D's
   three live smokes, E2's live gate, E3's Folia session, the archon token. The
   fallback discipline: merge with live verification logged PENDING on the
@@ -406,9 +569,9 @@ calendar weeks) and **user-gated** (scheduling-dependent, the real critical path
 | D | medium + Tier 3 + 3 soaks | three live Voxy smokes |
 | E1 | **large** (three payloads + broadcast service + two platform adapters + tracker + six keys + full registration set — comparable to v0.10.0's C1) | — |
 | E2 | medium | **the two-client live gate** |
-| E3 | small-medium | the Folia session |
-| F | small + the gauntlet (~2.5 h measured for v0.10.0's 28) + the program review round | — |
-| G | medium ×2 lines (delta-port, much smaller than fresh — M1) | per-line Voxy smokes |
+| E3 | small-medium | the Folia session + the R-10 mounted live check |
+| F | small + the gauntlet (~2.5 h measured for v0.10.0's 28) + the program review round | **the Modrinth pause (deploy + config refresh + user manual-testing sign-off — G is blocked on it)** |
+| G | medium ×2 lines (delta-port, much smaller than fresh — M1; the 26.1 port now includes FARP renderer porting) | per-line Voxy smokes + **the 26.1 renderer verification (two-client)** |
 | contingency | soak/tier re-runs per the catalog (v0.10.0 measured ~1.5 h of re-runs inside ~9 h of measurement) | — |
 
 C and E1 are the two rows that will absorb the variance; split C's PRs if C-set
@@ -506,7 +669,9 @@ finding; the highlights that changed the plan's shape:
 - **Tri-version M1/M2: stage G's mechanic.** The fresh-re-port rationale expired
   (the `-v0.10` branches ARE the released trees, at parity with main); a fresh cut
   would re-derive the 1.21.11 line's ~90-file adaptation set. → delta-port, with
-  the support base cut from main at the D merge so FARP is never subtracted (§2 G).
+  the support base cut from main at the D merge so FARP is never subtracted
+  (§2 G). *(Superseded for the 26.1 line by v1.2: its base is main at the F
+  merge, full tree incl. FARP; the D-merge base now applies to 1.21.11 only.)*
 - **Convergent (3 lenses): R-3/R-5 were mis-scoped.** R-3 imposed an unspecified
   FARP server behavior (now a two-sided amendment with the full-roster-on-any-prefs
   obligation + rate bound); R-5's SET-re-push∩FARP "non-collision" was wrong (the
@@ -528,3 +693,24 @@ finding; the highlights that changed the plan's shape:
 
 Full findings live in the five reviewers' reports (session artifacts); their
 substance is folded above, so this table is the durable record.
+
+**v1.3 round (same day, three Fable agents: whole-program technical /
+whole-program execution / R-10 deep-dive).** Verdicts: READY WITH FIXES ×2, SOUND
+WITH FIXES ×1 — all folded. Headlines: both whole-program lenses independently
+caught the v1.2 revision seams (the §0 release-shape sentence and the E2-slip
+fallbacks still carried the v1.1 scope) and the R-10 phasing contradiction (the
+mounted live check gated E2, a stage before the renderer exists — moved to E3).
+The R-10 deep-dive decompiled the MC 26.2/26.1.2 jars and read SeeU's full
+renderer: R-10 was rewritten around the SeeU-proven rider-at-own-wire-position
+model (which deletes the passenger-index wire gap its own v1.2 spec had), the
+seated pose got its mechanism (edge-triggered persistent ride link →
+`isPassenger` at extraction — bytecode-verified as the only vanilla path), mount
+motion is driven by the rider's velocity hint, and the ladder gained the
+DefaultedRegistry `getOptional` rung-1 requirement (unknown mounts otherwise
+resolve to PIG — a live SeeU bug) + the `create()`-returns-null rung. Also:
+GATE's resolved-K echo must move below store attachment (it currently prints
+before the store exists); the Modrinth pause gained its test list + found-bug
+loop (with the G-base re-anchor rule); benchmark.sh gets a distance pin at A (the
+"baselines untouched" claim was false there); the SeeU clone is vendored under
+`research/seeu/` at E1 (FARP's citations currently point at an ephemeral
+scratchpad).

--- a/docs/planning/v0.11.0-progress.md
+++ b/docs/planning/v0.11.0-progress.md
@@ -1,7 +1,7 @@
 # v0.11.0 program — progress (living doc)
 
 Created at program start, before stage A's first commit. The frozen spec is
-`v0.11.0-mega-plan.md` v1.1 (+ the five source plans it sequences). A plan
+`v0.11.0-mega-plan.md` **v1.3** (+ the five source plans it sequences). A plan
 deviation is legal only as a PAIR: a dated decisions-log entry here AND an edit to
 the overridden text (mega plan OR source plan) with a back-pointer.
 
@@ -11,15 +11,15 @@ Single source of stage status; updated in each stage's merge commit.
 
 | stage | content (short) | status | planned | started | merged | PR | gate verdicts / evidence |
 |---|---|---|---|---|---|---|---|
-| A | dirtyBroadcastIntervalSeconds: 0 (+ program prereqs) | pending | — | — | — | — | — |
-| B | disk-read gate + scenario + 5-script pins + rig deploy | pending | — | — | — | — | — |
+| A | dirty interval 0 + lodDistance default 300 (+ program prereqs) | pending | — | — | — | — | — |
+| B | disk-read gate + scenario + 5-script pins + echo move + rig deploy | pending | — | — | — | — | — |
 | C | /lsslod set + help + backfill estimate + descriptions | pending | — | — | — | — | — |
 | D | /lss reset + .lss cache relocation | pending | — | — | — | — | — |
-| E1 | far players wire+server+tracker (INERT) | pending | — | — | — | — | — |
+| E1 | far players wire+server+tracker (INERT; R-10 vehicle block; vendor research/seeu) | pending | — | — | — | — | — |
 | E2 | far players renderer (+ defaults flipped ON) | pending | — | — | — | — | — |
-| E3 | far players polish + Folia session | pending | — | — | — | — | — |
-| F | docs + notes + pre-G program review + gauntlet | pending | — | — | — | — | — |
-| G | delta-ports onto -v0.10 branches + tri-release | pending | — | — | — | — | — |
+| E3 | far players polish + R-10 mounts + mounted live check + Folia session | pending | — | — | — | — | — |
+| F | docs + notes + pre-G program review + gauntlet + **Modrinth pause** | pending | — | — | — | — | — |
+| G | delta-ports (26.1 = full tree; 1.21.11 = pre-FARP base) + tri-release | pending | — | — | — | — | — |
 
 ## Decisions log
 
@@ -32,6 +32,18 @@ Single source of stage status; updated in each stage's merge commit.
   arm-c acceptance threshold (pre-registered in B's PR before the run); (3) E1's
   tracker-ownership choice (R-5); (4) E1's LSSApi far-player-feed question;
   (5) the E1→E2 go/no-go (user call).
+- 2026-08-12 — **user decisions (v1.2)**: `lodDistanceChunks` default → 300
+  (rides stage A); Modrinth dev-deploy + manual-testing pause between F and G
+  (rig config refreshed to new defaults); FARP ships on the **26.1 line** too
+  (1.21.11 excluded for v0.11.0); far-player defaults confirmed `on` at E2 for
+  fresh AND upgrading installs; R-10 mounted-entity rendering added (wire fields
+  at E1, rendering at E3, degrade ladder for modded mounts).
+- 2026-08-12 — **v1.3**: final three-Fable round (2 whole-program + 1 R-10
+  deep-dive) folded — R-10 rewritten to the rider-at-own-position model
+  (no seat index on the wire), mounted live check moved to E3, Modrinth pause
+  specified (test list + found-bug loop + G-base re-anchor), GATE echo moves
+  below store attachment, benchmark.sh gains a distance pin at A, SeeU clone
+  vendored at E1. The mega plan v1.3 is the frozen spec.
 
 ## Review-round findings tables
 
@@ -43,9 +55,13 @@ Single source of stage status; updated in each stage's merge commit.
 - [ ] B: Modrinth rig deploy + burn-in observation (`read_gate=`, WARN, CPU)
 - [ ] C: rig smoke of `/lsslod set` + `help`
 - [ ] D: live smoke ×3 (real Voxy rebuild; no-Voxy server; old-cache adoption)
-- [ ] E2: two real GUI clients + dummy live gate (elytra, handoff, vanish/RCON)
+- [ ] E2: two real GUI clients + dummy live gate (elytra, handoff, vanish/RCON,
+      one mounted scenario per R-10)
 - [ ] E3: `run-folia` two-client session
-- [ ] G: per-line Voxy javap + reset smoke (26.1, 1.21.11)
+- [ ] F→G: Modrinth dev-deploy + config refresh to new defaults + **user
+      manual-testing sign-off** (G is blocked on this)
+- [ ] G: per-line Voxy javap + reset smoke (26.1, 1.21.11) + the 26.1 renderer
+      verification (E2 script re-run)
 
 ## Measurement ledger
 


### PR DESCRIPTION
v1.2 folds four user adjustments (lodDistance default 300, the pre-backport Modrinth manual-testing pause, FARP on the 26.1 line, R-10 mounted-entity rendering + defaults-on confirmation); v1.3 folds the final three-Fable whole-program round (two program lenses + one R-10 deep-dive against the decompiled MC jars and SeeU's renderer). All verdicts READY/SOUND WITH FIXES; §7 carries both round records.

Docs only — no code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)