### PR TITLE
docs: slow-link live gate PASS

### DIFF
--- a/docs/planning/adaptive-transfer-rate-plan.md
+++ b/docs/planning/adaptive-transfer-rate-plan.md
@@ -378,10 +378,17 @@ Removed outright (same branch, before the new mechanisms land):
 - T2 re-run. Paper T1 is a CHANGED surface (review M2): the config-test
   AUTO block rewrites to 0=OFF and the new key rows land there too.
 - Guard soak: fresh-backfill (both governors must be structurally inert).
-- **Live gate — the 4 Mbps throttled session**: tab ping settling to
-  ~300-600 ms while LODs stream at ~0.35-0.45 MB/s wire (the client INFO
-  logs the engaged rate); `yielded=` low; disconnect/rejoin re-engages
-  within ~2 s. A second check with the CLIENT kill switch off: behavior
+- **Live gate — the 4 Mbps throttled session: PASS (2026-08-13, user-run,
+  exceeded the criteria)** — ping settled to ~30 ms (the target was
+  300-600 ms) with LODs still streaming on the throttled proxy. The server
+  receipts told the ideal story: `sq=0/1024, obuf=4.0 KB, pingf=1.00,
+  yielded=0, paced=0` — the CLIENT governor alone held the rate under link
+  capacity, so no server mechanism ever fired (the backstops backstopped);
+  the only queue evidence was one bounded pre-engagement burst (obuf
+  high-water 348 KB). Original expectations kept below for the record:
+  tab ping settling to ~300-600 ms while LODs stream at ~0.35-0.45 MB/s
+  wire (the client INFO logs the engaged rate); `yielded=` low;
+  disconnect/rejoin re-engages within ~2 s. A second check with the CLIENT kill switch off: behavior
   degrades to yield-only (today's shape) and `pingf=` engages within ~30 s
   if ping balloons — B's live receipt. **Expected limit cycle (impl review
   m4, documented not fixed)**: on a permanently slow link the ping-normal

--- a/docs/planning/send-pacing-plan.md
+++ b/docs/planning/send-pacing-plan.md
@@ -283,6 +283,10 @@ allocation the flush already receives:
   expectation is UNCHANGED verdicts because every law is conservation- or
   quiescence-based at 5 s scale and the churn ceilings carry 2× headroom —
   but a moved baseline is a FINDING to diagnose, not a re-baseline.
+- Live gate note (2026-08-13): on the combined build's 4 Mbps session the
+  governor held the rate and the pacer never fired (`paced=0` — correct:
+  the client-owned rate leaves no burst to shape). The pacer's OWN live
+  case (governor off, medium link, store-warm join) remains open below.
 - Live gate (the rig, proxy at a MEDIUM rate ~4-10 Mbps): client governor
   kill-switched off to isolate the pacer; the SPECIFIC measurement is the
   store-warm rejoin first seconds (v1's uncovered corner): expect the join


### PR DESCRIPTION
Records the 4 Mbps live-gate result on both plan docs: 30 ms ping with LODs streaming — the client governor alone held the rate; every server mechanism idle (sq=0, obuf=4KB, pingf=1.00, paced=0, yielded=0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)