### PR TITLE
docs: v0.11.0 mega plan v1.4 — far players on all three lines

### DIFF
--- a/docs/planning/v0.11.0-mega-plan.md
+++ b/docs/planning/v0.11.0-mega-plan.md
@@ -1,4 +1,19 @@
-# v0.11.0 mega plan — operator controls + client reset + far players + CPU gate (2026-08-12, v1.3)
+# v0.11.0 mega plan — operator controls + client reset + far players + CPU gate (2026-08-12, v1.4)
+
+**v1.4 (same day, user direction): FARP ships on ALL THREE lines — 1.21.11
+included.** Grounds: a measured investigation (recorded in §7) — SeeU's own
+26.2→1.21.11 release diff for the same feature class is 60/43 lines of pure
+symbol renames (`LevelRenderContext`→`WorldRenderContext`,
+`submitNodeCollector()`→`commandQueue()`, `playC2S()` registration, etc.); the
+extract/submit render model exists identically on 1.21.11 under older names, so
+the renderer port is mechanical, not architectural. The v1.2 exclusion rationale
+("bigger API distance, ~90-file adaptation set") conflated the whole line's
+already-paid port cost with FARP's marginal cost. Consequences: both stage-G
+bases become main at the F merge (the per-line base split, the F-commit-
+separation discipline, and the "non-FARP parts of F" problem all DISSOLVE); G
+gains the 1.21.11 FARP obligations (Java-21 language-level audit, fabric-api
+render-context pin check, a third two-client renderer verification); v0.11.0
+becomes a perfectly symmetric tri-release.
 
 **v1.2 (same day, user direction):** four adjustments — (1) `lodDistanceChunks`
 default 512 → **300** (rides stage A); (2) a **Modrinth dev-deploy + manual-testing
@@ -48,8 +63,9 @@ fidelity / process / tri-version / sequencing lenses — full record in §7).
 Headline outcomes: **E1 ships inert** (`farPlayers` compiled default `off`, client
 bit unarmed until E2 — all five lenses converged on the v1.0 E2-slip story being
 false); **stage G becomes a delta-port onto the current `-v0.10` support branches
-with the support base cut from main at the D merge** *(superseded for the 26.1
-line by v1.2 — its base is main at the F merge; D-merge applies to 1.21.11)* (the
+with the support base cut from main at the D merge** *(superseded: v1.2 moved
+the 26.1 base to main-at-F-merge, and v1.4 moved BOTH lines there; the D-merge
+base survives only as the drop-FARP fallback in §4)* (the
 fresh-re-port rationale expired at v0.10.0 — the branches are one docs commit
 behind main, and cutting the base pre-E1 means FARP never needs subtracting from
 six pinned shared artifacts);
@@ -63,9 +79,9 @@ estimate inherit its error).
 off switch, the disk-read CPU gate (store-conditional auto), the runtime settings
 commands + help + backfill estimate + new package descriptions, the client
 `/lss reset` + `.lss/` cache relocation, and far-player proxies (capability-gated,
-LSS's first client-side renderer; ARMED only at E2). **The 26.1 support line gets
-ALL FIVE features; the 1.21.11 line gets everything except FARP** (R-7 v1.2) via
-stage G's delta-ports — tri-release at the end, no tag pushed before G. **Unlike
+LSS's first client-side renderer; ARMED only at E2). **Both support lines get ALL
+FIVE features (R-7 v1.4) — a fully symmetric tri-release** via stage G's
+delta-ports — tags at the end, none pushed before G. **Unlike
 v0.10.0 there is NO protocol bump**: every
 stage is additive and default-safe (FARP rides a masked capability bit + new
 `lss:*` channels old clients silently discard), so there is **no integration
@@ -73,7 +89,7 @@ branch** — every stage PRs to main directly and main stays releasable througho
 
 **Recorded alternative (user decision pending, raised by the review round):** ship
 A–D as v0.11.0 (a perfectly symmetric tri-release — all three lines get the same
-four features) and FARP as a **26.2 + 26.1** v0.12.0 (scope per R-7 v1.2). This
+four features) and FARP as an all-three-lines v0.12.0 (scope per R-7 v1.4). This
 dissolves the E2-slip risk and gives the first LSS renderer its own release
 window; the cost is far players waiting one release. This plan keeps all five in
 v0.11.0 per the original direction, with E1-inert as the safety; flipping to the
