### PR TITLE
Review-wave fold: governor carry, log-spam sweep, gate pins, doc banners

### DIFF
--- a/common/src/main/java/dev/vox/lss/common/Brand.java
+++ b/common/src/main/java/dev/vox/lss/common/Brand.java
@@ -58,8 +58,9 @@ public final class Brand {
     /** Short acronym for chat/console/thread text: {@code "LSS"} or {@code "VSS"}. */
     public static String shortName() { return shortName; }
 
-    /** Lowercased acronym for LOCAL filesystem names ({@code "lss"} / {@code "vss"}):
-     *  the store directory and cache dot-dir. Never a wire or identity token. */
+    /** Lowercased acronym for LOCAL names ({@code "lss"} / {@code "vss"}): operator
+     *  messages naming the brand-preferred config file, and (as literals kept in sync
+     *  with this) the store directory / cache dot-dir. Never a wire or identity token. */
     public static String lowerShortName() {
         return shortName.toLowerCase(java.util.Locale.ROOT);
     }

--- a/common/src/main/java/dev/vox/lss/common/DiagnosticsFormatter.java
+++ b/common/src/main/java/dev/vox/lss/common/DiagnosticsFormatter.java
@@ -21,45 +21,6 @@ public final class DiagnosticsFormatter {
             long outboundPending, long outboundHighWater, long sendDeferrals,
             long yielded, long ceilBytes, double pingFactor, long paced
     ) {
-        /** Pre-send-pacing shape — keeps existing constructions/tests intact
-         *  (paced renders 0). */
-        public PlayerDiag(String name, int sendQueue, int maxSendQueue, int pendingSync,
-                          int pendingGen, long sent, long bytes, long outboundPending,
-                          long outboundHighWater, long sendDeferrals, long yielded,
-                          long ceilBytes, double pingFactor) {
-            this(name, sendQueue, maxSendQueue, pendingSync, pendingGen, sent, bytes,
-                    outboundPending, outboundHighWater, sendDeferrals, yielded, ceilBytes,
-                    pingFactor, 0L);
-        }
-
-        /** Pre-ping-backstop shape — keeps existing constructions/tests intact
-         *  (pingf renders 1.00). */
-        public PlayerDiag(String name, int sendQueue, int maxSendQueue, int pendingSync,
-                          int pendingGen, long sent, long bytes, long outboundPending,
-                          long outboundHighWater, long sendDeferrals, long yielded,
-                          long ceilBytes) {
-            this(name, sendQueue, maxSendQueue, pendingSync, pendingGen, sent, bytes,
-                    outboundPending, outboundHighWater, sendDeferrals, yielded, ceilBytes,
-                    1.0, 0L);
-        }
-
-        /** No-ceiling shape — keeps existing constructions/tests intact
-         *  (ceil renders "off"). */
-        public PlayerDiag(String name, int sendQueue, int maxSendQueue, int pendingSync,
-                          int pendingGen, long sent, long bytes, long outboundPending,
-                          long outboundHighWater, long sendDeferrals, long yielded) {
-            this(name, sendQueue, maxSendQueue, pendingSync, pendingGen, sent, bytes,
-                    outboundPending, outboundHighWater, sendDeferrals, yielded, -1L, 1.0,
-                    0L);
-        }
-
-        /** Pre-transport-yield shape — keeps existing constructions/tests intact. */
-        public PlayerDiag(String name, int sendQueue, int maxSendQueue, int pendingSync,
-                          int pendingGen, long sent, long bytes, long outboundPending,
-                          long outboundHighWater, long sendDeferrals) {
-            this(name, sendQueue, maxSendQueue, pendingSync, pendingGen, sent, bytes,
-                    outboundPending, outboundHighWater, sendDeferrals, 0L, -1L);
-        }
     }
 
     public record DiagData(

--- a/common/src/main/java/dev/vox/lss/common/LSSConstants.java
+++ b/common/src/main/java/dev/vox/lss/common/LSSConstants.java
@@ -99,7 +99,8 @@ public final class LSSConstants {
     public static final int MIN_BYTES_PER_SECOND = 1024;
     /** Per-player bandwidth ceiling. Raised 100 MB -> 1 GiB 2026-08-02 (config review
      *  section 5): the live server hit the old ceiling exactly, and this bounds only what an
-     *  admin deliberately types. The DEFAULT is 15 MiB (25 -> 15 on 2026-08-05, v0.9.1) —
+     *  admin deliberately types. The DEFAULT is 25 MiB (25 -> 15 on 2026-08-05, re-raised
+     *  to 25 on 2026-08-08 — ServerConfigBase.DEFAULT_MB_PER_PLAYER is the authority) —
      *  the cap charges RAW bytes because it bounds client decode work (the confirmed
      *  receiver-limited bottleneck), so wire compression did not loosen the constraint it
      *  exists to enforce. */
@@ -172,7 +173,10 @@ public final class LSSConstants {
      *  field's default so "off" costs the same server-side as the default cadence. */
     public static final int DIRTY_DRAIN_ONLY_INTERVAL_SECONDS = 10;
     public static final int MIN_CONCURRENCY_LIMIT = 1;
-    public static final int MAX_CONCURRENCY_LIMIT = 1000;
+    // MAX_CONCURRENCY_LIMIT (1000) DELETED 2026-08-13 (deletion review D-6): the 9.1
+    // config-review fix replaced its clamp role with clampGenPerPlayer(v, configuredGlobal)
+    // — the constant enforced nothing and its two remaining test assertions pinned a
+    // number no mechanism used.
     /** Per-DIMENSION timestamp-cache bounds (multiply by dimension count for the real heap
      *  budget). Ceiling raised 256 -> 512 2026-08-02: reachable on a large-distance server.
      *  0 means AUTO — derived from lodDistanceChunks, see
@@ -364,6 +368,8 @@ public final class LSSConstants {
     public static final int COLUMN_COMPRESS_MIN_BYTES = 512;
 
     // Dimension resource location strings (common/ has no MC deps, so plain strings)
+    // Test-convenience literals only (deletion review D-13) — nothing on the wire or in
+    // production reads these; they live here for the shared test corpus, not the protocol.
     public static final String DIM_STR_OVERWORLD = "minecraft:overworld";
     public static final String DIM_STR_THE_NETHER = "minecraft:the_nether";
     public static final String DIM_STR_THE_END = "minecraft:the_end";

--- a/common/src/main/java/dev/vox/lss/common/config/ServerConfigBase.java
+++ b/common/src/main/java/dev/vox/lss/common/config/ServerConfigBase.java
@@ -149,7 +149,7 @@ public abstract class ServerConfigBase extends JsonConfig {
      */
     public boolean enablePingBackstop = true;
     /**
-     * Send pacing (send-pacing-plan.md v2 — the refill-floored proportional drain):
+     * Send pacing (send-pacing-plan.md v3 — the refill-floored, burst-clamped drain):
      * spreads the bandwidth bank's one-tick burst into a ~5-tick slope so vanilla
      * packets interleave during LOD resolution waves (join/rejoin/teleport). The
      * budget floors at the allocation's own per-tick refill share, so sustained

--- a/common/src/main/java/dev/vox/lss/common/farplayers/FarPlayerBroadcastService.java
+++ b/common/src/main/java/dev/vox/lss/common/farplayers/FarPlayerBroadcastService.java
@@ -72,8 +72,11 @@ public final class FarPlayerBroadcastService {
         boolean send(UUID viewer, String channel, byte[] body);
     }
 
-    /** Reflective vanish-mod bridge seam (melius-vanish on Fabric, vanish meta on
-     *  Paper); default sees everyone. */
+    /** Vanish bridge seam. Paper feeds the "vanished" metadata read (SuperVanish/
+     *  PremiumVanish/EssentialsX) through the snapshot instead; Fabric passes null —
+     *  there is no cross-mod vanish convention on Fabric (recorded descope,
+     *  v0.11.0-progress decisions log), so a Fabric vanish mod's players rely on the
+     *  exclude list / permission node. */
     @FunctionalInterface
     public interface VanishBridge {
         boolean canSee(UUID viewer, UUID target);

--- a/common/src/main/java/dev/vox/lss/common/processing/AbstractChunkDiskReader.java
+++ b/common/src/main/java/dev/vox/lss/common/processing/AbstractChunkDiskReader.java
@@ -45,8 +45,10 @@ public abstract class AbstractChunkDiskReader {
     private final LogThrottle saturationWarn = new LogThrottle(SATURATION_WARN_INTERVAL_MS);
     // Read timeouts are documented transients (miss-memo A/B finding) — same aggregation.
     private final LogThrottle timeoutWarn = new LogThrottle(SATURATION_WARN_INTERVAL_MS);
-    // Gate refusals are the same self-healing drop class — same aggregation; the message
-    // names the remedy (the operator signal the gate plan requires).
+    // (Gate PARK-OVERFLOW refusals are deliberately LOG-FREE — see the drop site.)
+    // Non-timeout read failures aggregate too (log-sweep finding: the bare else beside
+    // the throttled timeout branch repeated per failed read, and clients re-declare).
+    private final LogThrottle readErrorWarn = new LogThrottle(SATURATION_WARN_INTERVAL_MS);
 
     // Disk-read concurrency gate (disk-read-concurrency-gate-plan.md): bounds the
     // EXPENSIVE phase only — store hits are served before it. Constructed at pool size
@@ -225,7 +227,8 @@ public abstract class AbstractChunkDiskReader {
                     + ", park full): the request router is deferring cold-region reads to the"
                     + " next client declaration (running total: gate_stops= in /"
                     + Brand.serverCommand() + " diag). This is the gate working; raise"
-                    + " maxConcurrentDiskReads in lss-server-config.json if server CPU"
+                    + " maxConcurrentDiskReads in " + dev.vox.lss.common.Brand.lowerShortName()
+                    + "-server-config.json if server CPU"
                     + " headroom allows and you want faster cold backfill. (Logged once per"
                     + " session.)");
         }
@@ -347,8 +350,13 @@ public abstract class AbstractChunkDiskReader {
                     // original gets the duplicate-ghost above while the drained entry's
                     // pending wedges uncontained — the same accepted OOM-class residual,
                     // now two positions wide (review B-4).
-                    LSSLogger.error("Unexpected failure delivering disk read at "
-                            + chunkX + ", " + chunkZ, t);
+                    long fails = this.readErrorWarn.recordAndTryAcquire(
+                            System.nanoTime() / 1_000_000);
+                    if (fails > 0) {
+                        LSSLogger.error("Unexpected failure delivering disk read at "
+                                + chunkX + ", " + chunkZ + (fails > 1 ? " (+" + (fails - 1)
+                                + " more since last report)" : ""), t);
+                    }
                     addResult(playerUuid, ChunkReadResult.notFoundFromError(
                             playerUuid, chunkX, chunkZ, dimension, submissionOrder));
                 } finally {
@@ -363,7 +371,8 @@ public abstract class AbstractChunkDiskReader {
             if (rejected > 0) {
                 LSSLogger.warn("Disk reader saturated: " + rejected + " chunk read(s) dropped"
                         + " since the last warning — clients re-request automatically; raise"
-                        + " diskReaderThreads in lss-server-config.json if this persists");
+                        + " diskReaderThreads in " + dev.vox.lss.common.Brand.lowerShortName()
+                        + "-server-config.json if this persists");
             }
             // The bounce never consulted the store or storage: submitted+saturated+completed
             // recorded together so the at-rest identity (completed == outcomes) holds.
@@ -675,7 +684,12 @@ public abstract class AbstractChunkDiskReader {
                             + (releases > 1 ? " (+" + (releases - 1) + " more since last report)" : ""));
                 }
             } else {
-                LSSLogger.error("Failed to read chunk NBT from disk at " + chunkX + ", " + chunkZ, e);
+                long fails = this.readErrorWarn.recordAndTryAcquire(System.nanoTime() / 1_000_000);
+                if (fails > 0) {
+                    LSSLogger.error("Failed to read chunk NBT from disk at " + chunkX + ", "
+                            + chunkZ + (fails > 1 ? " (+" + (fails - 1)
+                            + " more since last report)" : ""), e);
+                }
             }
             this.diag.recordError();
             recordRealCompletion(System.nanoTime() - startNs);

--- a/common/src/main/java/dev/vox/lss/common/processing/AbstractPlayerRequestState.java
+++ b/common/src/main/java/dev/vox/lss/common/processing/AbstractPlayerRequestState.java
@@ -107,6 +107,9 @@ public abstract class AbstractPlayerRequestState<T> {
      *  mechanism counter beside deferred=/yielded=, never a loss signal). */
     private volatile long pacedTicks = 0;
 
+    private static final dev.vox.lss.common.LogThrottle SEND_FAIL_WARN =
+            new dev.vox.lss.common.LogThrottle(60_000);
+
     // ---- Transport yield (lodYieldsToVanillaTransport, yield plan v2.1) ----
     /** 100 ticks = 5 s: the §1.4 starvation floor — bounds worst-case LOD at ~1 column/5 s
      *  and distinguishes "yielding hard" from "dead". Yield starvation only; the ceiling
@@ -657,10 +660,11 @@ public abstract class AbstractPlayerRequestState<T> {
     }
 
     /**
-     * Fullest overload adding send pacing (send-pacing-plan.md v2:
-     * {@code enableSendPacing}, default true — the refill-floored proportional drain).
-     * While enabled, a tick's column flush writes at most
-     * {@code max(allocation/20, queuedRawBytes/PACE_HORIZON_TICKS)} RAW bytes (one
+     * Fullest overload adding send pacing (send-pacing-plan.md v3:
+     * {@code enableSendPacing}, default true — the refill-floored, BURST-CLAMPED
+     * proportional drain). While enabled, a tick's column flush writes at most
+     * {@code clamp(queuedRawBytes/PACE_HORIZON_TICKS, share, PACE_MAX_BURST_SHARES*share)}
+     * RAW bytes where share = allocation/20 (one
      * payload minimum — the presence gate), so the bandwidth bank's burst ships as a
      * ~5-tick slope instead of a one-tick cliff, and vanilla packets interleave every
      * tick. The floor is the allocation's own refill share, so NOTHING is ever paced
@@ -868,8 +872,14 @@ public abstract class AbstractPlayerRequestState<T> {
                     break;
                 }
             } catch (Exception e) {
-                LSSLogger.error("Failed to send queued payload to " + getPlayerName()
-                        + ", dropping remaining queue (" + this.sendQueue.size() + " entries)", e);
+                // Throttled (log sweep): a closing/broken connection can throw here every
+                // tick until the disconnect lands — its sibling yield WARN is latched.
+                long n = SEND_FAIL_WARN.recordAndTryAcquire(System.nanoTime() / 1_000_000);
+                if (n > 0) {
+                    LSSLogger.error("Failed to send queued payload to " + getPlayerName()
+                            + ", dropping remaining queue (" + this.sendQueue.size()
+                            + " entries; " + n + " send failure(s) since the last report)", e);
+                }
                 // Seeded with any prune-cleared positions from this tick: both classes
                 // need the caller's clearDiskReadDone routing, and overwriting would
                 // leak the pruned ones' stale done-bits.

--- a/common/src/main/java/dev/vox/lss/common/processing/IncomingRequestRouter.java
+++ b/common/src/main/java/dev/vox/lss/common/processing/IncomingRequestRouter.java
@@ -28,6 +28,11 @@ import java.util.UUID;
  */
 class IncomingRequestRouter<PS extends AbstractPlayerRequestState<?>> {
 
+    // Log-sweep hygiene: the Fabric probe path's twin throttle (this routing-path site
+    // was the bare one).
+    private static final dev.vox.lss.common.LogThrottle PROBE_SERVE_FAIL_WARN =
+            new dev.vox.lss.common.LogThrottle(60_000);
+
     private final OffThreadProcessor<PS> processor;
     private final Map<UUID, PS> players;
     private final ColumnTimestampCache timestampCache;
@@ -310,8 +315,12 @@ class IncomingRequestRouter<PS extends AbstractPlayerRequestState<?>> {
             // and a deterministic throw tripped the cycle backoff for all players. Contain
             // as the standard transient: counted superseded, no done-bit (the client
             // re-declares within <=1 s), the rest of the pass continues.
-            dev.vox.lss.common.LSSLogger.error("Failed to serve probe column "
-                    + req.cx() + ", " + req.cz(), t);
+            long n = PROBE_SERVE_FAIL_WARN.recordAndTryAcquire(System.nanoTime() / 1_000_000);
+            if (n > 0) {
+                dev.vox.lss.common.LSSLogger.error("Failed to serve probe column "
+                        + req.cx() + ", " + req.cz() + " (" + n
+                        + " probe-serve failure(s) since the last report)", t);
+            }
             this.ctx.diagnostics().addSuperseded(1);
             this.ctx.diagnostics().incrementInMemory();
             return true;

--- a/common/src/main/java/dev/vox/lss/common/processing/OffThreadProcessor.java
+++ b/common/src/main/java/dev/vox/lss/common/processing/OffThreadProcessor.java
@@ -108,6 +108,12 @@ public abstract class OffThreadProcessor<PlayerState extends AbstractPlayerReque
     private int evictionCounter;
     private int saveCounter;
     private int consecutiveErrors;
+    // Log-sweep hygiene (2026-08-13): persistent-condition error sites aggregate to one
+    // line/min — the park-overflow-WARN deletion set the bar for self-healing paths.
+    private final dev.vox.lss.common.LogThrottle cycleErrorWarn =
+            new dev.vox.lss.common.LogThrottle(60_000);
+    private final dev.vox.lss.common.LogThrottle deliveryErrorWarn =
+            new dev.vox.lss.common.LogThrottle(60_000);
     private long cycleNow; // cached epochSeconds for current processing cycle
     // Per-cycle phase-completion flags (processing-thread only): a failed cycle re-queues only
     // the lossless events whose phase did NOT complete, so an already-applied phase is never
@@ -340,7 +346,11 @@ public abstract class OffThreadProcessor<PlayerState extends AbstractPlayerReque
             try {
                 sender.send(state, types, positions, count);
             } catch (Exception e) {
-                LSSLogger.error("Failed to send batch response to " + state.getPlayerName(), e);
+                long n = this.deliveryErrorWarn.recordAndTryAcquire(System.nanoTime() / 1_000_000);
+                if (n > 0) {
+                    LSSLogger.error("Failed to send batch response to " + state.getPlayerName()
+                            + " (" + n + " delivery failure(s) since the last report)", e);
+                }
             }
         });
     }
@@ -522,7 +532,14 @@ public abstract class OffThreadProcessor<PlayerState extends AbstractPlayerReque
             } catch (Throwable t) {
                 // Catch Throwable (not just Exception) so a transient Error doesn't silently
                 // kill the processing thread and stop the LOD pipeline for every player.
-                LSSLogger.error("Error in processing cycle", t);
+                // Throttled (log-sweep top finding): a persistent throw here repeats at
+                // cycle rate (~20 Hz, ~1 Hz once the backoff engages) FOREVER — one
+                // stack per minute carries the same diagnostic value without the flood.
+                long cycleErrs = this.cycleErrorWarn.recordAndTryAcquire(System.nanoTime() / 1_000_000);
+                if (cycleErrs > 0) {
+                    LSSLogger.error("Error in processing cycle (" + cycleErrs
+                            + " failed cycle(s) since the last report)", t);
+                }
                 // The take destructively drained the lossless event buffers; discarding them
                 // on a failed cycle permanently loses player removals (leaked slots/dedup
                 // groups), generation outcomes (stranded pending generations), and
@@ -534,7 +551,9 @@ public abstract class OffThreadProcessor<PlayerState extends AbstractPlayerReque
                 // fresh tracking).
                 requeueLosslessEvents(take);
                 if (++this.consecutiveErrors >= 10) {
-                    LSSLogger.error("Processing thread hit " + this.consecutiveErrors + " consecutive errors, backing off");
+                    // The backoff NOTE rides the throttled line above (the old separate
+                    // per-cycle line repeated ~1/s forever once engaged); the sleep is
+                    // the mechanism, the log is not.
                     try { Thread.sleep(1000); } catch (InterruptedException ie) {
                         // Shutdown landed during the backoff: requeueLosslessEvents above put
                         // the failed cycle's unapplied invalidations back in the pending
@@ -1062,7 +1081,11 @@ public abstract class OffThreadProcessor<PlayerState extends AbstractPlayerReque
                 // live pending blocked every other setter) and drop as a standard transient
                 // (superseded, re-declared next scan). Other recipients of this dedup group
                 // still get their deliveries.
-                LSSLogger.error("Failed to deliver disk result for chunk " + cx + ", " + cz, t);
+                long n = this.deliveryErrorWarn.recordAndTryAcquire(System.nanoTime() / 1_000_000);
+                if (n > 0) {
+                    LSSLogger.error("Failed to deliver disk result for chunk " + cx + ", " + cz
+                            + " (" + n + " delivery failure(s) since the last report)", t);
+                }
                 state.clearDiskReadDone(packed);
                 this.ctx.diagnostics().addSuperseded(1);
             }
@@ -1345,7 +1368,11 @@ public abstract class OffThreadProcessor<PlayerState extends AbstractPlayerReque
                 // (idempotent, and worst case costs one honest re-read). Pending was already
                 // removed above — the catch must NOT touch pending again (a fresh session's
                 // entry at the same position could be stripped).
-                LSSLogger.error("Failed to process generation outcome for chunk " + cx + ", " + cz, t);
+                long n = this.deliveryErrorWarn.recordAndTryAcquire(System.nanoTime() / 1_000_000);
+                if (n > 0) {
+                    LSSLogger.error("Failed to process generation outcome for chunk " + cx + ", "
+                            + cz + " (" + n + " delivery failure(s) since the last report)", t);
+                }
                 state.clearDiskReadDone(packed);
                 this.ctx.diagnostics().addSuperseded(1);
             }

--- a/common/src/main/java/dev/vox/lss/common/store/LodStores.java
+++ b/common/src/main/java/dev/vox/lss/common/store/LodStores.java
@@ -96,7 +96,8 @@ public final class LodStores {
     public static String offRecommendationOrNull(boolean lssEnabled, boolean isFolia) {
         if (!lssEnabled || isFolia) return null;
         return "LOD store is off. Recommended: set \"lodStore\": \"on\" in"
-                + " lss-server-config.json for much faster LOD serving; the tradeoff is it"
+                + " " + Brand.lowerShortName() + "-server-config.json for much faster LOD"
+                + " serving; the tradeoff is it"
                 + " roughly doubles the size of your world directory.";
     }
 }

--- a/common/src/main/java/dev/vox/lss/common/voxel/ColumnTimestampCache.java
+++ b/common/src/main/java/dev/vox/lss/common/voxel/ColumnTimestampCache.java
@@ -53,6 +53,8 @@ public class ColumnTimestampCache {
 
     private static final int FORMAT_VERSION = 2;
     private static final String FILE_NAME = "lss-timestamps.bin";
+    private static final dev.vox.lss.common.LogThrottle SAVE_FAIL_WARN =
+            new dev.vox.lss.common.LogThrottle(60_000);
     /** 2025-01-01T00:00:00Z — every legitimate LSS stamp postdates it (design §2).
      *  Offsets are u32 seconds from here; 0 is the absent sentinel, so the epoch
      *  itself stores as 1 (+1 s overstate, the safe direction). Exhausts in ~2161. */
@@ -405,9 +407,17 @@ public class ColumnTimestampCache {
                 LSSLogger.debug("Saved " + size() + " timestamp cache entries to " + file);
             }
         } catch (IOException e) {
-            LSSLogger.warn("Failed to save timestamp cache to " + file, e);
+            // Throttled (log-sweep top finding): the invalidation debounce re-saves ~2 s
+            // after any dirty broadcast, so on a full/read-only disk this warned (with
+            // stack) every few seconds forever — the same cadence that demoted the
+            // SUCCESS line to debug above.
+            long n = SAVE_FAIL_WARN.recordAndTryAcquire(System.nanoTime() / 1_000_000);
+            if (n > 0) {
+                LSSLogger.warn("Failed to save timestamp cache to " + file
+                        + " (" + n + " failed save(s) since the last report)", e);
+            }
             try { Files.deleteIfExists(tmpFile); } catch (IOException e2) {
-                LSSLogger.warn("Failed to clean up temporary timestamp cache file " + tmpFile, e2);
+                // covered by the aggregate above; the tmp file is retried next save
             }
         }
     }

--- a/docs/planning/client-reset-command-and-cache-relocation-plan.md
+++ b/docs/planning/client-reset-command-and-cache-relocation-plan.md
@@ -1,6 +1,6 @@
 # Client full-reset command (`/lss reset`) + client cache relocation to `.lss/` — plan
 
-**Status: PLANNED, unimplemented** (2026-08-12). Two client-side features, one plan:
+**Status: IMPLEMENTED — shipped in v0.11.0** (stage D, 2026-08-13; `/lss reset` + the `.lss`/`.vss` cache dot-dirs; kept as the design record). Two client-side features, one plan:
 
 1. A new client command that clears BOTH the Voxy data cache (disk + **in-memory** —
    the player visibly watches all LODs disappear) AND the LSS client cache, then resets

--- a/docs/planning/cpu-opt-round2-instructions.md
+++ b/docs/planning/cpu-opt-round2-instructions.md
@@ -1,5 +1,9 @@
 # Instructions: CPU optimization round 2 (disk-read serving path)
 
+**Status: EXECUTED — historical.** Round 2 shipped (PR #74, `useNbtTranscode` default
+true) and later perf rounds superseded this work order. Do not execute; kept as the
+methodology record. (Banner added by the 2026-08-13 staleness sweep.)
+
 You are continuing a validated CPU-optimization effort on LSS's disk-read LOD serving
 path. Round 1 is DONE and measured; your job is round 2: implement the next tier,
 validate byte-identity through the existing gates, and prove the CPU win with the same

--- a/docs/planning/disk-read-concurrency-gate-plan.md
+++ b/docs/planning/disk-read-concurrency-gate-plan.md
@@ -610,3 +610,15 @@ generic) so K rides between auto-K and the pool size when the tick is healthy, a
 below auto-K under tick pressure. Needs its own design round (recovery clocking —
 the throttle only re-opens on samples — and a Paper story if Bukkit's
 `getAverageTickTime` is ever adopted).
+
+
+## Amendment 3 (2026-08-13) — the park-overflow WARN is DELETED
+
+The Amendment 2 text above kept the armor-drop WARN "with its throttle, without the
+remedy sentence". Live operation falsified even that: the throttled WARN repeated once
+per interval on a real server for a self-healing race (`read_gate=2/2, park full`),
+and the operator-log-hygiene bar set by this project (see also the store-eviction
+one-line latch) is that self-healing paths carry counters, not recurring log lines.
+The overflow path is now LOG-FREE: `disk.gated` + the always-rendered `gated=` diag
+token are the evidence, and the LATCHED gate-stop WARN (router retention) remains the
+actionable capacity signal. Do not restore the overflow WARN.

--- a/docs/planning/far-player-proxies-plan.md
+++ b/docs/planning/far-player-proxies-plan.md
@@ -1,6 +1,6 @@
 # Far-player proxies in LSS ("SeeU-native") — plan
 
-**Status: PLANNED, unimplemented** (2026-08-12). Design for rendering distant players
+**Status: IMPLEMENTED — shipped in v0.11.0** (E1-E3, 2026-08-13; kept as the design record — the mega plan's R-3/R-5/R-7/R-9/R-10 amendments apply on top). Design for rendering distant players
 beyond vanilla entity-tracking range as a native LSS feature — the player-entity
 complement to LOD terrain. Informed by a full source read of SeeU 0.7.3 (vendored at
 `research/seeu/`, commit `8d79f9a` = the 0.7.3 version bump, upstream

--- a/docs/planning/lod-store-release-notes-draft.md
+++ b/docs/planning/lod-store-release-notes-draft.md
@@ -1,5 +1,9 @@
 # LOD store — release notes DRAFT (for the eventual tag; user-facing format)
 
+**Status: SUPERSEDED — v0.9.0 shipped its own notes** (v0.9.0-release-notes.md is the
+authority; `lodStoreMemoryMB` advertised below was RETIRED 2026-08-03 and `lodStore`
+defaults changed again 2026-08-08). Kept as a draft artifact only.
+
 ### New Features
 
 - **Persistent LOD store (opt-in)** — New `lodStore` server option (`"off"` by

--- a/docs/planning/resource-management.md
+++ b/docs/planning/resource-management.md
@@ -1,6 +1,10 @@
 # Resource-Management Reference — How LOD Streaming Yields to Vanilla
 
-**Status:** reference snapshot as of 2026-07-16 (protocol v17, A+B read protection). Line
+**Status: SUPERSEDED snapshot (2026-07-16, protocol v17)** — the "1 Hz re-declaration"
+layer it describes is now the ADAPTIVE scan cadence (up to 4 Hz, 2026-08-03), the
+protocol is 20, and the transport lane gained the yield gate + send pacing + the
+transfer-rate pair (adaptive-transfer-rate-plan.md). Read CLAUDE.md for the current
+model; this file remains as the v17-era map. Line
 numbers cited inline were exact at authoring; re-grep the symbol if they've drifted. This
 documents *what exists* — the mechanisms by which LSS keeps LOD streaming from degrading
 vanilla chunk distribution across CPU, memory, disk, and network.

--- a/docs/planning/review-followups.md
+++ b/docs/planning/review-followups.md
@@ -1,5 +1,11 @@
 # Code Review Follow-ups
 
+**Status: HISTORICAL — pre-v17 branch state (protocol 15 era); do NOT action without
+re-verification.** Every `file:line` below is dead and the mechanisms cited
+(waitingQueue, RateLimiterSet, the cancel packet, the timeout sweep) were deleted by
+the v17 want-set redesign. Kept as the review record only. (Banner added by the
+2026-08-13 staleness sweep.)
+
 Deferred items from the multi-agent codebase review (branch `paper-release-26.1.2`, commit
 `ec040de`). The review surfaced 40 findings → 18 confirmed; 14 were fixed in `ec040de`. The
 items below were **deliberately not fixed** in that pass because they are either large/risky

--- a/docs/planning/runtime-settings-commands-plan.md
+++ b/docs/planning/runtime-settings-commands-plan.md
@@ -1,6 +1,6 @@
 # Runtime settings commands + backfill remaining-estimate + `/lsslod help` + package descriptions — plan
 
-**Status: PLANNED, unimplemented** (2026-08-12). **Reviewed 2026-08-12** (1 Fable
+**Status: IMPLEMENTED — shipped in v0.11.0** (stage C, 2026-08-13; `/lsslod set` on both platforms, `common/config/RuntimeSettings`; kept as the design record). **Reviewed 2026-08-12** (1 Fable
 subagent, all load-bearing citations re-verified): verdict IMPLEMENT WITH FIXES,
 2 MAJOR / 9 MINOR — all folded into this revision. Headlines: the SessionConfig
 re-push must enumerate + send on the pump/main thread AFTER the mailbox drain (a

--- a/docs/planning/simplification-review.md
+++ b/docs/planning/simplification-review.md
@@ -1,5 +1,9 @@
 # LSS Simplification & Maintainability Review
 
+**WARNING (2026-08-13 staleness sweep): pre-v17 branch state — the mechanisms
+critiqued below (rate-limit knobs, cancel packet, timeout sweep) were deleted by
+other routes; do not action any finding without re-verification against main.**
+
 **Date:** 2026-06-09 · **Branch:** `paper-release-26.1.2` (working tree incl. uncommitted round-3 hygiene changes — all `file:line` anchors refer to that state) · **Status: decision document — nothing here is implemented.**
 
 A multi-agent critical design review of how LSS works and is implemented, hunting three things the maintainer asked for: places to **simplify** the implementation, **unneeded code or functionality to remove**, and **refactors that improve readability/maintainability**. Method: 3 mapping agents traced the server flow, client flow, and full class/config/payload inventory; 8 design critics with distinct lenses produced 42 raw findings; overlapping proposals were merged into 28; each was then independently, adversarially verified against the code (premise re-checked, hidden users grepped, threading/wire/mapping constraints attacked, value judged). **All 28 survived** — verifier corrections are preserved per finding under *Caveats & corrections*.

--- a/docs/planning/timestamp-cache-tile-redesign.md
+++ b/docs/planning/timestamp-cache-tile-redesign.md
@@ -1,6 +1,6 @@
 # ColumnTimestampCache tile redesign — ~10x+ memory reduction at large lodDistance
 
-Status: PLANNED — reviewed 2026-08-08 by two subagent review rounds (adversarial
+Status: IMPLEMENTED — shipped in v0.10.0 (D0; `ColumnTimestampCache` cites this as the as-built design). Reviewed 2026-08-08 by two subagent review rounds (adversarial
 correctness + integration/completeness); all findings incorporated below, each marked
 "review round 1" (correctness) or "review round 2" (integration). Not implemented.
 Target branch: a fresh `feat/tscache-tiles` off `main` AFTER the protocol-20 C6 work

--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -392,7 +392,9 @@ tasks.register('vssJar') {
                         def rebranded = lang.collectEntries { k, v ->
                             [k, v.toString()
                                     .replace('LOD Server Support', 'Voxy Server Side')
-                                    .replace('LSS', 'VSS')]
+                                    // Word-boundary: never corrupt 'LSS' inside a longer
+                                    // token (review-wave V-M2).
+                                    .replaceAll(/\bLSS\b/, 'VSS')]
                         }
                         byte[] lb = groovy.json.JsonOutput.prettyPrint(
                                 groovy.json.JsonOutput.toJson(rebranded)).getBytes('UTF-8')

--- a/fabric/src/gametest/java/dev/vox/lss/test/LSSGameTests.java
+++ b/fabric/src/gametest/java/dev/vox/lss/test/LSSGameTests.java
@@ -136,7 +136,9 @@ public class LSSGameTests {
         helper.assertTrue(c.generationTimeoutSeconds >= LSSConstants.MIN_GENERATION_TIMEOUT && c.generationTimeoutSeconds <= LSSConstants.MAX_GENERATION_TIMEOUT, "generationTimeoutSeconds");
         // 0 = dirty pushes disabled (v0.11.0) — a first-class value beside the sending band.
         helper.assertTrue(c.dirtyBroadcastIntervalSeconds == 0 || (c.dirtyBroadcastIntervalSeconds >= LSSConstants.MIN_DIRTY_BROADCAST_INTERVAL && c.dirtyBroadcastIntervalSeconds <= LSSConstants.MAX_DIRTY_BROADCAST_INTERVAL), "dirtyBroadcastIntervalSeconds");
-        helper.assertTrue(c.generationConcurrencyLimitPerPlayer >= LSSConstants.MIN_CONCURRENCY_LIMIT && c.generationConcurrencyLimitPerPlayer <= LSSConstants.MAX_CONCURRENCY_LIMIT, "generationConcurrencyLimitPerPlayer");
+        // The real clamp semantic (R-2 / config review 9.1): per-player is bounded by the
+        // configured GLOBAL cap, not a protocol constant (MAX_CONCURRENCY_LIMIT is deleted).
+        helper.assertTrue(c.generationConcurrencyLimitPerPlayer >= LSSConstants.MIN_CONCURRENCY_LIMIT && c.generationConcurrencyLimitPerPlayer <= c.generationConcurrencyLimitGlobal, "generationConcurrencyLimitPerPlayer");
         helper.succeed();
     }
 }

--- a/fabric/src/main/java/dev/vox/lss/api/LSSApi.java
+++ b/fabric/src/main/java/dev/vox/lss/api/LSSApi.java
@@ -16,6 +16,11 @@ import java.util.concurrent.CopyOnWriteArrayList;
  * to receive pre-voxelized column data from the server.
  */
 public final class LSSApi {
+
+    // Log-sweep hygiene (2026-08-13): per-column/per-frame failure sites aggregate to
+    // one line/min — a persistent condition must not flood the client log.
+    private static final dev.vox.lss.common.LogThrottle CONSUMER_THROW_WARN =
+            new dev.vox.lss.common.LogThrottle(60_000);
     private static final List<VoxelColumnConsumer> columnConsumers = new CopyOnWriteArrayList<>();
 
     /**
@@ -158,7 +163,12 @@ public final class LSSApi {
             } catch (Throwable e) {
                 // Isolate per consumer: one consumer's failure (incl. Errors such as a
                 // LinkageError from an incompatible LOD mod) must not skip the others.
-                LSSLogger.error("Voxel column consumer threw exception", e);
+                long n = CONSUMER_THROW_WARN.recordAndTryAcquire(System.nanoTime() / 1_000_000);
+                if (n > 0) {
+                    LSSLogger.error("Voxel column consumer threw exception (" + n
+                            + " consumer throw(s) since the last report; each column is"
+                            + " re-served)", e);
+                }
                 // A throw means the column was not ingested — treat it like an explicit
                 // reportIngestFailure so the position is re-served instead of becoming a
                 // permanent hole: exactly one report per failing consumer per delivery.

--- a/fabric/src/main/java/dev/vox/lss/compat/VoxyCompat.java
+++ b/fabric/src/main/java/dev/vox/lss/compat/VoxyCompat.java
@@ -24,6 +24,11 @@ import java.util.function.Consumer;
  * intermediate ID translation.
  */
 class VoxyCompat {
+
+    // Log-sweep hygiene (2026-08-13): per-column/per-frame failure sites aggregate to
+    // one line/min — a persistent condition must not flood the client log.
+    private static final dev.vox.lss.common.LogThrottle INGEST_FAIL_WARN =
+            new dev.vox.lss.common.LogThrottle(60_000);
     // WorldIdentifier.of(Level) → Object
     private static MethodHandle worldIdentifierOf;
 
@@ -176,7 +181,11 @@ class VoxyCompat {
             reportSink.report(dimension, chunkX, chunkZ);
         } catch (Throwable e) {
             if (e instanceof Error && !(e instanceof AssertionError)) throw (Error) e;
-            LSSLogger.error("Voxy raw ingest failed", e);
+            long n = INGEST_FAIL_WARN.recordAndTryAcquire(System.nanoTime() / 1_000_000);
+            if (n > 0) {
+                LSSLogger.error("Voxy raw ingest failed (" + n
+                        + " failed ingest(s) since the last report; each is re-served)", e);
+            }
             reportSink.report(dimension, chunkX, chunkZ);
         }
     }

--- a/fabric/src/main/java/dev/vox/lss/networking/client/ClientColumnProcessor.java
+++ b/fabric/src/main/java/dev/vox/lss/networking/client/ClientColumnProcessor.java
@@ -26,6 +26,11 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Supplier;
 
 class ClientColumnProcessor {
+
+    // Log-sweep hygiene (2026-08-13): per-column/per-frame failure sites aggregate to
+    // one line/min — a persistent condition must not flood the client log.
+    private static final dev.vox.lss.common.LogThrottle PROCESS_FAIL_WARN =
+            new dev.vox.lss.common.LogThrottle(60_000);
     static final int MAX_QUEUED_COLUMNS = 8000;
     /** Byte budget for queued (still-compressed-in-memory) section payloads: the count cap
      *  alone admits up to 8000 x 2 MiB = 16 GiB from a hostile or misbehaving server before
@@ -380,8 +385,12 @@ class ClientColumnProcessor {
                 // class the delivery-honesty refactor eliminated; LSSApi.dispatchColumn one
                 // frame downstream already treats Throwable this way). Report FIRST so the
                 // stamp is forgotten, then let true Errors propagate.
-                LSSLogger.error("Failed to process voxel column at "
-                        + payload.chunkX() + "," + payload.chunkZ(), t);
+                long n = PROCESS_FAIL_WARN.recordAndTryAcquire(System.nanoTime() / 1_000_000);
+                if (n > 0) {
+                    LSSLogger.error("Failed to process voxel column at "
+                            + payload.chunkX() + "," + payload.chunkZ() + " (" + n
+                            + " failure(s) since the last report)", t);
+                }
                 this.failureReporter.report(payload.dimension(),
                         payload.chunkX(), payload.chunkZ());
                 if (t instanceof Error err && !(t instanceof AssertionError)) throw err;

--- a/fabric/src/main/java/dev/vox/lss/networking/client/ClientSessionGate.java
+++ b/fabric/src/main/java/dev/vox/lss/networking/client/ClientSessionGate.java
@@ -392,11 +392,25 @@ final class ClientSessionGate {
             // NEW manager, whose dimension guard drops it until its first tick — same
             // accepted residual as the disconnect race.)
             var previous = this.requestManager;
+            // Same connection, same link: SNAPSHOT the old governor before teardown
+            // resets it, and hand the state to the rebuilt manager (review-wave C-M1 —
+            // a /lsslod set re-push must not un-cap a governed slow link; the far-
+            // player tracker solved this same rebuild event by living OUTSIDE the
+            // manager, R-5). The teardown-then-rebuild ORDER is itself load-bearing
+            // (pinned: the old manager's cache save must land before the new one's
+            // load), hence the snapshot rather than a reorder. A legacy-fallback
+            // re-push self-corrects: legacy sessions hard-reset the governor on tick.
+            TransferRateGovernor carried = null;
             if (previous != null) {
+                carried = new TransferRateGovernor();
+                carried.adoptFrom(previous.governor);
                 teardownManager(previous);
             }
             this.connectionStartMs = System.currentTimeMillis();
             this.requestManager = this.managerFactory.create(config);
+            if (carried != null) {
+                this.requestManager.governor.adoptFrom(carried);
+            }
         }
     }
 

--- a/fabric/src/main/java/dev/vox/lss/networking/client/FarPlayerClientSupport.java
+++ b/fabric/src/main/java/dev/vox/lss/networking/client/FarPlayerClientSupport.java
@@ -22,6 +22,11 @@ import net.fabricmc.fabric.api.client.networking.v1.ClientPlayNetworking;
  */
 public final class FarPlayerClientSupport {
 
+    // Log-sweep hygiene (2026-08-13): per-column/per-frame failure sites aggregate to
+    // one line/min — a persistent condition must not flood the client log.
+    private static final dev.vox.lss.common.LogThrottle MALFORMED_FRAME_WARN =
+            new dev.vox.lss.common.LogThrottle(60_000);
+
     /** Flipped true at E2 (the defaults decision — E1 shipped false/inert).
      *  Package-visible for the pin test. */
     static final boolean CLIENT_ARMED = true;
@@ -147,7 +152,11 @@ public final class FarPlayerClientSupport {
         try {
             TRACKER.onRoster(FarPlayerWire.decodeRoster(body));
         } catch (Exception e) {
-            LSSLogger.warn("Malformed far-player roster frame — ignored (" + e + ")");
+            long n = MALFORMED_FRAME_WARN.recordAndTryAcquire(System.nanoTime() / 1_000_000);
+            if (n > 0) {
+                LSSLogger.warn("Malformed far-player roster frame — ignored (" + e + "; " + n
+                        + " malformed frame(s) since the last report)");
+            }
         }
     }
 
@@ -156,7 +165,11 @@ public final class FarPlayerClientSupport {
         try {
             TRACKER.onUpdates(FarPlayerWire.decodeUpdates(body), monotonicMillis());
         } catch (Exception e) {
-            LSSLogger.warn("Malformed far-player updates frame — ignored (" + e + ")");
+            long n = MALFORMED_FRAME_WARN.recordAndTryAcquire(System.nanoTime() / 1_000_000);
+            if (n > 0) {
+                LSSLogger.warn("Malformed far-player updates frame — ignored (" + e + "; " + n
+                        + " malformed frame(s) since the last report)");
+            }
         }
     }
 

--- a/fabric/src/main/java/dev/vox/lss/networking/client/FarPlayerRenderer.java
+++ b/fabric/src/main/java/dev/vox/lss/networking/client/FarPlayerRenderer.java
@@ -88,6 +88,13 @@ public final class FarPlayerRenderer {
     private final Set<UUID> submittedVehicles = new HashSet<>();
     private final FarPlayerMountLadder mountLadder = FarPlayerMountLadder.production();
     /** Small identity→Item cache (equipment strings repeat every frame). */
+    /** Identity-string → Item memo. CAPPED (review-wave C-M2): every sibling
+     *  structure carries explicit hostile-input armor (the tracker's 4096-identity
+     *  cap, the mount ladder's 256-type cap) and this map was the one unbounded
+     *  one — a hostile server feeding unique equipment identities grew client heap
+     *  for the JVM's life. Past the cap, identities resolve uncached (correct,
+     *  just unmemoized); the cache also empties with the proxies in clear(). */
+    private static final int ITEM_CACHE_CAP = 1024;
     private final Map<String, Item> itemCache = new ConcurrentHashMap<>();
     private int nextProxyId = PROXY_ID_BASE;
     private boolean crashLatched;
@@ -153,6 +160,7 @@ public final class FarPlayerRenderer {
         vehicles.clear();
         activeVehicles.clear();
         submittedVehicles.clear();
+        itemCache.clear(); // C-M2: the memo empties with the session's proxies
     }
 
     /** The COLLECT_SUBMITS pass. */
@@ -522,18 +530,22 @@ public final class FarPlayerRenderer {
         private static ItemStack stackFor(String identity, int count,
                                           Map<String, Item> itemCache) {
             if (identity == null) return ItemStack.EMPTY;
-            Item item = itemCache.computeIfAbsent(identity, id -> {
-                try {
-                    // Cross-version sessions (Via) can carry identities this client's
-                    // registry lacks — an unknown identity renders as an EMPTY slot,
-                    // the far-player analogue of the column fallback ladder.
-                    return BuiltInRegistries.ITEM.getValue(Identifier.parse(id));
-                } catch (Exception e) {
-                    return Items.AIR;
-                }
-            });
+            Item item = itemCache.size() >= ITEM_CACHE_CAP && !itemCache.containsKey(identity)
+                    ? resolveItem(identity) // cap reached: resolve uncached (C-M2 armor)
+                    : itemCache.computeIfAbsent(identity, Proxy::resolveItem);
             return item == null || item == Items.AIR ? ItemStack.EMPTY
                     : new ItemStack(item, count);
+        }
+
+        private static Item resolveItem(String id) {
+            try {
+                // Cross-version sessions (Via) can carry identities this client's
+                // registry lacks — an unknown identity renders as an EMPTY slot,
+                // the far-player analogue of the column fallback ladder.
+                return BuiltInRegistries.ITEM.getValue(Identifier.parse(id));
+            } catch (Exception e) {
+                return Items.AIR;
+            }
         }
 
         private void updateWalkAnimation(Vec3 position, boolean allowWalk,

--- a/fabric/src/main/java/dev/vox/lss/networking/client/LSSClientNetworking.java
+++ b/fabric/src/main/java/dev/vox/lss/networking/client/LSSClientNetworking.java
@@ -21,6 +21,11 @@ import net.minecraft.world.level.Level;
 import net.minecraft.world.level.storage.LevelResource;
 
 public class LSSClientNetworking {
+
+    // Log-sweep hygiene (2026-08-13): per-column/per-frame failure sites aggregate to
+    // one line/min — a persistent condition must not flood the client log.
+    private static final dev.vox.lss.common.LogThrottle UNKNOWN_TYPE_WARN =
+            new dev.vox.lss.common.LogThrottle(60_000);
     private static final ClientColumnProcessor columnProcessor = new ClientColumnProcessor();
 
     // Session state and the JOIN / SessionConfig / DISCONNECT ladders live in the gate
@@ -310,7 +315,15 @@ public class LSSClientNetworking {
                         // self-heal that approximates v16's ~1 s retry. Debug, not warn: on a
                         // v16 session this is routine, and a v18 server never sends it.
                         LSSLogger.debug("v16 rate-limited position " + packed + " (re-declared next scan)");
-                default -> LSSLogger.warn("Unknown batch response type: " + type);
+                default -> {
+                    // Throttled (log sweep): this sits INSIDE the per-element batch loop —
+                    // protocol drift would emit hundreds of lines per second bare.
+                    long n = UNKNOWN_TYPE_WARN.recordAndTryAcquire(System.nanoTime() / 1_000_000);
+                    if (n > 0) {
+                        LSSLogger.warn("Unknown batch response type: " + type + " (" + n
+                                + " unknown element(s) since the last report)");
+                    }
+                }
             }
         }
     }

--- a/fabric/src/main/java/dev/vox/lss/networking/client/LodRequestManager.java
+++ b/fabric/src/main/java/dev/vox/lss/networking/client/LodRequestManager.java
@@ -18,6 +18,11 @@ import java.util.concurrent.CompletableFuture;
 import java.util.function.IntSupplier;
 
 public class LodRequestManager {
+
+    // Log-sweep hygiene (2026-08-13): per-column/per-frame failure sites aggregate to
+    // one line/min — a persistent condition must not flood the client log.
+    private static final dev.vox.lss.common.LogThrottle BATCH_SEND_FAIL_WARN =
+            new dev.vox.lss.common.LogThrottle(60_000);
     /** Backpressure threshold: halt sending when column processing queue exceeds this fraction. */
     private static final int BACKPRESSURE_NUMERATOR = 3;
     private static final int BACKPRESSURE_DENOMINATOR = 4;
@@ -565,7 +570,11 @@ public class LodRequestManager {
                 this.metrics.recordRequestSent(positions[i], nowMs); // RTT: last-declare stamp
             }
         } catch (Exception e) {
-            LSSLogger.error("Failed to send want-set batch", e);
+            long n = BATCH_SEND_FAIL_WARN.recordAndTryAcquire(System.nanoTime() / 1_000_000);
+            if (n > 0) {
+                LSSLogger.error("Failed to send want-set batch (" + n
+                        + " send failure(s) since the last report; retried at 1 Hz)", e);
+            }
             // Nothing is consumed at send any more (marks are answer-consumed), and the next
             // scan re-declares the identical set, so no mark restoration is needed. Just drop
             // the awaiting entries so late-status gating doesn't credit a batch that never

--- a/fabric/src/main/java/dev/vox/lss/networking/client/TransferRateGovernor.java
+++ b/fabric/src/main/java/dev/vox/lss/networking/client/TransferRateGovernor.java
@@ -409,6 +409,35 @@ final class TransferRateGovernor {
      *  re-engages in 1-2 intervals off the kept baseline; only control state drops
      *  (a full reset would reseed the baseline from the CONGESTED current ping and
      *  the engagement conjunct could never fire again). */
+    /** Carry the governor across a same-connection manager REBUILD (a mid-session
+     *  SessionConfig re-push: {@code /lsslod set}, a Paper /reload re-attach, the
+     *  establish heal). Same link, same session — the review-wave C-M1 finding:
+     *  discarding state here un-capped a governed slow link for the seconds a fresh
+     *  governor needs to re-learn congestion (the round-5 runaway shape, briefly),
+     *  and reseeded the ping baseline from the CONGESTED current reading (the
+     *  MINOR-2 hazard onDimensionChange was built to avoid). Copies measurements
+     *  AND control; the interval accumulator deliberately reseeds so the first
+     *  new-manager tick re-bases the cumulative counters instead of inheriting a
+     *  torn window. */
+    void adoptFrom(TransferRateGovernor other) {
+        this.pingBaselineMs = other.pingBaselineMs;
+        this.baselineDriftAnchorMillis = other.baselineDriftAnchorMillis;
+        this.lastPingMs = other.lastPingMs;
+        this.sizeEwmaBytes = other.sizeEwmaBytes;
+        this.lastMissingVanilla = other.lastMissingVanilla;
+        this.minMissingVanilla = other.minMissingVanilla;
+        this.engaged = other.engaged;
+        this.desiredBytesPerSec = other.desiredBytesPerSec;
+        this.keptUpStreak = other.keptUpStreak;
+        this.rateDisengageStreak = other.rateDisengageStreak;
+        this.engagePendingStreak = other.engagePendingStreak;
+        this.engageNoted = other.engageNoted;
+        this.disengageNoted = other.disengageNoted;
+        this.intervalSeeded = false;
+        this.haltSeenThisInterval = false;
+        this.movementSeenThisInterval = false;
+    }
+
     void onDimensionChange() {
         hardReset();
         // A new dimension is a new view — the missing floor re-learns (the edge ring

--- a/fabric/src/main/java/dev/vox/lss/networking/server/DeferredTicketReleases.java
+++ b/fabric/src/main/java/dev/vox/lss/networking/server/DeferredTicketReleases.java
@@ -22,6 +22,9 @@ import java.util.LinkedHashMap;
  */
 final class DeferredTicketReleases {
 
+    private final dev.vox.lss.common.LogThrottle releaseFailWarn =
+            new dev.vox.lss.common.LogThrottle(60_000);
+
     /** Releases executed per drain call (one server tick). 4/tick clears a full 40-ticket
      *  sweep in half a second; a force-load ticket lingering that long is harmless. */
     static final int MAX_RELEASES_PER_TICK = 4;
@@ -53,8 +56,14 @@ final class DeferredTicketReleases {
             try {
                 entry.getValue().run();
             } catch (Exception e) {
-                LSSLogger.error("Deferred ticket release failed for " + entry.getKey()
-                        + " — ticket may remain held", e);
+                // Throttled (log sweep): a C2ME/Moonrise distance-graph incompatibility
+                // throws per ticket per tick here.
+                long n = this.releaseFailWarn.recordAndTryAcquire(System.nanoTime() / 1_000_000);
+                if (n > 0) {
+                    LSSLogger.error("Deferred ticket release failed for " + entry.getKey()
+                            + " — ticket may remain held (" + n
+                            + " failure(s) since the last report)", e);
+                }
             }
             ran++;
         }

--- a/fabric/src/main/java/dev/vox/lss/networking/server/FabricOffThreadProcessor.java
+++ b/fabric/src/main/java/dev/vox/lss/networking/server/FabricOffThreadProcessor.java
@@ -23,6 +23,11 @@ import java.util.concurrent.ConcurrentHashMap;
  * that will be sent via Fabric networking on the main thread.
  */
 public class FabricOffThreadProcessor extends OffThreadProcessor<PlayerRequestState> {
+
+    // Log-sweep hygiene (2026-08-13): per-column/per-event conditions aggregate to one
+    // line/min — self-healing paths must not flood operator consoles.
+    private static final dev.vox.lss.common.LogThrottle OVERSIZED_WARN =
+            new dev.vox.lss.common.LogThrottle(60_000);
     private final ChunkDiskReader diskReader;
 
     // Stored references for disk read submission. Grows but never prunes — acceptable because
@@ -102,17 +107,26 @@ public class FabricOffThreadProcessor extends OffThreadProcessor<PlayerRequestSt
         // pre-built store frames, whose non-shrinking degenerates ship raw) — load-bearing
         // for store-frame hits too, whose rows can legally exceed the send cap (plan §3).
         if (bytes.rawSize() > LSSConstants.MAX_SEND_SECTIONS_SIZE) {
-            LSSLogger.warn("Dropping oversized column [" + cx + ", " + cz + "] in " + dimension
+            {
+            long n = OVERSIZED_WARN.recordAndTryAcquire(System.nanoTime() / 1_000_000);
+            if (n > 0) LSSLogger.warn("Dropping oversized column [" + cx + ", " + cz + "] in " + dimension
                     + ": " + bytes.rawSize() + " bytes exceeds send limit "
-                    + LSSConstants.MAX_SEND_SECTIONS_SIZE + " (netty frame cap would kill the connection)");
+                    + LSSConstants.MAX_SEND_SECTIONS_SIZE + " (netty frame cap would kill the connection)"
+                    + " (" + n + " oversized drop(s) since the last report — the client"
+                    + " re-asks and is answered up-to-date)");
             return false;
+        }
         }
         if (dimension.length() > LSSConstants.MAX_DIMENSION_STRING_LENGTH) {
             // Drop just this column (like an oversized one) rather than letting writeUtf throw
             // at send time and nuke the whole send queue. No real dimension id is this long;
             // the !sent path answers the client up-to-date so it stops asking.
-            LSSLogger.warn("Dropping column [" + cx + ", " + cz + "] with oversized dimension id ("
-                    + dimension.length() + " chars > " + LSSConstants.MAX_DIMENSION_STRING_LENGTH + ")");
+            long dn = OVERSIZED_WARN.recordAndTryAcquire(System.nanoTime() / 1_000_000);
+            if (dn > 0) {
+                LSSLogger.warn("Dropping column [" + cx + ", " + cz + "] with oversized dimension id ("
+                        + dimension.length() + " chars > " + LSSConstants.MAX_DIMENSION_STRING_LENGTH
+                        + ") (" + dn + " oversized drop(s) since the last report)");
+            }
             return false;
         }
         var dimensionKey = this.dimensionKeyCache.computeIfAbsent(dimension,

--- a/fabric/src/main/java/dev/vox/lss/networking/server/RegionFileRawRead.java
+++ b/fabric/src/main/java/dev/vox/lss/networking/server/RegionFileRawRead.java
@@ -77,7 +77,15 @@ final class RegionFileRawRead {
                 // vanilla, and reading it here closes the non-ATOMIC_MOVE replace window
                 // the withdrawn lazy-pool-IO design would have re-opened (review C7).
                 if (streamLength != 0) {
-                    LSSLogger.warn("Chunk " + pos + " has both internal and external streams");
+                    // Throttled like every other corrupt-region line in this file (the
+                    // log sweep found this one bare — an affected chunk is re-read on
+                    // every re-declaration).
+                    long n = CORRUPT_WARN_THROTTLE.recordAndTryAcquire(
+                            System.nanoTime() / 1_000_000);
+                    if (n > 0) {
+                        LSSLogger.warn("Chunk " + pos + " has both internal and external"
+                                + " streams (" + n + " since the last report)");
+                    }
                 }
                 Path external = acc.lss$getExternalChunkPath(pos);
                 if (!Files.isRegularFile(external)) {

--- a/fabric/src/test/java/dev/vox/lss/common/DiagnosticsFormatterTest.java
+++ b/fabric/src/test/java/dev/vox/lss/common/DiagnosticsFormatterTest.java
@@ -112,7 +112,7 @@ class DiagnosticsFormatterTest {
                 2_097_152,
                 512,
                 List.of(new DiagnosticsFormatter.PlayerDiag("Steve", 3, 4000, 2, 1, 2000, 4096,
-                        65536L, 131072L, 7L)));
+                        65536L, 131072L, 7L, 0L, -1L, 1.0, 0L)));
 
         assertEquals(List.of(
                 "=== LSS LOD Diagnostics ===",
@@ -478,7 +478,7 @@ class DiagnosticsFormatterTest {
                 2_097_152,
                 512,
                 List.of(new DiagnosticsFormatter.PlayerDiag("Steve", 0, 4000, 0, 0, 0, 0,
-                        -1L, -1L, 0L)));
+                        -1L, -1L, 0L, 0L, -1L, 1.0, 0L)));
         var lines = DiagnosticsFormatter.formatDiagnostics(d);
         assertTrue(lines.stream().anyMatch(l -> l.contains("obuf=n/a/n/a")),
                 "no-signal must render as n/a, got: " + lines);
@@ -604,7 +604,7 @@ class DiagnosticsFormatterTest {
                 2_097_152,
                 512,
                 List.of(new DiagnosticsFormatter.PlayerDiag("Alex", 1, 4000, 0, 0, 10, 1000,
-                        50_000L, 60_000L, 0L, 3L, 125_000L)));
+                        50_000L, 60_000L, 0L, 3L, 125_000L, 1.0, 0L)));
         assertTrue(DiagnosticsFormatter.formatDiagnostics(d).stream()
                         .anyMatch(l -> l.contains("ceil=122.1 KB")),
                 "an armed ceiling renders its byte value");
@@ -627,7 +627,7 @@ class DiagnosticsFormatterTest {
                 2_097_152,
                 512,
                 List.of(new DiagnosticsFormatter.PlayerDiag("Alex", 1, 4000, 0, 0, 10, 1000,
-                        50_000L, 60_000L, 0L, 3L, -1L, 0.0833)));
+                        50_000L, 60_000L, 0L, 3L, -1L, 0.0833, 0L)));
         assertTrue(DiagnosticsFormatter.formatDiagnostics(d).stream()
                         .anyMatch(l -> l.contains("pingf=0.08")),
                 "a cut factor renders through the %.2f format");

--- a/fabric/src/test/java/dev/vox/lss/common/WantSetBudgetInvariantTest.java
+++ b/fabric/src/test/java/dev/vox/lss/common/WantSetBudgetInvariantTest.java
@@ -22,7 +22,5 @@ class WantSetBudgetInvariantTest {
                         + LSSConstants.WANT_SET_FRONTIER_RESERVE
                         <= LSSConstants.WANT_SET_BUDGET,
                 "budget must dominate max in-flight (sync cap + global gen ceiling) + frontier reserve");
-        assertTrue(LSSConstants.SYNC_ON_LOAD_SLOT_CAP <= LSSConstants.MAX_CONCURRENCY_LIMIT,
-                "the constant slot cap must respect the protocol concurrency ceiling");
     }
 }

--- a/fabric/src/test/java/dev/vox/lss/config/ConfigValidationTest.java
+++ b/fabric/src/test/java/dev/vox/lss/config/ConfigValidationTest.java
@@ -274,7 +274,7 @@ class ConfigValidationTest {
         // Plain per-field bound: the #28 cross-clamp is gone (no client budget derives
         // from this cap anymore; the successor invariant lives in WantSetBudgetInvariantTest).
         // Config review §9.1: the per-player ceiling is now the CONFIGURED global, not the
-        // unrelated MAX_CONCURRENCY_LIMIT (1000) — a per-player value above the fleet-wide one
+        // deleted MAX_CONCURRENCY_LIMIT — a per-player value above the fleet-wide one
         // is unreachable by construction, so it used to validate to silent nonsense.
         c.generationConcurrencyLimitGlobal = 64;
         c.generationConcurrencyLimitPerPlayer = 9999;

--- a/fabric/src/test/java/dev/vox/lss/networking/client/ClientSessionGateTest.java
+++ b/fabric/src/test/java/dev/vox/lss/networking/client/ClientSessionGateTest.java
@@ -74,6 +74,34 @@ class ClientSessionGateTest {
         return new SessionConfigS2CPayload(protocolVersion, enabled, 64, true);
     }
 
+    @org.junit.jupiter.api.Test
+    void sessionConfigRePushCarriesTheGovernorAcrossTheManagerRebuild() {
+        // Review-wave C-M1: a mid-session re-push (/lsslod set, a Paper /reload
+        // re-attach) rebuilds the manager — the fresh governor must ADOPT the old
+        // one's state, or a governed slow link is un-capped for the seconds a fresh
+        // loop needs to re-learn congestion (the round-5 runaway shape) and the ping
+        // baseline reseeds from the congested current reading.
+        gate.onSessionConfig(config(V, true), true, true);
+        var first = gate.getRequestManager();
+        // Engage the first manager's governor with a known shape (the manager-test rig).
+        first.governor.tick(1, 0, 0, 0, 1, false, 50, true);
+        first.governor.tick(1 + TransferRateGovernor.INTERVAL_MILLIS,
+                800 * 1024, 100, 20_000, 1, false, 2_000, true);
+        first.governor.tick(1 + 2 * TransferRateGovernor.INTERVAL_MILLIS,
+                1600 * 1024, 200, 40_000, 1, false, 2_000, true);
+        org.junit.jupiter.api.Assertions.assertTrue(first.governor.isEngaged(), "rig engagement");
+        long desired = first.governor.getDesiredBytesPerSec();
+
+        gate.onSessionConfig(config(V, true), true, true); // the re-push
+        var second = gate.getRequestManager();
+        org.junit.jupiter.api.Assertions.assertNotSame(first, second, "the re-push rebuilds");
+        org.junit.jupiter.api.Assertions.assertTrue(second.governor.isEngaged(),
+                "the rebuilt manager's governor must stay engaged");
+        org.junit.jupiter.api.Assertions.assertEquals(desired,
+                second.governor.getDesiredBytesPerSec(),
+                "the governed rate carries across the rebuild");
+    }
+
     /** The synthetic disabled shape the codec's drain branch produces for a foreign version. */
     private static SessionConfigS2CPayload codecForeignShape(int protocolVersion) {
         return new SessionConfigS2CPayload(protocolVersion, false, 0, false);

--- a/paper/src/main/java/dev/vox/lss/paper/PaperCommands.java
+++ b/paper/src/main/java/dev/vox/lss/paper/PaperCommands.java
@@ -80,7 +80,8 @@ public class PaperCommands implements CommandExecutor, TabCompleter {
                             PaperRequestProcessingService service, String[] args) {
         var config = this.configSupplier.get();
         if (args.length == 1) {
-            sender.sendMessage("Runtime-settable keys (applied + persisted to lss-server-config.json):");
+            sender.sendMessage("Runtime-settable keys (applied + persisted to "
+                    + dev.vox.lss.common.Brand.lowerShortName() + "-server-config.json):");
             for (var line : dev.vox.lss.common.config.RuntimeSettings.listLines(config)) {
                 sender.sendMessage("  " + line);
             }

--- a/paper/src/main/java/dev/vox/lss/paper/PaperOffThreadProcessor.java
+++ b/paper/src/main/java/dev/vox/lss/paper/PaperOffThreadProcessor.java
@@ -18,6 +18,11 @@ import java.util.concurrent.ConcurrentHashMap;
  * that will be sent via Plugin Messaging on the main thread.
  */
 public class PaperOffThreadProcessor extends OffThreadProcessor<PaperPlayerRequestState> {
+
+    // Log-sweep hygiene (2026-08-13): per-column/per-event conditions aggregate to one
+    // line/min — self-healing paths must not flood operator consoles.
+    private static final dev.vox.lss.common.LogThrottle OVERSIZED_WARN =
+            new dev.vox.lss.common.LogThrottle(60_000);
     private final PaperChunkDiskReader diskReader;
 
     // Maps a dimension id to its live ServerLevel for disk-read submission. Refreshed every
@@ -94,18 +99,27 @@ public class PaperOffThreadProcessor extends OffThreadProcessor<PaperPlayerReque
         // RAW-size guard (twin of the Fabric build; load-bearing for store-frame hits
         // whose rows can legally exceed the send cap — plan §3).
         if (bytes.rawSize() > LSSConstants.MAX_SEND_SECTIONS_SIZE) {
-            LSSLogger.warn("Dropping oversized column [" + cx + ", " + cz + "] in " + dimension
+            {
+            long n = OVERSIZED_WARN.recordAndTryAcquire(System.nanoTime() / 1_000_000);
+            if (n > 0) LSSLogger.warn("Dropping oversized column [" + cx + ", " + cz + "] in " + dimension
                     + ": " + bytes.rawSize() + " bytes exceeds send limit "
-                    + LSSConstants.MAX_SEND_SECTIONS_SIZE + " (netty frame cap would kill the connection)");
+                    + LSSConstants.MAX_SEND_SECTIONS_SIZE + " (netty frame cap would kill the connection)"
+                    + " (" + n + " oversized drop(s) since the last report — the client"
+                    + " re-asks and is answered up-to-date)");
             return false;
+        }
         }
         if (dimension.length() > LSSConstants.MAX_DIMENSION_STRING_LENGTH) {
             // Drop just this column (like an oversized one): without the guard
             // encodeVoxelColumnPreEncoded's writeUtf throws out of this method and aborts the
             // WHOLE processing cycle. No real dimension id is this long; the !sent path answers
             // the client up-to-date so it stops asking.
-            LSSLogger.warn("Dropping column [" + cx + ", " + cz + "] with oversized dimension id ("
-                    + dimension.length() + " chars > " + LSSConstants.MAX_DIMENSION_STRING_LENGTH + ")");
+            long dn = OVERSIZED_WARN.recordAndTryAcquire(System.nanoTime() / 1_000_000);
+            if (dn > 0) {
+                LSSLogger.warn("Dropping column [" + cx + ", " + cz + "] with oversized dimension id ("
+                        + dimension.length() + " chars > " + LSSConstants.MAX_DIMENSION_STRING_LENGTH
+                        + ") (" + dn + " oversized drop(s) since the last report)");
+            }
             return false;
         }
         // C2 legacy egress translation (XVER §4.2), at THIS per-recipient choke point —

--- a/paper/src/main/java/dev/vox/lss/paper/PaperPayloadHandler.java
+++ b/paper/src/main/java/dev/vox/lss/paper/PaperPayloadHandler.java
@@ -242,13 +242,28 @@ public final class PaperPayloadHandler {
         sendRawNmsPayload(player, ID_DIRTY_COLUMNS, data);
     }
 
+    // Malformed-C2S log guard (log-sweep top finding): these warns fire on
+    // CLIENT-SUPPLIED bytes at packet rate and returned null WITHOUT throwing, so they
+    // bypassed the plugin's hostile-frame throttle (which only covers the exception
+    // path) — a cheap remote log-flood vector. One aggregated line per minute, max.
+    private static final dev.vox.lss.common.LogThrottle MALFORMED_C2S_WARN =
+            new dev.vox.lss.common.LogThrottle(60_000);
+
+    private static void warnMalformed(String what) {
+        long n = MALFORMED_C2S_WARN.recordAndTryAcquire(System.nanoTime() / 1_000_000);
+        if (n > 0) {
+            LSSLogger.warn(what + " (" + n + " malformed C2S frame(s) since the last"
+                    + " report; contained — malformed frames are dropped)");
+        }
+    }
+
     // ---- C2S Decoding ----
 
     public record DecodedHandshake(int protocolVersion, int capabilities) {}
 
     public static DecodedHandshake decodeHandshake(byte[] data) {
         if (data == null || data.length == 0) {
-            LSSLogger.warn("Received empty handshake payload");
+            warnMalformed("Received empty handshake payload");
             return null;
         }
         return withReadBuffer(data, buf -> {
@@ -262,13 +277,13 @@ public final class PaperPayloadHandler {
 
     public static DecodedBatchChunkRequest decodeBatchChunkRequest(byte[] data) {
         if (data == null || data.length == 0) {
-            LSSLogger.warn("Received empty batch chunk request payload");
+            warnMalformed("Received empty batch chunk request payload");
             return null;
         }
         return withReadBuffer(data, buf -> {
             int count = buf.readVarInt();
             if (count < 0 || count > LSSConstants.MAX_BATCH_CHUNK_REQUESTS) {
-                LSSLogger.warn("Batch chunk request count out of range: " + count);
+                warnMalformed("Batch chunk request count out of range: " + count);
                 return null;
             }
             long[] packedPositions = new long[count];

--- a/paper/src/test/java/dev/vox/lss/paper/PluginYmlContractTest.java
+++ b/paper/src/test/java/dev/vox/lss/paper/PluginYmlContractTest.java
@@ -94,6 +94,19 @@ class PluginYmlContractTest {
     }
 
     @Test
+    void bothFarPlayerPrivacyNodesAreDeclaredDefaultFalse() {
+        // Review-wave V-M1 (the load-bearing dual declaration): the enforcement
+        // dual-checks lss.* OR vss.*, and Bukkit resolves an UNDECLARED node to the op
+        // default — deleting EITHER declaration (or flipping a default) silently hides
+        // every op from far players on the jars where that spelling is undeclared.
+        // Both spellings ship in BOTH jars; the vssJar rewrite must not rename them.
+        assertEquals("false", yml.getString("permissions/lss.farplayers.hidden/default"),
+                "lss.farplayers.hidden must be declared default false");
+        assertEquals("false", yml.getString("permissions/vss.farplayers.hidden/default"),
+                "vss.farplayers.hidden must be declared default false");
+    }
+
+    @Test
     void apiVersionMatchesTheDevBundleMinecraftVersion() throws Exception {
         String apiVersion = yml.getString("api-version");
         assertNotNull(apiVersion);

--- a/scripts/check_soak.py
+++ b/scripts/check_soak.py
@@ -218,6 +218,13 @@ SERVER_CONFIG_INT_KEYS = frozenset({
     # box whose AUTO pool exceeds it, needs the opt-in or a K=pool pin).
     "maxConcurrentDiskReads",
     "sendQueueLimitPerPlayer", "bytesPerSecondLimitGlobal",
+    # Canonical bandwidth spellings since the 2026-08-08 key rename (staleness-sweep
+    # finding: only the legacy byte spellings were listed, so a scenario written with
+    # the modern keys would be rejected — the R4 lesson again). Values are MiB/s
+    # doubles in the mod; scenarios may still write ints (validated as numeric below
+    # via the int allowlist — a fractional override belongs in a new float set if ever
+    # needed).
+    "mbPerSecondLimitPerPlayer", "mbPerSecondLimitGlobal",
     # Outbound ceiling (0 = off, the default; explicit = operator-fixed entry
     # gate — the AUTO mode was deleted, adaptive-transfer-rate-plan.md). Listed so
     # an A/B scenario can pin it — the R4 lesson below is exactly this omission.
@@ -997,8 +1004,14 @@ def evaluate_laws(ctx):
     for run, csnaps in sorted(ctx.runs.items()):
         violations += law_A6_client(run, csnaps)
 
-    # B2 over raw series, armed by the scenario's bandwidth cap override.
+    # B2 over raw series, armed by the scenario's bandwidth cap override — either
+    # spelling (the mb* keys are the canonical ones since 2026-08-08; bytes* are the
+    # legacy readers the mod honors forever).
     cap = ctx.config.get("bytesPerSecondLimitGlobal")
+    if not (isinstance(cap, int) and not isinstance(cap, bool)):
+        mb = ctx.config.get("mbPerSecondLimitGlobal")
+        if isinstance(mb, (int, float)) and not isinstance(mb, bool):
+            cap = int(mb * 1024 * 1024)
     if isinstance(cap, int) and not isinstance(cap, bool) and cap > 0:
         violations += law_B2(snaps, cap)
 
@@ -1599,9 +1612,11 @@ def check_bandwidth_throttle(ctx):
     send-queue breaker); only the recovery mechanism changed — a want dropped by a
     queue-full break is re-declared by the client's 1 Hz want-set, not rescued by the
     deleted 10 s in-flight timeout sweep."""
-    if "bytesPerSecondLimitGlobal" not in ctx.config:
+    if ("bytesPerSecondLimitGlobal" not in ctx.config
+            and "mbPerSecondLimitGlobal" not in ctx.config):
         yield Violation("bandwidth-throttle", "config",
-                        "scenario config must set bytesPerSecondLimitGlobal or B2 stays unarmed", {})
+                        "scenario config must set a global bandwidth cap (either spelling)"
+                        " or B2 stays unarmed", {})
     last = ctx.server_snaps[-1]
     if last["service"]["queue_full"] < 1:
         yield Violation("bandwidth-throttle", "final snapshot",

--- a/scripts/release_check.py
+++ b/scripts/release_check.py
@@ -375,6 +375,22 @@ def check_vss_pair_fabric(lss_jar, vss_jar, problems):
     icon = vmeta.get("icon")
     if icon and icon not in _names(vss_jar):
         problems.append(f"{vbase}: fabric.mod.json icon {icon!r} is not an entry in the jar")
+    # Lang-value rebrand pin (review-wave V-M2): the vssJar rewrites en_us.json VALUES —
+    # a silent no-op ships VSS Sodium pages reading "LOD Server Support"/"LSS" mid-
+    # sentence (the exact defect the rewrite exists to fix). Skipped when the jar has no
+    # lang entry (synthetic selftest fixtures); the byte-copy loop cannot drop entries.
+    LANG = "assets/lss/lang/en_us.json"
+    if LANG in _names(vss_jar):
+        try:
+            vlang = json.loads(_read(vss_jar, LANG))
+        except (KeyError, json.JSONDecodeError):
+            problems.append(f"{vbase}: {LANG} is not valid JSON after the lang rebrand")
+            vlang = {}
+        for k, v in vlang.items():
+            sv = str(v)
+            if "LOD Server Support" in sv or re.search(r"\bLSS\b", sv):
+                problems.append(f"{vbase}: lang value {k!r} still carries LSS branding "
+                                "— the vssJar lang rewrite no-opped or missed it")
 
 
 # plugin.yml lines that are the identity + wire contract: the VSS rebrand must leave every

--- a/test-server.sh
+++ b/test-server.sh
@@ -110,10 +110,11 @@ stage_move_trace_marker() {
 # `run-fabric-store` / `run-paper-store` below force "full". The store DB lives at
 # <world>/lss-lod/store.db and persists across restarts (derived data — deleting the
 # lss-lod/ dir is always safe); eyeball it with '/lsslod store status' in-game.
-# Default follows the SHIPPED default, which is OFF again as of 2026-08-03 (the store is
-# opt-in so an upgrade never silently doubles a world folder). So a plain ./test-server.sh
-# exercises what players actually get, and run-fabric-store / run-paper-store are once more
-# the meaningful store arm rather than aliases of the plain entrypoints.
+# Default "on", matching a FRESH INSTALL since the 2026-08-08 config rework (the compiled
+# default stays "off" so an UPGRADING server never silently arms the store, but a brand-new
+# install's generated config says "on" — and a fresh test-server rig is the fresh-install
+# case). run-fabric-store / run-paper-store therefore only differ from the plain
+# entrypoints by FORCING the store on (immune to LSS_LODSTORE=off) + enabling backfill.
 LSS_LODSTORE="${LSS_LODSTORE:-on}"
 case "$LSS_LODSTORE" in
     off|on|full) ;; # "on" == "full" since the 2026-08-08 config rework


### PR DESCRIPTION
Folds every actionable finding from the 4-Fable review of v0.10.0..HEAD (two MINORs from the client reviewer, three from the server reviewer, two from the far-players/VSS reviewer, the deletion reviewer's zero-risk items, its full 270-site log-spam classification, and the docs/scripts staleness sweep). Details in the commit message.

Not folded (decisions, not defects — see the session summary): MemoryLodStore deletion, the fixed outbound-ceiling mechanism, the v16 sunset schedule, rollback-flag sunset rule, one-shot script archival.

Gates: Fabric+Paper T1, T2 (72 gametests), both script selftests — green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)