### PR TITLE
docs: pause-checklist redeploy log (e7b268c4)

### DIFF
--- a/docs/planning/v0.11.0-progress.md
+++ b/docs/planning/v0.11.0-progress.md
@@ -525,7 +525,15 @@ Clean lenses (union): SET-repush × FARP (R-5 held), runtime-mutation threading 
       read_gate=0/2 AUTO with gated= climbing on the join burst, read_path=
       moonrise-low, Yield armed=true and FIRING on a real WAN join (yielded=2,
       11.8 MB withheld), FarPlayers subs=1. A 100 kbps throttle proxy for
-      slow-link testing is staged at ~/throttle-proxy.py (rig notes)
+      slow-link testing is staged at ~/throttle-proxy.py (rig notes).
+      **REDEPLOYED 2026-08-13 ~17:45 UTC (user-directed)** with post-merge main
+      @ e7b268c4 (jar sha a401d78c9de08eaf..., 7,896,313 B): folds in the
+      pause-time found-bug fixes — the ladder establish-heal + 10 s rungs
+      (PR #144) and the gate's Amendment 2 router retention (PR #145). Boot
+      verified over RCON: `gate_stops=` in the diag tokens (the retention
+      receipt), read_path=moonrise-low, store=full state=ok (sweep dropped
+      1210 stale rows / 17 changed regions — normal), Yield armed=true,
+      clean log. The pause's manual-testing window continues on this build.
 - [ ] F→G: **user manual-testing sign-off** (G is blocked on this — the pause is
       now LIVE on the deployed build)
 - [ ] G: per-line Voxy javap + reset smoke (26.1, 1.21.11) + the FARP renderer


### PR DESCRIPTION
Records the user-directed rig redeploy of post-merge main (ladder heal #144 + gate retention #145) with the RCON boot verification, in the F→G checklist's deploy item.

🤖 Generated with [Claude Code](https://claude.com/claude-code)