### PR TITLE
fix: ceiling estimator pure-drain sampling (live-gate falsification)

### DIFF
--- a/common/src/main/java/dev/vox/lss/common/processing/AbstractPlayerRequestState.java
+++ b/common/src/main/java/dev/vox/lss/common/processing/AbstractPlayerRequestState.java
@@ -147,14 +147,34 @@ public abstract class AbstractPlayerRequestState<T> {
         return this.autoCeilingGauge;
     }
 
+    /** Fast-streak up-recovery (round-3 amendment): consecutive probe intervals where
+     *  LSS wrote at least this much AND the channel gauge still read ~empty. */
+    static final long AUTO_CEILING_UP_EVIDENCE_MIN_WRITE = 32L * 1024;
+    static final long AUTO_CEILING_UP_EVIDENCE_EPSILON = 4L * 1024;
+    static final int AUTO_CEILING_UP_STREAK_TICKS = 40; // ~2 s at 20 Hz
+    private int ceilFastStreak;
+
     /**
-     * One estimator step at the authoritative probe read (design §Estimator):
-     * {@code drained = pending_prev + lss_wire_written_since_last_probe - pending_now},
-     * sampled only across busy intervals ({@code pending_prev > 0}), skipping negative
-     * samples (other writers grew the queue — vanilla bursts, far-player frames) and
-     * no-signal reads (-1 poisons the CURRENT and the NEXT sample via pendingPrev).
-     * A genuine zero-drain sample trains (a stalled link is real signal). Returns the
-     * derived ceiling in bytes, or -1 when AUTO is disarmed/untrained.
+     * One estimator step at the authoritative probe read (design §Estimator, as amended
+     * round 3 — the LIVE rig falsified the written-term arithmetic): netty writes are
+     * ASYNC, so bytes handed to the event loop may not be reflected in the pending
+     * gauge for milliseconds — a burst tick's sample {@code prev + written − now} then
+     * reads a phantom multi-MB/s drain (measured live: EWMA 6 MB/s on a 500 KB/s link,
+     * ceil=1.5 MB, the ceiling never bound). The estimator therefore samples ONLY
+     * PURE-DRAIN intervals ({@code written == 0} since the last probe — hold ticks,
+     * which dominate on exactly the links the ceiling exists for):
+     * {@code drained = pending_prev − pending_now}, no written term at all. Busy guard
+     * ({@code prev > 0}), negative guard (another writer grew the queue), and the
+     * no-signal poison are unchanged; a genuine zero-drain sample still trains.
+     *
+     * <p>UP-recovery (pure-drain sampling alone cannot observe an IMPROVED link — a
+     * converged flush writes every tick): {@link #AUTO_CEILING_UP_STREAK_TICKS}
+     * consecutive intervals of "wrote ≥ 32 KB and the gauge still reads ≤ 4 KB" double
+     * the EWMA — bounded probing whose overshoot is corrected within one hold tick's
+     * real sample, climbing a genuinely-fast link to the disarm threshold in a few
+     * seconds. Visibility lag cannot sustain the streak (~2 s of consistently-empty
+     * reads after MB-scale writes is genuine drain, not a millisecond hand-off).
+     * Returns the derived ceiling in bytes, or -1 when AUTO is disarmed/untrained.
      */
     private long updateDrainEstimatorAndDeriveCeiling(long pendingNow) {
         long now = this.ceilClock.getAsLong();
@@ -165,18 +185,32 @@ public abstract class AbstractPlayerRequestState<T> {
         long dtNanos = now - this.ceilLastProbeNanos;
         boolean probedBefore = this.ceilLastProbeNanos != 0;
         this.ceilLastProbeNanos = now;
-        if (probedBefore && prev > 0 && pendingNow >= 0 && dtNanos > 0) {
-            long drained = prev + written - pendingNow;
-            if (drained >= 0) {
-                double rate = drained * 1e9 / dtNanos;
-                if (!this.ceilTrained) {
-                    this.ceilDrainEwmaBytesPerSec = rate;
-                    this.ceilTrained = true;
-                } else {
-                    double alpha = 1 - Math.exp(-dtNanos / AUTO_CEILING_EWMA_TAU_NANOS);
-                    this.ceilDrainEwmaBytesPerSec =
-                            alpha * rate + (1 - alpha) * this.ceilDrainEwmaBytesPerSec;
+        if (probedBefore && dtNanos > 0 && pendingNow >= 0) {
+            if (written == 0 && prev > 0) {
+                // Pure-drain sample: the only interval shape whose arithmetic the async
+                // write hand-off cannot corrupt.
+                long drained = prev - pendingNow;
+                if (drained >= 0) {
+                    double rate = drained * 1e9 / dtNanos;
+                    if (!this.ceilTrained) {
+                        this.ceilDrainEwmaBytesPerSec = rate;
+                        this.ceilTrained = true;
+                    } else {
+                        double alpha = 1 - Math.exp(-dtNanos / AUTO_CEILING_EWMA_TAU_NANOS);
+                        this.ceilDrainEwmaBytesPerSec =
+                                alpha * rate + (1 - alpha) * this.ceilDrainEwmaBytesPerSec;
+                    }
                 }
+                this.ceilFastStreak = 0;
+            } else if (this.ceilTrained
+                    && written >= AUTO_CEILING_UP_EVIDENCE_MIN_WRITE
+                    && pendingNow <= AUTO_CEILING_UP_EVIDENCE_EPSILON) {
+                if (++this.ceilFastStreak >= AUTO_CEILING_UP_STREAK_TICKS) {
+                    this.ceilFastStreak = 0;
+                    this.ceilDrainEwmaBytesPerSec *= 2;
+                }
+            } else {
+                this.ceilFastStreak = 0;
             }
         }
         if (!this.ceilTrained) return -1; // optimistic start: no ceiling until evidence

--- a/docs/planning/auto-outbound-ceiling-design.md
+++ b/docs/planning/auto-outbound-ceiling-design.md
@@ -286,6 +286,27 @@ exceed it — round-2 nit).
   switch, the ChannelAccessorContractTest pin, the inverted Paper floor
   assert, the full docs/notes sweep, `deferred=` meaning flip, volatile
   `ceil=` gauge, Paper goldens verified unaffected. ALL folded into this v2.
+- **Round 3 (2026-08-13, LIVE FALSIFICATION on the rig — the acceptance gate
+  earning its keep):** the first deployed build measured `ceil=1.5 MB,
+  deferred=0, yielded=668` on the 4 Mbps session — the EWMA trained to ~6 MB/s
+  on a 500 KB/s link and the ceiling never bound (user-observed: vanilla
+  updates arriving in 3-5 s clumps = 1.5 MB / 500 KB/s). ROOT CAUSE all three
+  review rounds missed: netty writes are ASYNC — bytes handed to the event
+  loop are not yet reflected in the pending gauge, so a burst tick's
+  written-inclusive sample (`prev + written − now`) reads phantom multi-MB/s
+  drain (~28 MB/s spikes live). FIX: the estimator samples ONLY PURE-DRAIN
+  intervals (`written == 0` since the last probe: `drained = prev − now`, no
+  written term — hold ticks dominate on exactly the links the ceiling serves),
+  plus a bounded fast-streak UP-recovery (40 consecutive intervals of "wrote
+  ≥ 32 KB, gauge still ≤ 4 KB" double the EWMA — pure-drain sampling alone
+  cannot observe an improved link, and visibility lag cannot sustain a 2 s
+  streak). The stability §'s "samples flow while the ceiling binds" claim is
+  amended: in converged partial-flush states samples pause and the ceiling
+  freezes (degradation re-samples via holds; improvement recovers via the
+  streak). Confirmed live: capping the player's bandwidth to 0.4 MB/s (the
+  burst-bank experiment) collapsed the latency to normal — the injection
+  amplitude was the entire effect.
+
 - **Round 2 (2026-08-13, delta review by the round-1 control reviewer):**
   IMPLEMENT WITH FIXES. Fixes folded: the 2 MB constant is a DISARM threshold,
   not a clamp (a clamp silently governs fast clients under a raised bandwidth

--- a/docs/planning/v0.11.0-progress.md
+++ b/docs/planning/v0.11.0-progress.md
@@ -434,6 +434,13 @@ Clean lenses (union): SET-repush × FARP (R-5 held), runtime-mutation threading 
   moved-wrongly M2 resolved, checker comment, notes items ×4, this pair).
   Live acceptance gate: the next 4 Mbps throttled session (deferred= climbing,
   yielded= near-quiet, ceil= ~100-150 KB, near-vanilla action latency).
+  **ROUND 3 (same day): the live gate FALSIFIED the first build** — ceil=1.5 MB
+  (EWMA 12x over: async netty writes made burst-tick samples read phantom
+  drain), fixed by pure-drain-interval sampling + the fast-streak up-recovery
+  (fix/ceiling-pure-drain-sampling; 2 new pins). The 0.4 MB/s bandwidth-cap
+  experiment confirmed the mechanism live (latency collapsed to normal — the
+  user: "working perfectly"). A post-deploy 2-Fable whole-feature review round
+  is user-ordered on top.
 
 ## Release-notes ledger (stage-accreted; stage F consolidates into the tag drafts)
 

--- a/fabric/src/test/java/dev/vox/lss/common/processing/AutoOutboundCeilingTest.java
+++ b/fabric/src/test/java/dev/vox/lss/common/processing/AutoOutboundCeilingTest.java
@@ -287,6 +287,58 @@ class AutoOutboundCeilingTest {
     }
 
     @Test
+    void writtenIntervalsNeverSampleTheAsyncLagRegression() throws Exception {
+        // Round-3 amendment (found LIVE on the rig): netty writes are ASYNC, so a
+        // burst tick's written bytes may not be in the pending gauge yet — the old
+        // written-inclusive sample read a phantom multi-MB/s drain (measured: EWMA
+        // 6 MB/s on a 500 KB/s link, ceil=1.5 MB, the ceiling never bound). An
+        // interval with ANY written bytes must not sample, however drain-shaped its
+        // arithmetic looks.
+        trainTo500KBps(); // ceil 125 KB from pure-drain samples
+        tickClock();
+        setPending(75_000); // steady: this tick's own sample is 0-drain (tiny decay)
+        state.addReadyPayload(new QueuedPayload<>("burst", 100_000, 0, POS_1));
+        Thread.sleep(50);
+        autoFlush(); // probe first (gauge settles), THEN writes 100 KB
+        assertEquals(List.of("burst"), sent, "premise: the burst left (presence gate)");
+        long gaugeAfterWrite = state.getAutoCeilingGauge();
+        tickClock();
+        setPending(0); // the phantom shape: prev 75K + written 100K − now 0 would
+                       // have read 3.5 MB/s under the old written-inclusive sample
+        autoFlush();
+        assertEquals(gaugeAfterWrite, state.getAutoCeilingGauge(),
+                "a written interval must NOT train — the async hand-off makes its "
+                        + "arithmetic read phantom drain (3.5 MB/s here, 28 MB/s live)");
+    }
+
+    @Test
+    void fastStreakDoublesTheEwmaTowardDisarm() throws Exception {
+        // Pure-drain sampling cannot observe an IMPROVED link (a converged flush
+        // writes every tick) — the bounded up-recovery: 40 consecutive intervals of
+        // "wrote >= 32 KB, gauge still ~empty" double the EWMA; a genuinely fast
+        // link climbs to the disarm threshold in a few rounds, and an overshoot is
+        // corrected by the next hold tick's real sample.
+        trainTo500KBps(); // EWMA ~500 KB/s, ceil ~125 KB
+        // Each 40-iteration round yields ~one doubling (the round's first interval has
+        // written=0 from the previous probe and samples instead, resetting the streak);
+        // ~5 doublings take the EWMA past the 8 MB/s that computes over the 2 MB bar.
+        for (int round = 0; round < 7 && state.getAutoCeilingGauge() != -1; round++) {
+            for (int i = 0; i <= AbstractPlayerRequestState.AUTO_CEILING_UP_STREAK_TICKS; i++) {
+                tickClock();
+                setPending(0); // gauge empty every read
+                state.addReadyPayload(new QueuedPayload<>("w" + round + "_" + i,
+                        40_000, 100 + round * 100 + i, POS_1));
+                Thread.sleep(1);
+                autoFlush(); // writes 40 KB; next probe sees pending 0 → streak++
+            }
+        }
+        assertEquals(-1, state.getAutoCeilingGauge(),
+                "sustained wrote-and-vanished evidence must climb the EWMA to the "
+                        + "disarm threshold (500 KB/s x2 x2 x2 crosses 8 MB/s > the "
+                        + "2 MB-computed bar) — an improved link is never left clipped");
+    }
+
+    @Test
     void nonAutoOverloadsNeverTrainOrGate() throws Exception {
         // The S-9a defaults pin, extended: the 7-arg overload (auto=false) must keep 0
         // meaning "no ceiling at all" — busy probe reads must not train anything.


### PR DESCRIPTION
The 4 Mbps live gate caught the estimator training 12× over (async netty writes make burst-tick samples read phantom drain), so the ceiling never bound. Fix: sample only pure-drain intervals (no written term) + a bounded fast-streak up-recovery for improved links. The 0.4 MB/s bandwidth-cap experiment confirmed the mechanism live before the fix shipped. Design doc round-3 amendment records the falsification. Gates: ceiling suite 13/13 incl. the async-lag regression pin, full T1 both platforms, T2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)