### PR TITLE
Governor headroom retune + movement hold (live round 2)

### DIFF
--- a/docs/planning/adaptive-transfer-rate-plan.md
+++ b/docs/planning/adaptive-transfer-rate-plan.md
@@ -353,6 +353,32 @@ Removed outright (same branch, before the new mechanisms land):
   structural claim. B stays structurally inert on loopback (ping ~0 never
   crosses 750 ms excess) — that half keeps its structural pin.
 
+## Live round 2 (2026-08-13, the honest ungoverned-manual test)
+
+The first "PASS" was accidentally run with the manual 50-col/s cap still set.
+The honest test (manual cap 0, governor alone): **~500 ms steady, spikes to
+~1500 ms under movement** — significantly better than the pre-program ~5 s,
+but two mechanisms showed up in the receipts (`governed=60/s (320 KB/s)`,
+server `pingf=0.02, yielded=747, paced=852, sq=308`):
+
+1. **The AIMD equilibrium hovers AT capacity**: the climb/overshoot cycle
+   keeps the link full, so a standing few-hundred-ms queue never drains —
+   the steady ~500 ms. RETUNED: drain every 4th kept-up (was 8th) at STEP/2
+   depth (was STEP/4) — the bleed now outruns the climb's overshoot.
+2. **Movement spikes are vanilla competing**: the governor kept climbing
+   +STEP into the window where a moving player's vanilla chunk bursts share
+   the link; the cut then took 1-2 intervals — the spike's duration.
+   ADDED: the movement hold — a kept-up interval that saw a chunk crossing
+   (the manager's recenter hook) holds `desired` (no up-probe; shortfall
+   still cuts; the drain streak is untouched).
+3. **The backstop fired during the spikes** (`pingf=0.02`) and behaved
+   exactly as designed: its binding cut landed at ~1 MB/s allocation —
+   ABOVE the governor's 320 KB/s ask — so it never actually throttled the
+   session (the operating-region separation held in the BINDING sense even
+   though the spike excess crossed 750 ms). The server's standing
+   `sq=308` is resolved-but-unsent RAM, not link latency (obuf stayed
+   ~3 KB); the relevance prune + re-declaration own it.
+
 ## Test plan
 
 - T1: governor AIMD unit suite (engagement gate incl. demand-backing, the

--- a/fabric/src/main/java/dev/vox/lss/networking/client/LodRequestManager.java
+++ b/fabric/src/main/java/dev/vox/lss/networking/client/LodRequestManager.java
@@ -369,6 +369,9 @@ public class LodRequestManager {
             this.lastChunkX = playerCx;
             this.lastChunkZ = playerCz;
             this.scanner.recenter();
+            // Live round 2: a crossing holds the governor's up-probe for the current
+            // interval — vanilla's own chunk bursts are about to compete for the link.
+            this.governor.noteMovement();
         }
     }
 

