### PR TITLE
docs: stage A merged — progress table

### DIFF
--- a/docs/planning/v0.11.0-progress.md
+++ b/docs/planning/v0.11.0-progress.md
@@ -11,7 +11,7 @@ Single source of stage status; updated in each stage's merge commit.
 
 | stage | content (short) | status | planned | started | merged | PR | gate verdicts / evidence |
 |---|---|---|---|---|---|---|---|
-| A | dirty interval 0 + lodDistance default 300 (+ program prereqs) | PR #125 in review | 2026-08-13 | 2026-08-13 | — | [#125](https://github.com/VoX/lod-server-support/pull/125) | Tier 1 both platforms green (one cataloged MemoryLodStoreTest tombstone flake, clean on isolation + full re-run); Tier 2 green; `dirty-broadcast` PASS 25w/0v/0w (`soak-results/dirty-broadcast-20260813T042808Z`); `paper-dirty-falling-block` PASS 27w/0v/0w (`soak-results/paper-dirty-falling-block-paper-20260813T043805Z`); review round MERGE WITH FIXES 0 MAJOR / 3 MINOR, all fixed (findings table below) |
+| A | dirty interval 0 + lodDistance default 300 (+ program prereqs) | merged | 2026-08-13 | 2026-08-13 | 2026-08-13 (8f2b5037) | [#125](https://github.com/VoX/lod-server-support/pull/125) | Tier 1 both platforms green (one cataloged MemoryLodStoreTest tombstone flake, clean on isolation + full re-run); Tier 2 green; `dirty-broadcast` PASS 25w/0v/0w (`soak-results/dirty-broadcast-20260813T042808Z`); `paper-dirty-falling-block` PASS 27w/0v/0w (`soak-results/paper-dirty-falling-block-paper-20260813T043805Z`); review round MERGE WITH FIXES 0 MAJOR / 3 MINOR, all fixed (findings table below) |
 | B | disk-read gate + scenario + 5-script pins + echo move + rig deploy | pending | — | — | — | — | — |
 | C | /lsslod set + help + backfill estimate + descriptions | pending | — | — | — | — | — |
 | D | /lss reset + .lss cache relocation | pending | — | — | — | — | — |


### PR DESCRIPTION
Stage-table row flip only (docs-only, CI-skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)