@@ -231,49 +247,60 @@ self-verify its no-op pin; FARP's soak-client property gate
 at E1 (its review demanded Phase-A self-verifiability) and re-asserted by the
 stage-F gauntlet's counters-stay-zero check.
 
-### R-7 — Re-port scope: far players ships on 26.2 AND 26.1; 1.21.11 excluded (v1.2 — user direction)
+### R-7 — Re-port scope: far players ships on ALL THREE lines (v1.4 — user direction, measurement-backed)
 
-The 26.1 line receives ALL FIVE features (user decision 2026-08-12 — the 26.1.2
-rendering API generation is near-identical to 26.2's, the v0.10.0 D3 record shows
-the 26.1 source delta was ~8 files, and SeeU itself ships 26.1.2 releases, proving
-the renderer approach ports). The 1.21.11 line receives DIRTY0 + GATE + SET +
-RESET, **not FARP**, for v0.11.0 (SeeU's own 1.21.x releases prove feasibility —
-recorded as a candidate v0.11.x/v0.12.0 follow-up, not a permanent exclusion).
-Consequence for stage G's bases: the 26.1 delta-port takes main at the F merge
-(full tree); the 1.21.11 delta-port takes main at the D merge (pre-FARP, so FARP
-is never subtracted). G gains a 26.1 renderer verification (the E2 live-gate
-script re-run once on the 26.1 rig).
+Every line receives ALL FIVE features. Grounds per line: 26.1 — the rendering API
+generation is near-identical (SeeU's measured 26.2→26.1.2 diff: 6 lines), the
+v0.10.0 D3 source delta was ~8 files. 1.21.11 (v1.4) — SeeU's measured
+26.2→1.21.11 diff is 60/43 lines of pure symbol renames with the SAME
+extract/submit render architecture (`WorldRenderContext`/`matrices()`/
+`commandQueue()`/`worldState()`/`getMainCamera()` + `PayloadTypeRegistry.playC2S/
+playS2C`); FARP's wire is version-neutral by design so the E1 surface has ~zero
+delta and its wire goldens are line-identical (no per-MC regeneration — unlike
+the NBT corpus). Both stage-G bases are **main at the F merge** (or the last
+pre-G merge per the pause's re-anchor rule) — no per-line base split, no FARP
+subtraction anywhere.
+
+1.21.11-specific obligations (v1.4):
+- **Java-21 language-level audit**: the 1.21.11 fabric module builds at Java 21
+  (the paperweight/toolchain constraint) — FARP code avoids Java-25-only
+  features FROM E1 (cheap discipline that keeps G mechanical; the D3 record's
+  shim pattern is the fallback).
+- **fabric-api render-context pin check**: confirm the line's fabric-api pin
+  carries the `WorldRenderContext`/`commandQueue()` era SeeU's 1.21.11 release
+  proves exists (one-minute javap/source check before the port is declared
+  mechanical).
+- **A third two-client renderer verification** (the E2 live-gate script on the
+  1.21.11 rig) — user-assisted, on the checklist.
 
 Obligations this scope creates (review — v1.0 asserted these; they are gates):
 
 - **The FARP wire is MC-version-neutral from E1** (identity strings via the v20
   dictionary pattern for equipment/vehicle types — never numeric registry ids).
-  The 26.2-only scope is a SHIPPING decision, not a wire decision; an E1 reviewer
-  must not read "26.2-only" as license for version-locked encoding.
+  Wire-neutrality remains mandatory even at full three-line scope: it is what
+  makes cross-MC sessions work, and what keeps any FUTURE line addition a
+  shipping decision rather than a wire decision.
 - **The C2S prefs frame gets the `lss:client_info` sidecar guard pattern**
-  (try/catch containment + send-once-per-session-unless-changed/reset): a 26.2
-  client sends prefs at every pre-v0.11.0 server and every support-line server —
-  populations that never registered the channel. Version-mix cell recorded: 26.2
-  client + support-line server → capability bit masked (verified:
-  `HandshakeGate:151` masks) AND prefs send contained → silence.
-- **Privacy asymmetry documented**: a 1.21.11 client on a FARP-carrying v0.11.0
-  server is a far-player TARGET with no client-side `shareSelf` (the pref exists
-  only in FARP-carrying client configs); its protections are the server-side mode
-  / exclude list / permission node. Goes in the README privacy note + release
-  notes.
-- **Cross-MC sessions (Via) carry far players BY DESIGN — between FARP-carrying
-  lines** (26.2 ↔ 26.1 for v0.11.0; a 1.21.11 client carries no FARP code, so it
-  is target-only): the wire-neutrality obligation above is exactly what makes a
-  FARP-carrying client on one MC version render far players from a v0.11.0
-  server on another (Via translates the MC protocol; the `lss:*` plugin channels
-  pass through; identity strings resolve against the client's own registries).
-  Same-LSS-version cross-MC sessions never select a legacy dialect, so the C5 Via
-  guard does not fire. Unresolvable identities degrade per the FARP fallback
-  rules — a missing equipment piece renders bare, a missing mount renders the
-  player unmounted (R-10; measured: 26.2 adds exactly ONE entity type over
-  26.1.2, so the cross-version mount space is nearly identity). Note: R-7 v1.2
-  also supersedes FARP §8's "support-line backports likely skip Phase B" for the
-  26.1 line (the §6.1 pair — the source-plan pointer edit rides E1's PR).
+  (try/catch containment + send-once-per-session-unless-changed/reset): a
+  v0.11.0 client sends prefs at every PRE-v0.11.0 server — a population that
+  never registered the channel. Version-mix cell recorded: v0.11.0 client +
+  older-LSS server → capability bit masked (verified: `HandshakeGate:151` masks)
+  AND prefs send contained → silence.
+- **Privacy asymmetry documented (v1.4 rescope: now an OLD-LSS-CLIENT asymmetry,
+  not a per-line one)**: any client running LSS ≤ v0.10.0 (or vanilla) on a
+  FARP-carrying v0.11.0 server is a far-player TARGET with no client-side
+  `shareSelf`; its protections are the server-side mode / exclude list /
+  permission node. Goes in the README privacy note + release notes.
+- **Cross-MC sessions (Via) carry far players BY DESIGN**: any v0.11.0 client on
+  any of the three lines renders far players from any v0.11.0 server (Via
+  translates the MC protocol; the `lss:*` plugin channels pass through; identity
+  strings resolve against the client's own registries). Same-LSS-version cross-MC
+  sessions never select a legacy dialect, so the C5 Via guard does not fire.
+  Unresolvable identities degrade per the FARP fallback rules — a missing
+  equipment piece renders bare, a missing mount renders the player unmounted
+  (R-10; measured: 26.2 adds exactly ONE entity type over 26.1.2). Note: R-7
+  v1.4 supersedes FARP §8's "support-line backports likely skip Phase B"
+  entirely (the §6.1 pair — the source-plan pointer edit rides E1's PR).
 - **RESET vs per-line Voxy is a stage-G GATE, not an assumption** (v1.0's
   "0.2.11-era, old rung" claim was wrong for the 26.1 line — the locally available
   0.2.18-beta-26.1.2 jar exports the NEW `IVoxyRenderSystemHolder`; the README
@@ -432,7 +459,7 @@ their shipped mechanism, not speculation.
 | **E2** | Far players phase B: renderer (proxy entities, declared-cadence lerp + velocity extrapolation, event-triggered handoff with SeeU's conjuncts, NO glow, NO fog mixin), Sodium rows; **defaults flipped ON** (server `on` for fresh AND upgrading installs — user decision 2026-08-12; client bit armed — E1's inert shipping deliberately overrides FARP §3.3's "active from Phase A" text, mechanism: client capability composition compiled bit-off until this stage). **Owns the SoakPlayer-dummy-rig doc section** (§6.3 docs-ride rule) | FARP §3.3, §7-B | Tier 1 tracker math; **live gate on the test rig — two real GUI clients + the dummy** (elytra extrapolation, tracking-boundary handoff, vanish/spectator via RCON, **the R-10 PRE-rendering mounted scenario: mounted target renders unmounted, no crash**) — rendering has no test tier, the live gate is THE gate (user-scheduled, R-8 checklist) |
 | **E3** | Far players phase C: **mounted-entity rendering per R-10 v1.3** (rider-at-own-position, persistent ride link, rider-velocity mount motion, the degrade ladder, vehicle lifecycle), coexist default (`isModLoaded("seeu")` off + INFO + Sodium tooltip), README privacy note (incl. R-7's asymmetry), exporter/soak-report fields final, **the `run-folia` two-client session** (FARP's own Folia gate — the new cross-region equipment/pose read class; v1.0 dropped it) | FARP §7-C as amended by R-10 | Tier 1 additions incl. the R-10 ladder pins (injected resolvers + the rung-1 REAL-registry pin); **the mounted LIVE check on the test rig** (review — the stage that ships the mount renderer carries its live evidence); full-suite soak with counters-stay-zero (R-6); the Folia session (user-assisted, checklist) |
 | **F** | Docs consolidation (CLAUDE.md sweep, READMEs incl. version table rows, clamp-audit errata), release notes all three lines + **three `release-tag-v0.11.0*.txt` drafts + the short Modrinth changelog variant** (three lines carry DIFFERENT notes — FARP on 26.2+26.1 only — and Modrinth is hand-fix-only), **the pre-G whole-program review round** (scope: the full A..E3 diff — the v0.10.0 pre-D3 round found 5 MAJORs; v1.0 had no program-level round at all), pre-flight. **Then (v1.2, user direction): deploy the dev build to the Modrinth test server, refresh its config to the new v0.11.0 defaults (R-8), and PAUSE for user manual testing** | this doc §3.2 | **full `soak.sh all` on all three platforms** (count NOT frozen — B made it 20 Fabric), Tier 3 green **discharged against the last code-carrying commit** (docs-only PRs skip CI — cite E3's runs), `release_check.py` OK, `CI=true` pre-flight build, the review round's findings dispositioned; **G does not start until the user signs off the Modrinth manual-testing pause** (checklist item) |
-| **G** | **Delta-port onto the current support branches** (review — the fresh-re-port rationale expired: the `-v0.10` branches ARE the released v0.10.0 trees, current to one docs commit): cut `support/mc<ver>-v0.11` from `support/mc<ver>-v0.10`, then merge/cherry-pick the per-line base — **26.1: main at the F merge (full tree incl. FARP, per R-7 v1.2); 1.21.11: main at the D merge** (pre-E1, so FARP never needs subtracting from the six R-1 artifacts) + the non-FARP parts of F. Fresh re-port survives only as the documented escape hatch with its cost stated (the 90-file 1.21.11 adaptation set would be re-derived). **F-commit discipline serving this row (v1.3, review): F keeps FARP and non-FARP content in separate commits, and pre-G-review fixes to A–D code land as their own PRs — otherwise "the non-FARP parts of F" is not commit-well-defined for the 1.21.11 port.** Per-line: R-7's Voxy-rung javap gate, **the 26.1 renderer verification (the E2 live-gate script once on the 26.1 rig)**, the gotcha catalogue, staging/smoke, **archive the stale v0.8.1-era `support/mc*` branches** (recorded convention gap). Then tri-release | R-7 + this row | per-line pre-flights green; R-7 gates discharged; tags pushed ONLY here, `--cleanup=verbatim`, annotation verified via `git for-each-ref` BEFORE push, rendered notes verified on GitHub AND Modrinth after; never re-run a partially published release; no throwaway `v*` tags ever |
+| **G** | **Delta-port onto the current support branches** (review — the fresh-re-port rationale expired: the `-v0.10` branches ARE the released v0.10.0 trees, current to one docs commit): cut `support/mc<ver>-v0.11` from `support/mc<ver>-v0.10`, then merge/cherry-pick **main at the F merge on BOTH lines** (R-7 v1.4 — the full tree incl. FARP; no per-line base split, no FARP subtraction, no F-commit-separation discipline needed). Fresh re-port survives only as the documented escape hatch with its cost stated (the 90-file 1.21.11 adaptation set would be re-derived). Per-line: R-7's Voxy-rung javap gate, **the FARP renderer verification on EACH support line (the E2 live-gate script once per line rig)**, the 1.21.11 Java-21 audit + fabric-api render-context pin check (R-7 v1.4), the gotcha catalogue (the renderer rename recipe = SeeU's measured diff), staging/smoke, **archive the stale v0.8.1-era `support/mc*` branches** (recorded convention gap). Then tri-release | R-7 + this row | per-line pre-flights green; R-7 gates discharged; tags pushed ONLY here, `--cleanup=verbatim`, annotation verified via `git for-each-ref` BEFORE push, rendered notes verified on GitHub AND Modrinth after; never re-run a partially published release; no throwaway `v*` tags ever |
 
 **Ordering rationale, compressed:** A first — smallest, and it exercises the exact
 config/clamp/test-table discipline every later stage repeats. B second — early
@@ -479,11 +506,11 @@ first.
 - Every pin touched by two stages (echo shape, formatter goldens, exporter
   literal, registry goldens) is re-verified at each touching stage.
 
-### 3.2 Release notes (v0.11.0; format per CLAUDE.md; three lines, FARP on 26.2 + 26.1)
+### 3.2 Release notes (v0.11.0; format per CLAUDE.md; three lines, ALL features on all lines — v1.4)
 
-- **New Features**: far players (26.2 + 26.1 lines, explicitly — 1.21.11 gets it
-  later; mounted-entity rendering per R-10; privacy modes + the 2048 default +
-  R-7's non-FARP-client-targets asymmetry; **SeeU credited as MIT prior art** —
+- **New Features**: far players (all three lines — R-7 v1.4; mounted-entity
+  rendering per R-10; privacy modes + the 2048 default +
+  R-7's old-LSS-client-targets asymmetry; **SeeU credited as MIT prior art** —
   an attribution obligation from FARP §5, dropped in v1.0); `/lss reset`;
   `/lsslod set` + `help` (legacy-dialect distance-shrink wording per SET: "legacy
   clients keep re-asking beyond the new distance until rejoin"); backfill
@@ -502,11 +529,11 @@ first.
 
 ### 3.3 Explicitly OUT of v0.11.0 (recorded so nothing silently re-enters)
 
-- FARP on the 1.21.11 line (R-7 v1.2 — candidate follow-up, SeeU's 1.21.x
-  releases prove feasibility); FARP's fog/glow options and "smart" SeeU
+- FARP's fog/glow options and "smart" SeeU
   detection; `farPlayersExclude` as a runtime-settable key (list-typed; R-9
   scoped it out); vehicle STACKS beyond the direct mount (R-10 collapses to the
-  direct vehicle).
+  direct vehicle). (The former "FARP off the 1.21.11 line" item was struck by
+  R-7 v1.4.)
 - GATE's MSPT modulation of K; the store-ON gate soak variant (follow-up — noting
   honestly that the live rig, its stand-in, is the program's least reliable
   channel).
@@ -527,15 +554,15 @@ first.
   E1 is INERT (the v1.0 story — "v0.11.0 goes without FARP, other rows
   unaffected" — was false: E1's defaults would have shipped a live position
   broadcast rendering nothing). With E1 inert, a slipped E2 ships dead code, not
-  exposure. **Pre-declared fallback states (re-derived for two-line scope,
-  v1.3)**: (i) ship E1-inert on BOTH FARP lines — v0.11.0 releases with far
-  players compiled dark on 26.2 AND 26.1, flipped in v0.11.1/v0.12.0, and G's
-  "26.1 renderer verification" gate is struck (nothing to verify); or (ii) drop
-  FARP from the release entirely by re-anchoring BOTH G bases to main-at-the-D-
-  merge — NOT a revert-from-main (there is no release branch in this program;
+  exposure. **Pre-declared fallback states (re-derived for three-line scope,
+  v1.4)**: (i) ship E1-inert on ALL lines — v0.11.0 releases with far players
+  compiled dark everywhere, flipped in v0.11.1/v0.12.0, and G's per-line
+  renderer-verification gates are struck (nothing to verify); or (ii) drop FARP
+  from the release entirely by re-anchoring ALL G bases to main-at-the-D-merge —
+  NOT a revert-from-main (there is no release branch in this program;
   subtracting E1 from main's six accreted artifacts is exactly the cost the
-  D-merge base exists to avoid). The E1→E2 go/no-go is the user's call, recorded
-  in the decisions log.
+  D-merge fallback base exists to avoid). The E1→E2 go/no-go is the user's call,
+  recorded in the decisions log.
 - **User-gated work is the critical path** (review): B/C rig observations, D's
   three live smokes, E2's live gate, E3's Folia session, the archon token. The
   fallback discipline: merge with live verification logged PENDING on the
@@ -571,7 +598,7 @@ calendar weeks) and **user-gated** (scheduling-dependent, the real critical path
 | E2 | medium | **the two-client live gate** |
 | E3 | small-medium | the Folia session + the R-10 mounted live check |
 | F | small + the gauntlet (~2.5 h measured for v0.10.0's 28) + the program review round | **the Modrinth pause (deploy + config refresh + user manual-testing sign-off — G is blocked on it)** |
-| G | medium ×2 lines (delta-port, much smaller than fresh — M1; the 26.1 port now includes FARP renderer porting) | per-line Voxy smokes + **the 26.1 renderer verification (two-client)** |
+| G | medium ×2 lines (delta-port, much smaller than fresh — M1; both ports now include the FARP renderer renames — measured recipe: SeeU's 60/43-line diff) | per-line Voxy smokes + **the renderer verification on EACH support line (two-client)** |
 | contingency | soak/tier re-runs per the catalog (v0.10.0 measured ~1.5 h of re-runs inside ~9 h of measurement) | — |
 
 C and E1 are the two rows that will absorb the variance; split C's PRs if C-set
@@ -670,8 +697,8 @@ finding; the highlights that changed the plan's shape:
   (the `-v0.10` branches ARE the released trees, at parity with main); a fresh cut
   would re-derive the 1.21.11 line's ~90-file adaptation set. → delta-port, with
   the support base cut from main at the D merge so FARP is never subtracted
-  (§2 G). *(Superseded for the 26.1 line by v1.2: its base is main at the F
-  merge, full tree incl. FARP; the D-merge base now applies to 1.21.11 only.)*
+  (§2 G). *(Superseded: v1.2 moved the 26.1 base to main-at-F-merge; v1.4 moved
+  both lines there — the D-merge base survives only as §4's drop-FARP fallback.)*
 - **Convergent (3 lenses): R-3/R-5 were mis-scoped.** R-3 imposed an unspecified
   FARP server behavior (now a two-sided amendment with the full-roster-on-any-prefs
   obligation + rate bound); R-5's SET-re-push∩FARP "non-collision" was wrong (the
@@ -714,3 +741,16 @@ loop (with the G-base re-anchor rule); benchmark.sh gets a distance pin at A (th
 "baselines untouched" claim was false there); the SeeU clone is vendored under
 `research/seeu/` at E1 (FARP's citations currently point at an ephemeral
 scratchpad).
+
+**v1.4 record (same day): the 1.21.11 FARP investigation + user decision.**
+Method: fetched SeeU's per-MC release tags and diffed the same feature set across
+lines — 26.2→1.21.11 = 60 insertions/43 deletions across 10 files, ALL symbol
+renames (`WorldRenderContext`/`matrices()`/`commandQueue()`/`worldState()`/
+`getMainCamera()`, `PayloadTypeRegistry.playC2S/playS2C`); the extract/submit
+render architecture is IDENTICAL on 1.21.11. 26.2→26.1.2 = 6 lines (calibration).
+Conclusion: the renderer port is mechanical; FARP's E1 surface is version-neutral
+with line-identical wire goldens; the marginal 1.21.11 cost ≈ ~40 lines of Fabric
+renames + the Java-21 audit + one more user-assisted two-client session. The
+v1.2 exclusion rationale conflated the line's already-paid port cost with FARP's
+marginal cost. User direction: include 1.21.11 → R-7 v1.4, symmetric tri-release,
+both G bases at main-at-F-merge.

--- a/docs/planning/v0.11.0-progress.md
+++ b/docs/planning/v0.11.0-progress.md
@@ -1,7 +1,7 @@
 # v0.11.0 program — progress (living doc)
 
 Created at program start, before stage A's first commit. The frozen spec is
-`v0.11.0-mega-plan.md` **v1.3** (+ the five source plans it sequences). A plan
+`v0.11.0-mega-plan.md` **v1.4** (+ the five source plans it sequences). A plan
 deviation is legal only as a PAIR: a dated decisions-log entry here AND an edit to
 the overridden text (mega plan OR source plan) with a back-pointer.
 
@@ -19,7 +19,7 @@ Single source of stage status; updated in each stage's merge commit.
 | E2 | far players renderer (+ defaults flipped ON) | pending | — | — | — | — | — |
 | E3 | far players polish + R-10 mounts + mounted live check + Folia session | pending | — | — | — | — | — |
 | F | docs + notes + pre-G program review + gauntlet + **Modrinth pause** | pending | — | — | — | — | — |
-| G | delta-ports (26.1 = full tree; 1.21.11 = pre-FARP base) + tri-release | pending | — | — | — | — | — |
+| G | delta-ports (both lines = full tree incl. FARP, R-7 v1.4) + tri-release | pending | — | — | — | — | — |
 
 ## Decisions log
 
@@ -43,7 +43,13 @@ Single source of stage status; updated in each stage's merge commit.
   (no seat index on the wire), mounted live check moved to E3, Modrinth pause
   specified (test list + found-bug loop + G-base re-anchor), GATE echo moves
   below store attachment, benchmark.sh gains a distance pin at A, SeeU clone
-  vendored at E1. The mega plan v1.3 is the frozen spec.
+  vendored at E1.
+- 2026-08-12 — **user decision (v1.4)**: FARP ships on ALL THREE lines. Backed by
+  the measured SeeU per-line diff (26.2→1.21.11 = 60/43 lines of symbol renames,
+  same render architecture; 26.2→26.1.2 = 6 lines). Both G bases = main at F
+  merge; G gains the 1.21.11 Java-21 audit + fabric-api render-context pin check
+  + a third two-client renderer verification. FARP code avoids Java-25-only
+  features from E1. The mega plan v1.4 is the frozen spec.
 
 ## Review-round findings tables
 
@@ -60,8 +66,8 @@ Single source of stage status; updated in each stage's merge commit.
 - [ ] E3: `run-folia` two-client session
 - [ ] F→G: Modrinth dev-deploy + config refresh to new defaults + **user
       manual-testing sign-off** (G is blocked on this)
-- [ ] G: per-line Voxy javap + reset smoke (26.1, 1.21.11) + the 26.1 renderer
-      verification (E2 script re-run)
+- [ ] G: per-line Voxy javap + reset smoke (26.1, 1.21.11) + the FARP renderer
+      verification on EACH support line (E2 script re-run, two-client)
 
 ## Measurement ledger
 


### PR DESCRIPTION
Folds the user's decision to include the 1.21.11 line in far-player scope, grounded in a measured investigation: SeeU ships the same feature class on 26.2 and 1.21.11, and its per-version diff is 60/43 lines of pure symbol renames on an identical extract/submit render architecture — so the port is mechanical. Both stage-G delta-port bases unify at main-at-F-merge, several v1.2/v1.3 complexities dissolve, and G gains the 1.21.11-specific gates (Java-21 audit, fabric-api render-context pin check, a third two-client renderer verification). §7 carries the investigation record.

Docs only — no code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)