--- a/fabric/src/main/java/dev/vox/lss/networking/client/TransferRateGovernor.java
+++ b/fabric/src/main/java/dev/vox/lss/networking/client/TransferRateGovernor.java
@@ -56,10 +56,13 @@ final class TransferRateGovernor {
     /** Disengage path (b): consecutive intervals of normal ping (~1 min — closes the
      *  frozen-engaged state, review m10). */
     static final int DISENGAGE_PING_NORMAL_INTERVALS = 30;
-    /** The deterministic drain bias (review M3): every Nth consecutive kept-up interval
-     *  bleeds standing queue instead of probing up — a rate-matched loop never drains
-     *  queue it INHERITED (the pre-engagement burst can bank ~cap/4). */
-    static final int DRAIN_EVERY_KEPT_UP = 8;
+    /** The deterministic drain bias (review M3; retuned at live round 2): every Nth
+     *  consecutive kept-up interval bleeds standing queue instead of probing up — a
+     *  rate-matched loop never drains queue it INHERITED, and an AIMD equilibrium
+     *  HOVERS AT capacity (the first live session measured ~500 ms standing queue at
+     *  convergence — the climb/overshoot cycle keeps the link full). 8→4 with a
+     *  deeper bleed halves the time spent at/above capacity. */
+    static final int DRAIN_EVERY_KEPT_UP = 4;
     /** Asymmetric column-size EWMA (review M4): fast-up so a terrain batch after an
      *  ocean crossing under-counts R instead of over-bursting; slow-down so
      *  ghost-clear runs decay the estimate gently. */
@@ -82,6 +85,7 @@ final class TransferRateGovernor {
     private long intervalStartDeclared;
     private boolean awaitingAtStart;
     private boolean haltSeenThisInterval;
+    private boolean movementSeenThisInterval;
 
     // ---- Ping baseline ----
     private int pingBaselineMs = -1;       // -1 = unseeded (zero/absent samples ignored)
@@ -137,6 +141,8 @@ final class TransferRateGovernor {
             return;
         }
         if (halted) this.haltSeenThisInterval = true;
+        // movementSeenThisInterval is latched by noteMovement() (the manager's
+        // chunk-crossing hook) and cleared at each interval seed.
         long elapsed = nowMillis - this.intervalStartMillis;
         if (elapsed < INTERVAL_MILLIS) return;
 
@@ -209,14 +215,23 @@ final class TransferRateGovernor {
             this.desiredBytesPerSec =
                     Math.max(measured - STEP_BYTES_PER_SEC / 2, MIN_RATE_BYTES_PER_SEC);
             this.keptUpStreak = 0;
+        } else if (this.movementSeenThisInterval) {
+            // Live round 2: a kept-up interval that saw chunk crossings HOLDS — the
+            // climb must not probe into the window where vanilla's own chunk bursts
+            // are about to compete for the link (the measured movement spikes:
+            // ~1500 ms while climbing +STEP into a moving player's vanilla traffic).
+            // Shortfall above still cuts normally during movement; only the up-probe
+            // pauses. The streak is untouched (movement neither earns nor forfeits
+            // drain cadence).
         } else if (++this.keptUpStreak % DRAIN_EVERY_KEPT_UP == 0) {
             // Deterministic drain interval: bleed standing queue instead of probing
             // up. Anchored at min(desired, measured) (impl review MINOR-3): when the
             // size EWMA lags a regime change, measured can exceed desired, and a
             // measured-anchored drain would RAISE desired several-fold in one step —
-            // the opposite of a bleed.
+            // the opposite of a bleed. Depth STEP/2 since live round 2 (with STEP/4
+            // the bleed barely outran the climb's overshoot).
             this.desiredBytesPerSec = Math.max(
-                    Math.min(this.desiredBytesPerSec, measured) - STEP_BYTES_PER_SEC / 4,
+                    Math.min(this.desiredBytesPerSec, measured) - STEP_BYTES_PER_SEC / 2,
                     MIN_RATE_BYTES_PER_SEC);
         } else {
             this.desiredBytesPerSec += STEP_BYTES_PER_SEC;
@@ -301,6 +316,7 @@ final class TransferRateGovernor {
         this.intervalStartDeclared = declared;
         this.awaitingAtStart = awaitingSize > 0;
         this.haltSeenThisInterval = false;
+        this.movementSeenThisInterval = false;
     }
 
     private void hardReset() {
@@ -312,8 +328,15 @@ final class TransferRateGovernor {
         this.intervalSeeded = false;
         this.intervalStartMillis = 0;
         this.haltSeenThisInterval = false;
+        this.movementSeenThisInterval = false;
         // The size estimator and ping baseline survive a config-toggle reset (they are
         // measurements, not control state) but die with the session in reset().
+    }
+
+    /** Chunk-crossing hook (live round 2): latches the movement hold for the current
+     *  measurement interval — see the kept-up branch. Main client thread. */
+    void noteMovement() {
+        this.movementSeenThisInterval = true;
     }
 
     /** Dimension change (impl review MINOR-2): same connection, same link — the

--- a/fabric/src/test/java/dev/vox/lss/networking/client/TransferRateGovernorTest.java
+++ b/fabric/src/test/java/dev/vox/lss/networking/client/TransferRateGovernorTest.java
@@ -172,15 +172,16 @@ class TransferRateGovernorTest {
     }
 
     @Test
-    void everyEighthKeptUpIsADrainInterval() {
-        // Review M3's second defect: a rate-matched loop never drains INHERITED queue —
-        // the deterministic drain bias bleeds it every DRAIN_EVERY_KEPT_UP kept-ups.
+    void everyFourthKeptUpIsADrainInterval() {
+        // Review M3's second defect + live round 2's retune: an AIMD equilibrium
+        // hovers AT capacity (measured ~500 ms standing queue live), so the bleed
+        // runs every 4th kept-up at STEP/2 depth.
         var g = new TransferRateGovernor();
         long t = 0;
         tick(g, t, 0, 0, 1, false, NORMAL_PING);
         tick(g, t += INTERVAL, 800 * KB, 100, 1, false, CONGESTED_PING);
         long bytes = 800 * KB;
-        // Feed exactly-kept-up intervals (measured = desired): 7 step up, the 8th drains.
+        // Feed exactly-kept-up intervals (measured = desired): 3 step up, the 4th drains.
         for (int keptUp = 1; keptUp <= TransferRateGovernor.DRAIN_EVERY_KEPT_UP; keptUp++) {
             long desiredBefore = g.getDesiredBytesPerSec();
             long measuredBps = desiredBefore;
@@ -190,10 +191,42 @@ class TransferRateGovernorTest {
                 assertEquals(desiredBefore + STEP, g.getDesiredBytesPerSec(),
                         "kept-up " + keptUp + " probes up");
             } else {
-                assertEquals(measuredBps - STEP / 4, g.getDesiredBytesPerSec(),
-                        "the 8th consecutive kept-up bleeds standing queue instead");
+                assertEquals(measuredBps - STEP / 2, g.getDesiredBytesPerSec(),
+                        "the 4th consecutive kept-up bleeds standing queue instead");
             }
         }
+    }
+
+    @Test
+    void movementIntervalHoldsTheClimb() {
+        // Live round 2: the ~1500 ms movement spikes were the governor climbing +STEP
+        // into the window where vanilla's own chunk bursts compete for the link. A
+        // kept-up interval that saw a chunk crossing HOLDS desired; shortfall during
+        // movement still cuts.
+        var g = new TransferRateGovernor();
+        long t = 0;
+        tick(g, t, 0, 0, 1, false, NORMAL_PING);
+        tick(g, t += INTERVAL, 800 * KB, 100, 1, false, CONGESTED_PING);
+        long desired = g.getDesiredBytesPerSec();
+        long bytes = 800 * KB;
+        // Kept-up interval WITH movement: held.
+        bytes += desired * 2;
+        g.noteMovement();
+        tick(g, t += INTERVAL, bytes, 200, 1, false, CONGESTED_PING);
+        assertEquals(desired, g.getDesiredBytesPerSec(),
+                "a moving kept-up interval must not probe up");
+        // The same shape WITHOUT movement climbs — the hold was the movement's doing.
+        bytes += desired * 2;
+        tick(g, t += INTERVAL, bytes, 300, 1, false, CONGESTED_PING);
+        assertEquals(desired + STEP, g.getDesiredBytesPerSec(),
+                "a stationary kept-up interval probes up");
+        // Shortfall during movement still cuts (the hold pauses only the up-probe).
+        long slow = (desired + STEP) / 2;
+        bytes += slow * 2;
+        g.noteMovement();
+        tick(g, t += INTERVAL, bytes, 400, 1, false, CONGESTED_PING);
+        assertEquals(Math.max(slow - STEP / 2, TransferRateGovernor.MIN_RATE_BYTES_PER_SEC),
+                g.getDesiredBytesPerSec(), "movement never suppresses a genuine cut");
     }
 
     @Test
@@ -212,11 +245,11 @@ class TransferRateGovernorTest {
             tick(g, t += INTERVAL, bytes, 100 + keptUp * 10L, 1, false, CONGESTED_PING);
         }
         long desiredBefore = g.getDesiredBytesPerSec();
-        // The 8th kept-up measures DOUBLE desired (EWMA-lag shape): must bleed down
-        // from desired, never jump up toward measured.
+        // The drain-cadence kept-up measures DOUBLE desired (EWMA-lag shape): must
+        // bleed down from desired, never jump up toward measured.
         bytes += desiredBefore * 4;
         tick(g, t += INTERVAL, bytes, 200, 1, false, CONGESTED_PING);
-        assertEquals(desiredBefore - STEP / 4, g.getDesiredBytesPerSec(),
+        assertEquals(desiredBefore - STEP / 2, g.getDesiredBytesPerSec(),
                 "the drain anchors at min(desired, measured)");
     }
 


### PR DESCRIPTION
The honest ungoverned 4 Mbps test: ~500 ms steady (AIMD hovering at capacity), ~1500 ms movement spikes (climbing into vanilla's chunk-burst window). Drain 4th/STEP-2 (was 8th/STEP-4) + the movement hold on kept-up intervals. Full trace + receipts in the plan's Live round 2 section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)