### PR TITLE
fix: discovery-ladder dialect-flip hard-kick heal + 10 s rung delay

### DIFF
--- a/docs/planning/release-notes-v0.11.0-modrinth.md
+++ b/docs/planning/release-notes-v0.11.0-modrinth.md
@@ -13,3 +13,7 @@ Credit: SeeU (MIT) as prior art. Folia remains experimental.
 `dirtyBroadcastIntervalSeconds: 0` = broadcasts off, `lodDistanceChunks` default
 now 300, LOD yields to vanilla transport by default
 (`lodYieldsToVanillaTransport: true`), client cache in `.lss/` for fresh installs.
+
+**Fixed**: a "Packet was larger than I expected" disconnect right after joining
+on slow connections (a protocol-discovery race with the server's legacy-client
+support; the client also waits longer before trying legacy protocols now).

--- a/docs/planning/release-tag-v0.11.0-mc1.21.11.txt
+++ b/docs/planning/release-tag-v0.11.0-mc1.21.11.txt
@@ -1,3 +1,7 @@
+### Bug Fixes
+
+- **Fixes a disconnect on slow connections** — joining through a slow or saturated link could kill the connection right after login with "Packet ... was larger than I expected": the client's legacy-server discovery could leave the server briefly speaking an older wire dialect just as the session started, and the first terrain packets then broke the connection. The client now re-confirms its protocol before requesting any terrain, and waits longer (10 seconds per step) before trying legacy protocols, so slow joins no longer trigger false legacy fallbacks. Fabric client.
+
 ### New Features
 
 - **Far players** — see other players far beyond normal render distance as simple player models standing in your LOD terrain: positions, poses (sneak/glide/swim), equipment, name tags, and smooth motion including elytra dead-reckoning. On by default — including for servers upgrading from earlier versions (`farPlayers` mode `on`; `opt-in` and `off` available, and the exclude list/permission below give per-player control). Bandwidth cost is tiny — quantized positions, change-only equipment, names sent once. Players riding horses, boats, minecarts or any other vanilla entity render seated WITH their mount; mounts your client doesn't know (modded, other MC versions) show an unmounted player instead — never a crash. Prior art: the SeeU mod (MIT) — reimplemented natively in LSS with server-authoritative privacy. On Folia this is the largest new surface and Folia support remains **experimental**.

--- a/docs/planning/release-tag-v0.11.0-mc26.1.txt
+++ b/docs/planning/release-tag-v0.11.0-mc26.1.txt
@@ -1,3 +1,7 @@
+### Bug Fixes
+
+- **Fixes a disconnect on slow connections** — joining through a slow or saturated link could kill the connection right after login with "Packet ... was larger than I expected": the client's legacy-server discovery could leave the server briefly speaking an older wire dialect just as the session started, and the first terrain packets then broke the connection. The client now re-confirms its protocol before requesting any terrain, and waits longer (10 seconds per step) before trying legacy protocols, so slow joins no longer trigger false legacy fallbacks. Fabric client.
+
 ### New Features
 
 - **Far players** — see other players far beyond normal render distance as simple player models standing in your LOD terrain: positions, poses (sneak/glide/swim), equipment, name tags, and smooth motion including elytra dead-reckoning. On by default — including for servers upgrading from earlier versions (`farPlayers` mode `on`; `opt-in` and `off` available, and the exclude list/permission below give per-player control). Bandwidth cost is tiny — quantized positions, change-only equipment, names sent once. Players riding horses, boats, minecarts or any other vanilla entity render seated WITH their mount; mounts your client doesn't know (modded, other MC versions) show an unmounted player instead — never a crash. Prior art: the SeeU mod (MIT) — reimplemented natively in LSS with server-authoritative privacy. On Folia this is the largest new surface and Folia support remains **experimental**.

