### PR TITLE
docs: v0.11.0 deploy log — rig deployed, pause live

### DIFF
--- a/docs/planning/v0.11.0-progress.md
+++ b/docs/planning/v0.11.0-progress.md
@@ -453,8 +453,19 @@ Clean lenses (union): SET-repush × FARP (R-5 held), runtime-mutation threading 
       second GUI client); PENDING user scheduling with the E2 live gate
 - [ ] E3: `run-folia` two-client session (FARP's own Folia gate — the new
       cross-region equipment/pose read class; experimental label rules apply)
-- [ ] F→G: Modrinth dev-deploy + config refresh to new defaults + **user
-      manual-testing sign-off** (G is blocked on this)
+- [x] F→G: Modrinth dev-deploy + config refresh — **DONE 2026-08-13** (user-directed
+      during the pause): jar `lod-server-support-fabric-0.11.0+26.2.jar` (main @
+      5472a8f4, incl. the yield-default flip) uploaded over SFTP; the rig config
+      DELETED and regenerated to full v0.11.0 fresh defaults (user's preference —
+      known delta: lodStoreMaxMB now uncapped, recorded in the deploy doc); restart
+      via RCON `stop` (the panel auto-restarts — no archon token needed, rig note
+      recorded); verified live: distance 300, store=full serving warm (h=16k),
+      read_gate=0/2 AUTO with gated= climbing on the join burst, read_path=
+      moonrise-low, Yield armed=true and FIRING on a real WAN join (yielded=2,
+      11.8 MB withheld), FarPlayers subs=1. A 100 kbps throttle proxy for
+      slow-link testing is staged at ~/throttle-proxy.py (rig notes)
+- [ ] F→G: **user manual-testing sign-off** (G is blocked on this — the pause is
+      now LIVE on the deployed build)
 - [ ] G: per-line Voxy javap + reset smoke (26.1, 1.21.11) + the FARP renderer
       verification on EACH support line (E2 script re-run, two-client)
 


### PR DESCRIPTION
Checklist record of the user-directed dev deploy (jar from 5472a8f4 incl. the yield flip; config delete-and-regenerate; RCON-stop restart; live verification). Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)