--- a/docs/planning/release-tag-v0.11.0.txt
+++ b/docs/planning/release-tag-v0.11.0.txt
@@ -1,3 +1,7 @@
+### Bug Fixes
+
+- **Fixes a disconnect on slow connections** — joining through a slow or saturated link could kill the connection right after login with "Packet ... was larger than I expected": the client's legacy-server discovery could leave the server briefly speaking an older wire dialect just as the session started, and the first terrain packets then broke the connection. The client now re-confirms its protocol before requesting any terrain, and waits longer (10 seconds per step) before trying legacy protocols, so slow joins no longer trigger false legacy fallbacks. Fabric client.
+
 ### New Features
 
 - **Far players** — see other players far beyond normal render distance as simple player models standing in your LOD terrain: positions, poses (sneak/glide/swim), equipment, name tags, and smooth motion including elytra dead-reckoning. On by default — including for servers upgrading from earlier versions (`farPlayers` mode `on`; `opt-in` and `off` available, and the exclude list/permission below give per-player control). Bandwidth cost is tiny — quantized positions, change-only equipment, names sent once. Players riding horses, boats, minecarts or any other vanilla entity render seated WITH their mount; mounts your client doesn't know (modded, other MC versions) show an unmounted player instead — never a crash. Prior art: the SeeU mod (MIT) — reimplemented natively in LSS with server-authoritative privacy. On Folia this is the largest new surface and Folia support remains **experimental**.

--- a/docs/planning/v0.11.0-progress.md
+++ b/docs/planning/v0.11.0-progress.md
@@ -355,6 +355,32 @@ Clean lenses (union): SET-repush × FARP (R-5 held), runtime-mutation threading 
   variant; the deploy doc amended to the user's delete-and-regenerate config
   refresh (known delta: lodStoreMaxMB regenerates uncapped — recorded there).
 
+- 2026-08-13 — **Found-bug loop (pause, live): discovery-ladder dialect-flip
+  hard-kick.** Both a v0.10.0 client and the dev client joining the rig through
+  the 1000 kbps throttle died to `DecoderException … found 26871 bytes extra`
+  (identical byte count — the same warm-store column) shortly after establish.
+  Mechanism (server logs ×3 + client disconnect files + code trace): the
+  saturated link delayed the SessionConfig echoes past the 5 s rung delay, the
+  ladder walked 20→19→16 (the server's dialect mark following each announce),
+  the late 20 echo established, and the manager's first want-set — C2S is
+  byte-identical across dialects — raced ahead of the downgrade guard's heal on
+  the C2S stream: the still-v16-marked server answered it with legacy-layout
+  columns that the client's v20 codec cannot consume (netty hard kick, NOT a
+  contained ingest failure — corrects the earlier "contained + re-served"
+  claim about this window). FIX (fix/ladder-establish-reannounce): the
+  establish path re-announces the accepted version BEFORE the manager is built
+  when `currentAnnounce != version` (TCP ordering puts the server's dialect
+  flip ahead of the first batch); send-success-only commit; the downgrade
+  guard also commits so heal echoes never re-announce; closes the pre-heal
+  transient decode-arming window as a side effect. PLUS the user-directed
+  timeout raise: `V16_DISCOVERY_DELAY_TICKS` 100 → 200 (10 s/rung, ~20 s worst
+  case to v16 — slower legacy discovery accepted). Owning gates (C3 ladder =
+  v0.10.0 client code): ClientSessionGateTest 42/42 incl. 4 new pins + the
+  transient-window pin inverted (window now closed), full T1 + T2 re-run.
+  Design doc updated (v16-client-compat-design.md deviations list). Released
+  v0.9.1–v0.10.0 clients still carry the race on saturated links — client-side
+  fix, ships v0.11.0; the rig server needs no redeploy for it.
+
 ## Release-notes ledger (stage-accreted; stage F consolidates into the tag drafts)
 
 - (A, Configuration) **`dirtyBroadcastIntervalSeconds: 0` now disables dirty
@@ -424,6 +450,14 @@ Clean lenses (union): SET-repush × FARP (R-5 held), runtime-mutation threading 
   distant player twice); set `farPlayersWithSeeU: true` or "Prefer LSS Far
   Players" in the Sodium screen to use LSS instead. On LSS-only servers SeeU
   shows nothing, so prefer LSS there. Fabric client.
+- (pause found-bug, Bug Fixes) **Fixes a disconnect on slow connections**
+  ("Packet … was larger than I expected") — on a saturated link the client's
+  legacy-server discovery could leave the server briefly speaking an older
+  wire dialect just as the session started, and the first terrain packets
+  then killed the connection. The client now re-confirms its protocol before
+  requesting anything, and waits longer (10 s per step) before trying legacy
+  protocols, so slow joins no longer trigger false legacy fallbacks. Fabric
+  client.
 
 ## Manual-verification checklist (user-assisted items — escalate when blocked >1 stage)
 

--- a/docs/planning/v16-client-compat-design.md
+++ b/docs/planning/v16-client-compat-design.md
@@ -23,8 +23,26 @@ production changes), and the isolation held. Where the code diverges from §§2�
   the implementation splits it into `ClientSessionGate` (discovery timer + `isV16Server` + the
   version-acceptance ladder) and `V16ClientWire` (the one static column-decode flag).
   Functionally equivalent, arguably cleaner — but the §5 diagram names a class that does not exist.
-- **Discovery delay is 100 ticks (5 s), not 60/3 s** (`V16_DISCOVERY_DELAY_TICKS`). Widened for
-  margin against a healthy v18 server whose SessionConfig is briefly delayed by a join-time stall.
+- **Discovery delay is 200 ticks (10 s), not 60/3 s** (`V16_DISCOVERY_DELAY_TICKS`). Originally
+  widened to 100/5 s for margin against a healthy server whose SessionConfig is briefly delayed by
+  a join-time stall; doubled 2026-08-13 (user decision) after a live 1 Mbps throttled join held the
+  config echo past 10 s and walked the whole ladder against a healthy v20 server. Slower legacy
+  discovery (~20 s worst case to a v16 session) is the accepted cost.
+- **NEW — establish-path dialect-flip heal (2026-08-13, found live as a client hard-disconnect).**
+  When the ladder advanced past the version a late echo establishes, the server's dialect mark
+  follows the client's LAST announce — and because C2S batches are byte-identical across dialects,
+  the new manager's first want-set raced ahead of the downgrade guard's heal and was answered with
+  LEGACY-LAYOUT columns: a netty `DecoderException` hard kick ("found 26871 bytes extra") at the
+  client's current-dialect codec, killing the connection on every warm join through a slow link.
+  Fix in `ClientSessionGate.onSessionConfig`: at establish, if `currentAnnounce != version`, the
+  client re-announces the accepted version (mark-before-send) BEFORE the manager is built — TCP
+  ordering then guarantees the server's dialect flip precedes the first batch. Send-success-only
+  commit of `currentAnnounce` (a thrown send retries on the next config); the downgrade guard also
+  commits, so heal echoes never re-announce. This also closes the pre-heal transient decode window
+  (a raced lower echo could mis-arm legacy decode against the established stream until the guard
+  ran). Pinned by the `establishAfterTheLadderAdvancedReAnnounces*` family in
+  `ClientSessionGateTest`. Released v0.9.1–v0.10.0 clients carry the racy ladder and can still hit
+  the kick on saturated links; the heal ships with v0.11.0.
 - **NEW — downgrade guard + v18 re-assert (not in the plan; closes the review's headline finding).**
   Two independent review agents found that a slow-join v18 server (SessionConfig later than the
   discovery delay) makes the client fire the v16 fallback, which a compat-on v18 server *answers*,

--- a/fabric/src/main/java/dev/vox/lss/networking/client/ClientSessionGate.java
+++ b/fabric/src/main/java/dev/vox/lss/networking/client/ClientSessionGate.java
@@ -39,13 +39,18 @@ final class ClientSessionGate {
     }
 
     /** Ticks (client tick = 1/20 s) of SessionConfig silence before the discovery ladder
-     *  advances one rung (C3, XVER §6: announce 20 → 19 → 16). Generous (5 s per rung): a
-     *  healthy same-version server replies in well under a second, and the margin keeps a
-     *  briefly-stalled server (a join-time freeze on a heavy modded server) from tripping
-     *  the fallback. Should a rung slip through anyway, the downgrade guard in
-     *  {@link #onSessionConfig} re-asserts the established version rather than degrading.
-     *  Worst case to a v16 session: ~10 s of silence after the first announce. */
-    static final int V16_DISCOVERY_DELAY_TICKS = 100;
+     *  advances one rung (C3, XVER §6: announce 20 → 19 → 16). Generous (10 s per rung —
+     *  raised from 5 s, 2026-08-13): a healthy same-version server replies in well under a
+     *  second, but a SATURATED LINK can hold the whole join-time burst — the config echo
+     *  included — past 5 s (measured live through a 1 Mbps throttled proxy: the ladder
+     *  walked all three rungs against a healthy current server), and every false walk
+     *  costs a server-side dialect flip plus manager-rebuild churn that the establish
+     *  re-announce then has to heal. The margin's cost lands only on genuine legacy
+     *  servers — slower first LOD (worst case to a v16 session: ~20 s of silence after
+     *  the first announce), accepted per user decision 2026-08-13. Should a rung slip
+     *  through anyway, establishment re-announces the accepted version (see
+     *  {@link #onSessionConfig}) and the downgrade guard re-asserts it on raced echoes. */
+    static final int V16_DISCOVERY_DELAY_TICKS = 200;
 
     private final ClientColumnProcessor columnProcessor;
     // Sends the C2S handshake announcing the given protocol version; injected so tests can
@@ -310,10 +315,49 @@ final class ClientSessionGate {
                 int reAnnounce = this.sessionVersion;
                 V16ClientWire.markAnnouncedVersion(reAnnounce);
                 this.handshakeSender.accept(reAnnounce);
+                // Commit the announce (send-success only, matching the ladder's m4 rule)
+                // so the server's echo to this re-assert skips the establish-path
+                // re-announce below — without this the echo would observe a stale
+                // currentAnnounce and burn one redundant handshake round-trip.
+                this.currentAnnounce = reAnnounce;
             } catch (Exception e) {
                 LSSLogger.debug("re-assert handshake send failed: " + e.getMessage());
             }
             return;
+        }
+
+        // Dialect-flip heal at ESTABLISH (found live 2026-08-13 through a throttled 1 Mbps
+        // link, as a client hard-disconnect): when the ladder advanced past the version
+        // being established — the SLOW-ECHO race accepted above — the server's dialect
+        // mark follows this connection's LAST announce, so at this instant the server
+        // considers the session legacy and will serve LEGACY-LAYOUT columns. C2S batches
+        // are byte-identical across dialects (v16-compat design), so the new manager's
+        // first want-set would be accepted and answered in the wrong dialect — and a
+        // dialect-mismatched column frame is a netty-level DecoderException HARD KICK
+        // ("found N bytes extra"), not a contained ingest failure. Re-announce the
+        // accepted version BEFORE the manager exists: TCP ordering then guarantees the
+        // server's dialect flip precedes the first batch, so it can never answer a
+        // current client in a legacy layout. The raced lower echoes still land in the
+        // downgrade guard above (idempotent re-asserts). Bounded: the server's reply
+        // echoes this same version and currentAnnounce is committed below (send-success
+        // only — a thrown send leaves it stale so a re-sent config retries the heal),
+        // which makes the echo skip this branch. The != 0 conjunct keeps a connection
+        // that never announced (no handshake sent) from ever handshaking from here.
+        if (this.currentAnnounce != 0 && this.currentAnnounce != version) {
+            LSSLogger.info("Establishing protocol " + version + " after the discovery ladder "
+                    + "had advanced to v" + this.currentAnnounce + " (slow echo) — re-announcing v"
+                    + version + " so the server sheds the ladder's dialect mark before any "
+                    + "column is served.");
+            try {
+                // Mark-before-send: this also re-arms our own column decode for the
+                // ESTABLISHED dialect — the ladder had armed the legacy rung's decode,
+                // and a column arriving before the raced echoes heal it would misparse.
+                V16ClientWire.markAnnouncedVersion(version);
+                this.handshakeSender.accept(version);
+                this.currentAnnounce = version;
+            } catch (Exception e) {
+                LSSLogger.debug("establish re-announce send failed: " + e.getMessage());
+            }
         }
 
         this.isV16Server = v16;

--- a/fabric/src/main/java/dev/vox/lss/networking/payloads/SessionConfigS2CPayload.java
+++ b/fabric/src/main/java/dev/vox/lss/networking/payloads/SessionConfigS2CPayload.java
@@ -96,7 +96,7 @@ public record SessionConfigS2CPayload(
                         // same 4-field layout this arm reads (the data-version append is
                         // version-20-only, so isReadable() is false and it decodes 0).
                         // STICKY announce memory (review CRITICAL-1): the ladder's own 16
-                        // rung firing 5 s later must not push a still-in-flight 19 echo
+                        // rung firing 10 s later must not push a still-in-flight 19 echo
                         // to the foreign arm — that fabricated (19, enabled=false) and
                         // silently disabled LOD for the session. Gated on the client's own
                         // announce (mark-before-send causality, see V16ClientWire), so an

--- a/fabric/src/test/java/dev/vox/lss/networking/client/ClientSessionGateTest.java
+++ b/fabric/src/test/java/dev/vox/lss/networking/client/ClientSessionGateTest.java
@@ -439,7 +439,12 @@ class ClientSessionGateTest {
         assertEquals(64, gate.getServerLodDistance());
         assertNotNull(gate.getRequestManager(), "a v16 session still builds a manager (load-only)");
         assertEquals(List.of("rebuild"), events, "the legacy session builds exactly one manager");
-        assertEquals(List.of(V), handshakeVersions, "a SessionConfig reply sends no further handshake");
+        assertEquals(List.of(V, V16), handshakeVersions,
+                "accepting a v16 session when the last announce was 20 re-announces 16 — the "
+                        + "establish heal aligns the server's dialect mark with the accepted "
+                        + "session before any column flows (unreachable against a real v16 "
+                        + "server, which never replies cross-version; harmless there — a "
+                        + "re-register plus config re-send)");
     }
 
     @Test
@@ -659,9 +664,11 @@ class ClientSessionGateTest {
     void slowTwentyEchoAfterTheLadderAdvancedStillEstablishesAndTheRacedNineteenReasserts() {
         // The load-bearing race (C3 plan): a healthy v20 server whose echo was slow enough
         // that the ladder already announced 19. The late 20 echo must be ACCEPTED (rejecting
-        // would disable LOD against a healthy server); the server's 19 echo to our raced
-        // announce then hits the downgrade guard, which re-announces the ESTABLISHED 20 —
-        // healing the server-side dialect flip the 19 announce caused.
+        // would disable LOD against a healthy server). Establishment itself now heals the
+        // server-side dialect flip FIRST (the establish re-announce — see
+        // establishAfterTheLadderAdvancedReAnnouncesBeforeTheManagerIsBuilt); the server's
+        // 19 echo to our raced announce then hits the downgrade guard, whose re-announce of
+        // the ESTABLISHED 20 stays as the idempotent second assert.
         gate.onJoin(true, false, true, true);
         tickDiscovery(ClientSessionGate.V16_DISCOVERY_DELAY_TICKS); // → announce 19
         assertEquals(List.of(V, V19), handshakeVersions);
@@ -672,20 +679,131 @@ class ClientSessionGateTest {
         V16ClientWire.observeSessionConfigVersion(V);
         gate.onSessionConfig(config(V, true), true, true); // the slow 20 echo lands
         assertTrue(gate.isServerEnabled(), "the late current-version echo must establish");
+        assertEquals(List.of(V, V19, V), handshakeVersions,
+                "the establish heal re-announces the accepted 20 immediately — the manager's "
+                        + "first batch must never race the server's dialect flip");
         handshakeVersions.clear();
 
         V16ClientWire.observeSessionConfigVersion(V19); // the raced 19 echo, netty half
-        assertTrue(V16ClientWire.isNativeBodySession(),
-                "premise: the raced echo transiently arms (announced-19 is sticky)");
+        assertFalse(V16ClientWire.isNativeBodySession(),
+                "the establish heal already retired the 19 announce, so the raced echo can "
+                        + "no longer arm native-body decode — the pre-heal transient window "
+                        + "(a raced 19 frame mis-arming against the live v20 stream) is CLOSED");
         gate.onSessionConfig(config(V19, true), true, true); // …then the main half
         assertEquals(List.of(V), handshakeVersions,
-                "the guard re-announces the ESTABLISHED version, healing the server-side flip");
+                "the guard re-announces the ESTABLISHED version — the idempotent second assert");
         assertFalse(V16ClientWire.isNativeBodySession(),
-                "the guard's re-assert disarms the transient window immediately");
+                "still disarmed after the guard's re-assert");
         V16ClientWire.observeSessionConfigVersion(V19);
         assertFalse(V16ClientWire.isNativeBodySession(),
                 "after the re-assert, a later unsolicited 19 frame must not arm "
                         + "native-body decode against the live v20 stream");
+    }
+
+    // ---- The establish-path dialect-flip heal (found live 2026-08-13: a 1 Mbps throttled
+    // link walked the full ladder against a healthy v20 server; the late 20 echo
+    // established, the manager's first want-set raced ahead of any heal on the C2S stream,
+    // and the still-v16-marked server answered it with legacy-layout columns — a netty
+    // DecoderException hard kick at the client's v20 codec, "found 26871 bytes extra").
+
+    @Test
+    void establishAfterTheLadderAdvancedReAnnouncesBeforeTheManagerIsBuilt() {
+        // THE ordering pin: the re-announce must be SENT before the manager exists. TCP
+        // ordering is the entire correctness argument — the server's dialect flip must
+        // precede the first want-set batch, and the batch cannot exist before the manager.
+        var ordered = new ArrayList<String>();
+        var orderedGate = new ClientSessionGate(processor,
+                v -> ordered.add("hs:" + v),
+                cfg -> { ordered.add("manager"); return new RecordingManager(new ArrayList<>()); });
+
+        orderedGate.onJoin(true, false, true, true);
+        for (int i = 0; i < 2 * ClientSessionGate.V16_DISCOVERY_DELAY_TICKS; i++) {
+            orderedGate.tickDiscoveryLadder(); // walks 19 then 16
+        }
+        assertEquals(List.of("hs:" + V, "hs:" + V19, "hs:" + V16), ordered,
+                "premise: the full ladder walked before any echo arrived");
+
+        orderedGate.onSessionConfig(config(V, true), true, true); // the slow 20 echo lands
+
+        assertEquals(List.of("hs:" + V, "hs:" + V19, "hs:" + V16, "hs:" + V, "manager"), ordered,
+                "the establish re-announce goes out BEFORE the manager is built — TCP "
+                        + "ordering then guarantees the server sheds its legacy dialect mark "
+                        + "before the first batch can arrive");
+
+        V16ClientWire.observeSessionConfigVersion(V16);
+        assertFalse(V16ClientWire.isColumnSourceless(),
+                "the establish re-announce also retires the ladder's v16 announce — a late "
+                        + "legacy frame must not arm sourceless decode against the v20 stream");
+    }
+
+    @Test
+    void establishReAnnounceEchoTakesThePlainReconfigPathWithoutAnotherHandshake() {
+        // Boundedness: the server replies to the establish re-announce with a fresh v20
+        // config. currentAnnounce was committed at the re-announce, so the echo is the
+        // normal re-config path — never a handshake ping-pong.
+        gate.onJoin(true, false, true, true);
+        tickDiscovery(2 * ClientSessionGate.V16_DISCOVERY_DELAY_TICKS); // → announced 19, 16
+        gate.onSessionConfig(config(V, true), true, true); // slow echo → establish + heal
+        assertEquals(List.of(V, V19, V16, V), handshakeVersions,
+                "premise: the establish heal re-announced exactly once");
+
+        gate.onSessionConfig(config(V, true), true, true); // the heal's own echo
+
+        assertEquals(List.of(V, V19, V16, V), handshakeVersions,
+                "the heal echo re-configures without any further handshake");
+        assertTrue(gate.isServerEnabled());
+    }
+
+    @Test
+    void thrownEstablishReAnnounceStillEstablishesAndTheNextConfigRetriesTheHeal() {
+        // A thrown heal send must not block establishment (the session is still viable —
+        // the connection may just be mid-teardown), and the uncommitted announce means a
+        // re-sent config RETRIES the heal instead of silently accepting the stale mark.
+        var sends = new ArrayList<Integer>();
+        boolean[] failNext = {false};
+        var throwingGate = new ClientSessionGate(processor,
+                v -> {
+                    if (failNext[0]) { failNext[0] = false; throw new IllegalStateException("send failed"); }
+                    sends.add(v);
+                },
+                cfg -> { events.add("rebuild"); return new RecordingManager(events); });
+
+        throwingGate.onJoin(true, false, true, true);
+        for (int i = 0; i < 2 * ClientSessionGate.V16_DISCOVERY_DELAY_TICKS; i++) {
+            throwingGate.tickDiscoveryLadder();
+        }
+        assertEquals(List.of(V, V19, V16), sends, "premise: the full ladder walked");
+
+        failNext[0] = true;
+        throwingGate.onSessionConfig(config(V, true), true, true); // heal send THROWS
+        assertEquals(List.of(V, V19, V16), sends, "the thrown heal sent nothing");
+        assertTrue(throwingGate.isServerEnabled(), "a thrown heal must not block establishment");
+        assertNotNull(throwingGate.getRequestManager());
+
+        throwingGate.onSessionConfig(config(V, true), true, true); // a re-sent config
+        assertEquals(List.of(V, V19, V16, V), sends,
+                "the stale announce is retried on the next accepted config");
+
+        throwingGate.onSessionConfig(config(V, true), true, true);
+        assertEquals(List.of(V, V19, V16, V), sends, "committed — no further handshake");
+    }
+
+    @Test
+    void slowNineteenEchoAfterTheLadderReachedSixteenReAnnouncesNineteen() {
+        // The heal generalizes per rung: a v19 server whose echo lands after the ladder
+        // announced 16 establishes the 19 session AND re-announces 19 — a v19-native
+        // client fed source-less v16-layout columns is the same decoder kick one rung down.
+        gate.onJoin(true, false, true, true);
+        tickDiscovery(2 * ClientSessionGate.V16_DISCOVERY_DELAY_TICKS); // 19 then 16
+        assertEquals(List.of(V, V19, V16), handshakeVersions);
+
+        V16ClientWire.observeSessionConfigVersion(V19);
+        gate.onSessionConfig(config(V19, true), true, true);
+
+        assertTrue(gate.isServerEnabled(), "the late 19 echo must establish");
+        assertNotNull(gate.getRequestManager());
+        assertEquals(List.of(V, V19, V16, V19), handshakeVersions,
+                "establishing 19 after the 16 announce re-announces 19 before any column flows");
     }
 
     @Test
@@ -764,6 +882,9 @@ class ClientSessionGateTest {
         assertTrue(gate.isV16Server(), "a first-and-only v16 config builds the legacy session");
         assertNotNull(gate.getRequestManager());
         assertEquals(List.of("rebuild"), events);
-        assertEquals(List.of(V), handshakeVersions, "no v18 re-assert — this was not a downgrade");
+        assertEquals(List.of(V, V16), handshakeVersions,
+                "no DOWNGRADE-guard re-assert (this was not a downgrade of a live session) — "
+                        + "the second handshake is the establish heal re-announcing the "
+                        + "accepted 16, because the last announce was 20");
     }
 }


### PR DESCRIPTION
Found live during the v0.11.0 Modrinth pause (1 Mbps throttled joins): both a v0.10.0 client and the dev client hard-disconnected with `DecoderException … found 26871 bytes extra` right after establish. Root cause: the discovery ladder's establish path never re-announced, so the first want-set raced the downgrade guard's heal and the still-legacy-marked server answered a current client with legacy-layout columns — a netty hard kick.

Fix: establish-path re-announce before the manager is built (TCP ordering closes the window), guard commit for heal-echo boundedness, and `V16_DISCOVERY_DELAY_TICKS` 100→200 (user decision: slower legacy discovery over false ladder walks on slow links).

Gates: ClientSessionGateTest 42/42 (4 new pins incl. the re-announce-before-manager ordering pin; the transient decode-window pin inverted — the window is now closed), full Tier 1, Tier 2, Tier 3 all green. Progress doc, design doc, and all four release-note drafts updated (new Bug Fixes section).

🤖 Generated with [Claude Code](https://claude.com/claude-code)