### PR TITLE
Far players: issue-#160-proofing (ENTITY_LOAD containment, per-type rider attribution)

### DIFF
--- a/entity26.txt
+++ b/entity26.txt
@@ -1,0 +1,11721 @@
+Compiled from "Entity.java"
+public abstract class net.minecraft.world.entity.Entity implements net.minecraft.world.Nameable, net.minecraft.world.level.entity.EntityAccess, net.minecraft.world.scores.ScoreHolder, net.minecraft.network.syncher.SyncedDataHolder, net.minecraft.core.component.DataComponentGetter, net.minecraft.world.entity.ItemOwner, net.minecraft.world.entity.SlotProvider, net.minecraft.util.debug.DebugValueSource, net.minecraft.core.TypedInstance<net.minecraft.world.entity.EntityType<?>>, net.fabricmc.fabric.api.attachment.v1.AttachmentTarget, net.fabricmc.fabric.api.event.lifecycle.v1.EntityLoadData, net.fabricmc.fabric.api.permission.v1.PermissionContextOwner {
+  private static final org.slf4j.Logger LOGGER;
+
+  public static final java.lang.String TAG_ID;
+
+  public static final java.lang.String TAG_UUID;
+
+  public static final java.lang.String TAG_PASSENGERS;
+
+  public static final java.lang.String TAG_DATA;
+
+  public static final java.lang.String TAG_POS;
+
+  public static final java.lang.String TAG_MOTION;
+
+  public static final java.lang.String TAG_ROTATION;
+
+  public static final java.lang.String TAG_PORTAL_COOLDOWN;
+
+  public static final java.lang.String TAG_NO_GRAVITY;
+
+  public static final java.lang.String TAG_AIR;
+
+  public static final java.lang.String TAG_ON_GROUND;
+
+  public static final java.lang.String TAG_FALL_DISTANCE;
+
+  public static final java.lang.String TAG_FIRE;
+
+  public static final java.lang.String TAG_SILENT;
+
+  public static final java.lang.String TAG_GLOWING;
+
+  public static final java.lang.String TAG_INVULNERABLE;
+
+  public static final java.lang.String TAG_CUSTOM_NAME;
+
+  public static final int INVALID_ENTITY_ID;
+
+  public static final int CONTENTS_SLOT_INDEX;
+
+  public static final int BOARDING_COOLDOWN;
+
+  public static final int TOTAL_AIR_SUPPLY;
+
+  public static final int MAX_ENTITY_TAG_COUNT;
+
+  private static final com.mojang.serialization.Codec<java.util.List<java.lang.String>> TAG_LIST_CODEC;
+
+  public static final double DEFAULT_NAME_TAG_DISTANCE;
+
+  public static final double DEFAULT_BELOW_NAME_DISTANCE;
+
+  public static final double MAX_NAME_TAG_DISTANCE;
+
+  public static final float DELTA_AFFECTED_BY_BLOCKS_BELOW_0_2;
+
+  public static final double DELTA_AFFECTED_BY_BLOCKS_BELOW_0_5;
+
+  public static final double DELTA_AFFECTED_BY_BLOCKS_BELOW_1_0;
+
+  public static final int BASE_TICKS_REQUIRED_TO_FREEZE;
+
+  public static final int FREEZE_HURT_FREQUENCY;
+
+  public static final int BASE_SAFE_FALL_DISTANCE;
+
+  private static final net.minecraft.world.phys.AABB INITIAL_AABB;
+
+  private static final double WATER_FLOW_SCALE;
+
+  private static final double LAVA_FAST_FLOW_SCALE;
+
+  private static final double LAVA_SLOW_FLOW_SCALE;
+
+  private static final int MAX_BLOCK_ITERATIONS_ALONG_TRAVEL_PER_TICK;
+
+  private static final double MAX_MOVEMENT_RESETTING_TRACE_DISTANCE;
+
+  private static double viewScale;
+
+  private final net.minecraft.world.entity.EntityType<?> type;
+
+  private boolean requiresPrecisePosition;
+
+  private int id;
+
+  public boolean blocksBuilding;
+
+  private com.google.common.collect.ImmutableList<net.minecraft.world.entity.Entity> passengers;
+
+  protected int boardingCooldown;
+
+  private net.minecraft.world.entity.Entity vehicle;
+
+  private net.minecraft.world.level.Level level;
+
+  public double xo;
+
+  public double yo;
+
+  public double zo;
+
+  private net.minecraft.world.phys.Vec3 position;
+
+  private net.minecraft.core.BlockPos blockPosition;
+
+  private net.minecraft.world.level.ChunkPos chunkPosition;
+
+  private net.minecraft.world.phys.Vec3 deltaMovement;
+
+  private float yRot;
+
+  private float xRot;
+
+  public float yRotO;
+
+  public float xRotO;
+
+  private net.minecraft.world.phys.AABB bb;
+
+  private boolean onGround;
+
+  public boolean horizontalCollision;
+
+  public boolean verticalCollision;
+
+  public boolean verticalCollisionBelow;
+
+  public boolean minorHorizontalCollision;
+
+  public boolean hurtMarked;
+
+  protected net.minecraft.world.phys.Vec3 stuckSpeedMultiplier;
+
+  private net.minecraft.world.entity.Entity$RemovalReason removalReason;
+
+  public static final float DEFAULT_BB_WIDTH;
+
+  public static final float DEFAULT_BB_HEIGHT;
+
+  public float moveDist;
+
+  public float flyDist;
+
+  public double fallDistance;
+
+  private float nextStep;
+
+  public double xOld;
+
+  public double yOld;
+
+  public double zOld;
+
+  public boolean noPhysics;
+
+  protected final net.minecraft.util.RandomSource random;
+
+  public int tickCount;
+
+  private int remainingFireTicks;
+
+  private final net.minecraft.world.entity.EntityFluidInteraction fluidInteraction;
+
+  protected boolean wasTouchingWater;
+
+  protected boolean wasEyeInWater;
+
+  public int invulnerableTime;
+
+  protected boolean firstTick;
+
+  protected final net.minecraft.network.syncher.SynchedEntityData entityData;
+
+  protected static final net.minecraft.network.syncher.EntityDataAccessor<java.lang.Byte> DATA_SHARED_FLAGS_ID;
+
+  protected static final int FLAG_ONFIRE;
+
+  private static final int FLAG_SHIFT_KEY_DOWN;
+
+  private static final int FLAG_SPRINTING;
+
+  private static final int FLAG_SWIMMING;
+
+  private static final int FLAG_INVISIBLE;
+
+  protected static final int FLAG_GLOWING;
+
+  protected static final int FLAG_FALL_FLYING;
+
+  private static final net.minecraft.network.syncher.EntityDataAccessor<java.lang.Integer> DATA_AIR_SUPPLY_ID;
+
+  private static final net.minecraft.network.syncher.EntityDataAccessor<java.util.Optional<net.minecraft.network.chat.Component>> DATA_CUSTOM_NAME;
+
+  private static final net.minecraft.network.syncher.EntityDataAccessor<java.lang.Boolean> DATA_CUSTOM_NAME_VISIBLE;
+
+  private static final net.minecraft.network.syncher.EntityDataAccessor<java.lang.Boolean> DATA_SILENT;
+
+  private static final net.minecraft.network.syncher.EntityDataAccessor<java.lang.Boolean> DATA_NO_GRAVITY;
+
+  protected static final net.minecraft.network.syncher.EntityDataAccessor<net.minecraft.world.entity.Pose> DATA_POSE;
+
+  private static final net.minecraft.network.syncher.EntityDataAccessor<java.lang.Integer> DATA_TICKS_FROZEN;
+
+  private net.minecraft.world.level.entity.EntityInLevelCallback levelCallback;
+
+  private final net.minecraft.network.protocol.game.VecDeltaCodec packetPositionCodec;
+
+  public boolean needsSync;
+
+  public boolean syncPosition;
+
+  public net.minecraft.world.entity.PortalProcessor portalProcess;
+
+  private int portalCooldown;
+
+  private boolean invulnerable;
+
+  protected java.util.UUID uuid;
+
+  protected java.lang.String stringUUID;
+
+  private boolean hasGlowingTag;
+
+  private final java.util.Set<java.lang.String> tags;
+
+  private final double[] pistonDeltas;
+
+  private long pistonDeltasGameTime;
+
+  private net.minecraft.world.entity.EntityDimensions dimensions;
+
+  private float eyeHeight;
+
+  public boolean isInPowderSnow;
+
+  public boolean wasInPowderSnow;
+
+  public java.util.Optional<net.minecraft.core.BlockPos> mainSupportingBlockPos;
+
+  private boolean onGroundNoBlocks;
+
+  private float crystalSoundIntensity;
+
+  private int lastCrystalSoundPlayTick;
+
+  private boolean hasVisualFire;
+
+  private net.minecraft.world.phys.Vec3 lastKnownSpeed;
+
+  private net.minecraft.world.phys.Vec3 lastKnownPosition;
+
+  private net.minecraft.world.level.block.state.BlockState inBlockState;
+
+  public static final int MAX_MOVEMENTS_HANDELED_PER_TICK;
+
+  private final java.util.ArrayDeque<net.minecraft.world.entity.Entity$Movement> movementThisTick;
+
+  private final java.util.List<net.minecraft.world.entity.Entity$Movement> finalMovementsThisTick;
+
+  private final it.unimi.dsi.fastutil.longs.LongSet visitedBlocks;
+
+  private final net.minecraft.world.entity.InsideBlockEffectApplier$StepBasedCollector insideEffectCollector;
+
+  private net.minecraft.world.item.component.CustomData customData;
+
+  public net.minecraft.world.entity.Entity(net.minecraft.world.entity.EntityType<?>, net.minecraft.world.level.Level);
+    Code:
+         0: aload_0
+         1: invokespecial #430                // Method java/lang/Object."<init>":()V
+         4: aload_0
+         5: iconst_0
+         6: putfield      #432                // Field id:I
+         9: aload_0
+        10: invokestatic  #436                // Method com/google/common/collect/ImmutableList.of:()Lcom/google/common/collect/ImmutableList;
+        13: putfield      #438                // Field passengers:Lcom/google/common/collect/ImmutableList;
+        16: aload_0
+        17: getstatic     #443                // Field net/minecraft/world/phys/Vec3.ZERO:Lnet/minecraft/world/phys/Vec3;
+        20: putfield      #445                // Field deltaMovement:Lnet/minecraft/world/phys/Vec3;
+        23: aload_0
+        24: getstatic     #447                // Field INITIAL_AABB:Lnet/minecraft/world/phys/AABB;
+        27: putfield      #449                // Field bb:Lnet/minecraft/world/phys/AABB;
+        30: aload_0
+        31: getstatic     #443                // Field net/minecraft/world/phys/Vec3.ZERO:Lnet/minecraft/world/phys/Vec3;
+        34: putfield      #451                // Field stuckSpeedMultiplier:Lnet/minecraft/world/phys/Vec3;
+        37: aload_0
+        38: fconst_1
+        39: putfield      #453                // Field nextStep:F
+        42: aload_0
+        43: invokestatic  #459                // InterfaceMethod net/minecraft/util/RandomSource.create:()Lnet/minecraft/util/RandomSource;
+        46: putfield      #461                // Field random:Lnet/minecraft/util/RandomSource;
+        49: aload_0
+        50: new           #463                // class net/minecraft/world/entity/EntityFluidInteraction
+        53: dup
+        54: getstatic     #469                // Field net/minecraft/tags/FluidTags.WATER:Lnet/minecraft/tags/TagKey;
+        57: getstatic     #472                // Field net/minecraft/tags/FluidTags.LAVA:Lnet/minecraft/tags/TagKey;
+        60: invokestatic  #477                // InterfaceMethod java/util/Set.of:(Ljava/lang/Object;Ljava/lang/Object;)Ljava/util/Set;
+        63: invokespecial #480                // Method net/minecraft/world/entity/EntityFluidInteraction."<init>":(Ljava/util/Set;)V
+        66: putfield      #482                // Field fluidInteraction:Lnet/minecraft/world/entity/EntityFluidInteraction;
+        69: aload_0
+        70: iconst_1
+        71: putfield      #484                // Field firstTick:Z
+        74: aload_0
+        75: getstatic     #489                // Field net/minecraft/world/level/entity/EntityInLevelCallback.NULL:Lnet/minecraft/world/level/entity/EntityInLevelCallback;
+        78: putfield      #491                // Field levelCallback:Lnet/minecraft/world/level/entity/EntityInLevelCallback;
+        81: aload_0
+        82: new           #493                // class net/minecraft/network/protocol/game/VecDeltaCodec
+        85: dup
+        86: invokespecial #494                // Method net/minecraft/network/protocol/game/VecDeltaCodec."<init>":()V
+        89: putfield      #496                // Field packetPositionCodec:Lnet/minecraft/network/protocol/game/VecDeltaCodec;
+        92: aload_0
+        93: aload_0
+        94: getfield      #461                // Field random:Lnet/minecraft/util/RandomSource;
+        97: invokestatic  #502                // Method net/minecraft/util/Mth.createInsecureUUID:(Lnet/minecraft/util/RandomSource;)Ljava/util/UUID;
+       100: putfield      #504                // Field uuid:Ljava/util/UUID;
+       103: aload_0
+       104: aload_0
+       105: getfield      #504                // Field uuid:Ljava/util/UUID;
+       108: invokevirtual #510                // Method java/util/UUID.toString:()Ljava/lang/String;
+       111: putfield      #512                // Field stringUUID:Ljava/lang/String;
+       114: aload_0
+       115: invokestatic  #518                // Method com/google/common/collect/Sets.newHashSet:()Ljava/util/HashSet;
+       118: putfield      #520                // Field tags:Ljava/util/Set;
+       121: aload_0
+       122: iconst_3
+       123: newarray       double
+       125: dup
+       126: iconst_0
+       127: dconst_0
+       128: dastore
+       129: dup
+       130: iconst_1
+       131: dconst_0
+       132: dastore
+       133: dup
+       134: iconst_2
+       135: dconst_0
+       136: dastore
+       137: putfield      #522                // Field pistonDeltas:[D
+       140: aload_0
+       141: invokestatic  #528                // Method java/util/Optional.empty:()Ljava/util/Optional;
+       144: putfield      #530                // Field mainSupportingBlockPos:Ljava/util/Optional;
+       147: aload_0
+       148: iconst_0
+       149: putfield      #532                // Field onGroundNoBlocks:Z
+       152: aload_0
+       153: getstatic     #443                // Field net/minecraft/world/phys/Vec3.ZERO:Lnet/minecraft/world/phys/Vec3;
+       156: putfield      #534                // Field lastKnownSpeed:Lnet/minecraft/world/phys/Vec3;
+       159: aload_0
+       160: aconst_null
+       161: putfield      #536                // Field inBlockState:Lnet/minecraft/world/level/block/state/BlockState;
+       164: aload_0
+       165: new           #538                // class java/util/ArrayDeque
+       168: dup
+       169: bipush        100
+       171: invokespecial #541                // Method java/util/ArrayDeque."<init>":(I)V
+       174: putfield      #543                // Field movementThisTick:Ljava/util/ArrayDeque;
+       177: aload_0
+       178: new           #545                // class it/unimi/dsi/fastutil/objects/ObjectArrayList
+       181: dup
+       182: invokespecial #546                // Method it/unimi/dsi/fastutil/objects/ObjectArrayList."<init>":()V
+       185: putfield      #548                // Field finalMovementsThisTick:Ljava/util/List;
+       188: aload_0
+       189: new           #550                // class it/unimi/dsi/fastutil/longs/LongOpenHashSet
+       192: dup
+       193: invokespecial #551                // Method it/unimi/dsi/fastutil/longs/LongOpenHashSet."<init>":()V
+       196: putfield      #553                // Field visitedBlocks:Lit/unimi/dsi/fastutil/longs/LongSet;
+       199: aload_0
+       200: new           #46                 // class net/minecraft/world/entity/InsideBlockEffectApplier$StepBasedCollector
+       203: dup
+       204: invokespecial #554                // Method net/minecraft/world/entity/InsideBlockEffectApplier$StepBasedCollector."<init>":()V
+       207: putfield      #556                // Field insideEffectCollector:Lnet/minecraft/world/entity/InsideBlockEffectApplier$StepBasedCollector;
+       210: aload_0
+       211: getstatic     #561                // Field net/minecraft/world/item/component/CustomData.EMPTY:Lnet/minecraft/world/item/component/CustomData;
+       214: putfield      #563                // Field customData:Lnet/minecraft/world/item/component/CustomData;
+       217: aload_0
+       218: aload_1
+       219: putfield      #565                // Field type:Lnet/minecraft/world/entity/EntityType;
+       222: aload_0
+       223: aload_2
+       224: putfield      #567                // Field level:Lnet/minecraft/world/level/Level;
+       227: aload_0
+       228: aload_2
+       229: invokevirtual #573                // Method net/minecraft/world/level/Level.getNextEntityId:()I
+       232: putfield      #432                // Field id:I
+       235: aload_0
+       236: aload_1
+       237: invokevirtual #579                // Method net/minecraft/world/entity/EntityType.getDimensions:()Lnet/minecraft/world/entity/EntityDimensions;
+       240: putfield      #581                // Field dimensions:Lnet/minecraft/world/entity/EntityDimensions;
+       243: aload_0
+       244: getstatic     #443                // Field net/minecraft/world/phys/Vec3.ZERO:Lnet/minecraft/world/phys/Vec3;
+       247: putfield      #583                // Field position:Lnet/minecraft/world/phys/Vec3;
+       250: aload_0
+       251: getstatic     #585                // Field net/minecraft/core/BlockPos.ZERO:Lnet/minecraft/core/BlockPos;
+       254: putfield      #587                // Field blockPosition:Lnet/minecraft/core/BlockPos;
+       257: aload_0
+       258: getstatic     #591                // Field net/minecraft/world/level/ChunkPos.ZERO:Lnet/minecraft/world/level/ChunkPos;
+       261: putfield      #593                // Field chunkPosition:Lnet/minecraft/world/level/ChunkPos;
+       264: new           #51                 // class net/minecraft/network/syncher/SynchedEntityData$Builder
+       267: dup
+       268: aload_0
+       269: invokespecial #596                // Method net/minecraft/network/syncher/SynchedEntityData$Builder."<init>":(Lnet/minecraft/network/syncher/SyncedDataHolder;)V
+       272: astore_3
+       273: aload_3
+       274: getstatic     #598                // Field DATA_SHARED_FLAGS_ID:Lnet/minecraft/network/syncher/EntityDataAccessor;
+       277: iconst_0
+       278: invokestatic  #604                // Method java/lang/Byte.valueOf:(B)Ljava/lang/Byte;
+       281: invokevirtual #608                // Method net/minecraft/network/syncher/SynchedEntityData$Builder.define:(Lnet/minecraft/network/syncher/EntityDataAccessor;Ljava/lang/Object;)Lnet/minecraft/network/syncher/SynchedEntityData$Builder;
+       284: pop
+       285: aload_3
+       286: getstatic     #610                // Field DATA_AIR_SUPPLY_ID:Lnet/minecraft/network/syncher/EntityDataAccessor;
+       289: aload_0
+       290: invokevirtual #613                // Method getMaxAirSupply:()I
+       293: invokestatic  #618                // Method java/lang/Integer.valueOf:(I)Ljava/lang/Integer;
+       296: invokevirtual #608                // Method net/minecraft/network/syncher/SynchedEntityData$Builder.define:(Lnet/minecraft/network/syncher/EntityDataAccessor;Ljava/lang/Object;)Lnet/minecraft/network/syncher/SynchedEntityData$Builder;
+       299: pop
+       300: aload_3
+       301: getstatic     #620                // Field DATA_CUSTOM_NAME_VISIBLE:Lnet/minecraft/network/syncher/EntityDataAccessor;
+       304: iconst_0
+       305: invokestatic  #625                // Method java/lang/Boolean.valueOf:(Z)Ljava/lang/Boolean;
+       308: invokevirtual #608                // Method net/minecraft/network/syncher/SynchedEntityData$Builder.define:(Lnet/minecraft/network/syncher/EntityDataAccessor;Ljava/lang/Object;)Lnet/minecraft/network/syncher/SynchedEntityData$Builder;
+       311: pop
+       312: aload_3
+       313: getstatic     #627                // Field DATA_CUSTOM_NAME:Lnet/minecraft/network/syncher/EntityDataAccessor;
+       316: invokestatic  #528                // Method java/util/Optional.empty:()Ljava/util/Optional;
+       319: invokevirtual #608                // Method net/minecraft/network/syncher/SynchedEntityData$Builder.define:(Lnet/minecraft/network/syncher/EntityDataAccessor;Ljava/lang/Object;)Lnet/minecraft/network/syncher/SynchedEntityData$Builder;
+       322: pop
+       323: aload_3
+       324: getstatic     #629                // Field DATA_SILENT:Lnet/minecraft/network/syncher/EntityDataAccessor;
+       327: iconst_0
+       328: invokestatic  #625                // Method java/lang/Boolean.valueOf:(Z)Ljava/lang/Boolean;
+       331: invokevirtual #608                // Method net/minecraft/network/syncher/SynchedEntityData$Builder.define:(Lnet/minecraft/network/syncher/EntityDataAccessor;Ljava/lang/Object;)Lnet/minecraft/network/syncher/SynchedEntityData$Builder;
+       334: pop
+       335: aload_3
+       336: getstatic     #631                // Field DATA_NO_GRAVITY:Lnet/minecraft/network/syncher/EntityDataAccessor;
+       339: iconst_0
+       340: invokestatic  #625                // Method java/lang/Boolean.valueOf:(Z)Ljava/lang/Boolean;
+       343: invokevirtual #608                // Method net/minecraft/network/syncher/SynchedEntityData$Builder.define:(Lnet/minecraft/network/syncher/EntityDataAccessor;Ljava/lang/Object;)Lnet/minecraft/network/syncher/SynchedEntityData$Builder;
+       346: pop
+       347: aload_3
+       348: getstatic     #633                // Field DATA_POSE:Lnet/minecraft/network/syncher/EntityDataAccessor;
+       351: getstatic     #639                // Field net/minecraft/world/entity/Pose.STANDING:Lnet/minecraft/world/entity/Pose;
+       354: invokevirtual #608                // Method net/minecraft/network/syncher/SynchedEntityData$Builder.define:(Lnet/minecraft/network/syncher/EntityDataAccessor;Ljava/lang/Object;)Lnet/minecraft/network/syncher/SynchedEntityData$Builder;
+       357: pop
+       358: aload_3
+       359: getstatic     #641                // Field DATA_TICKS_FROZEN:Lnet/minecraft/network/syncher/EntityDataAccessor;
+       362: iconst_0
+       363: invokestatic  #618                // Method java/lang/Integer.valueOf:(I)Ljava/lang/Integer;
+       366: invokevirtual #608                // Method net/minecraft/network/syncher/SynchedEntityData$Builder.define:(Lnet/minecraft/network/syncher/EntityDataAccessor;Ljava/lang/Object;)Lnet/minecraft/network/syncher/SynchedEntityData$Builder;
+       369: pop
+       370: aload_0
+       371: aload_3
+       372: invokevirtual #645                // Method defineSynchedData:(Lnet/minecraft/network/syncher/SynchedEntityData$Builder;)V
+       375: aload_0
+       376: aload_3
+       377: invokevirtual #649                // Method net/minecraft/network/syncher/SynchedEntityData$Builder.build:()Lnet/minecraft/network/syncher/SynchedEntityData;
+       380: putfield      #651                // Field entityData:Lnet/minecraft/network/syncher/SynchedEntityData;
+       383: aload_0
+       384: dconst_0
+       385: dconst_0
+       386: dconst_0
+       387: invokevirtual #655                // Method setPos:(DDD)V
+       390: aload_0
+       391: aload_0
+       392: getfield      #581                // Field dimensions:Lnet/minecraft/world/entity/EntityDimensions;
+       395: invokevirtual #660                // Method net/minecraft/world/entity/EntityDimensions.eyeHeight:()F
+       398: putfield      #662                // Field eyeHeight:F
+       401: return
+
+  public boolean isColliding(net.minecraft.core.BlockPos, net.minecraft.world.level.block.state.BlockState);
+    Code:
+         0: aload_2
+         1: aload_0
+         2: invokevirtual #672                // Method level:()Lnet/minecraft/world/level/Level;
+         5: aload_1
+         6: aload_0
+         7: invokestatic  #677                // InterfaceMethod net/minecraft/world/phys/shapes/CollisionContext.of:(Lnet/minecraft/world/entity/Entity;)Lnet/minecraft/world/phys/shapes/CollisionContext;
+        10: invokevirtual #683                // Method net/minecraft/world/level/block/state/BlockState.getCollisionShape:(Lnet/minecraft/world/level/BlockGetter;Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/phys/shapes/CollisionContext;)Lnet/minecraft/world/phys/shapes/VoxelShape;
+        13: aload_1
+        14: invokevirtual #689                // Method net/minecraft/world/phys/shapes/VoxelShape.move:(Lnet/minecraft/core/Vec3i;)Lnet/minecraft/world/phys/shapes/VoxelShape;
+        17: astore_3
+        18: aload_3
+        19: aload_0
+        20: invokevirtual #693                // Method getBoundingBox:()Lnet/minecraft/world/phys/AABB;
+        23: invokestatic  #698                // Method net/minecraft/world/phys/shapes/Shapes.create:(Lnet/minecraft/world/phys/AABB;)Lnet/minecraft/world/phys/shapes/VoxelShape;
+        26: getstatic     #704                // Field net/minecraft/world/phys/shapes/BooleanOp.AND:Lnet/minecraft/world/phys/shapes/BooleanOp;
+        29: invokestatic  #708                // Method net/minecraft/world/phys/shapes/Shapes.joinIsNotEmpty:(Lnet/minecraft/world/phys/shapes/VoxelShape;Lnet/minecraft/world/phys/shapes/VoxelShape;Lnet/minecraft/world/phys/shapes/BooleanOp;)Z
+        32: ireturn
+
+  public int getTeamColor();
+    Code:
+         0: aload_0
+         1: invokevirtual #715                // Method getTeam:()Lnet/minecraft/world/scores/PlayerTeam;
+         4: astore_1
+         5: aload_1
+         6: ifnull        33
+         9: aload_1
+        10: invokevirtual #720                // Method net/minecraft/world/scores/Team.getColor:()Ljava/util/Optional;
+        13: invokevirtual #724                // Method java/util/Optional.isPresent:()Z
+        16: ifeq          33
+        19: aload_1
+        20: invokevirtual #720                // Method net/minecraft/world/scores/Team.getColor:()Ljava/util/Optional;
+        23: invokevirtual #728                // Method java/util/Optional.get:()Ljava/lang/Object;
+        26: checkcast     #730                // class net/minecraft/world/scores/TeamColor
+        29: invokevirtual #733                // Method net/minecraft/world/scores/TeamColor.rgb:()I
+        32: ireturn
+        33: ldc_w         #734                // int 16777215
+        36: ireturn
+
+  public boolean isSpectator();
+    Code:
+         0: iconst_0
+         1: ireturn
+
+  public boolean canInteractWithLevel();
+    Code:
+         0: aload_0
+         1: invokevirtual #741                // Method isAlive:()Z
+         4: ifeq          25
+         7: aload_0
+         8: invokevirtual #744                // Method isRemoved:()Z
+        11: ifne          25
+        14: aload_0
+        15: invokevirtual #746                // Method isSpectator:()Z
+        18: ifne          25
+        21: iconst_1
+        22: goto          26
+        25: iconst_0
+        26: ireturn
+
+  public final void unRide();
+    Code:
+         0: aload_0
+         1: invokevirtual #750                // Method isVehicle:()Z
+         4: ifeq          11
+         7: aload_0
+         8: invokevirtual #753                // Method ejectPassengers:()V
+        11: aload_0
+        12: invokevirtual #756                // Method isPassenger:()Z
+        15: ifeq          22
+        18: aload_0
+        19: invokevirtual #759                // Method stopRiding:()V
+        22: return
+
+  public void syncPacketPositionCodec(double, double, double);
+    Code:
+         0: aload_0
+         1: getfield      #496                // Field packetPositionCodec:Lnet/minecraft/network/protocol/game/VecDeltaCodec;
+         4: new           #440                // class net/minecraft/world/phys/Vec3
+         7: dup
+         8: dload_1
+         9: dload_3
+        10: dload         5
+        12: invokespecial #765                // Method net/minecraft/world/phys/Vec3."<init>":(DDD)V
+        15: invokevirtual #769                // Method net/minecraft/network/protocol/game/VecDeltaCodec.setBase:(Lnet/minecraft/world/phys/Vec3;)V
+        18: return
+
+  public net.minecraft.network.protocol.game.VecDeltaCodec getPositionCodec();
+    Code:
+         0: aload_0
+         1: getfield      #496                // Field packetPositionCodec:Lnet/minecraft/network/protocol/game/VecDeltaCodec;
+         4: areturn
+
+  public net.minecraft.world.entity.EntityType<?> getType();
+    Code:
+         0: aload_0
+         1: getfield      #565                // Field type:Lnet/minecraft/world/entity/EntityType;
+         4: areturn
+
+  public net.minecraft.core.Holder<net.minecraft.world.entity.EntityType<?>> typeHolder();
+    Code:
+         0: aload_0
+         1: getfield      #565                // Field type:Lnet/minecraft/world/entity/EntityType;
+         4: invokevirtual #781                // Method net/minecraft/world/entity/EntityType.builtInRegistryHolder:()Lnet/minecraft/core/Holder$Reference;
+         7: areturn
+
+  public boolean getRequiresPrecisePosition();
+    Code:
+         0: aload_0
+         1: getfield      #784                // Field requiresPrecisePosition:Z
+         4: ireturn
+
+  public void setRequiresPrecisePosition(boolean);
+    Code:
+         0: aload_0
+         1: iload_1
+         2: putfield      #784                // Field requiresPrecisePosition:Z
+         5: return
+
+  public int getId();
+    Code:
+         0: aload_0
+         1: getfield      #432                // Field id:I
+         4: ifne          18
+         7: new           #789                // class java/lang/IllegalStateException
+        10: dup
+        11: ldc_w         #791                // String Tried to access entity ID before ID assignment
+        14: invokespecial #794                // Method java/lang/IllegalStateException."<init>":(Ljava/lang/String;)V
+        17: athrow
+        18: aload_0
+        19: getfield      #432                // Field id:I
+        22: ireturn
+
+  public void setId(int);
+    Code:
+         0: aload_0
+         1: iload_1
+         2: putfield      #432                // Field id:I
+         5: return
+
+  public java.util.Set<java.lang.String> entityTags();
+    Code:
+         0: aload_0
+         1: getfield      #520                // Field tags:Ljava/util/Set;
+         4: areturn
+
+  public boolean addTag(java.lang.String);
+    Code:
+         0: aload_0
+         1: getfield      #520                // Field tags:Ljava/util/Set;
+         4: invokeinterface #804,  1          // InterfaceMethod java/util/Set.size:()I
+         9: sipush        1024
+        12: if_icmplt     17
+        15: iconst_0
+        16: ireturn
+        17: aload_0
+        18: getfield      #520                // Field tags:Ljava/util/Set;
+        21: aload_1
+        22: invokeinterface #808,  2          // InterfaceMethod java/util/Set.add:(Ljava/lang/Object;)Z
+        27: ireturn
+
+  public boolean removeTag(java.lang.String);
+    Code:
+         0: aload_0
+         1: getfield      #520                // Field tags:Ljava/util/Set;
+         4: aload_1
+         5: invokeinterface #812,  2          // InterfaceMethod java/util/Set.remove:(Ljava/lang/Object;)Z
+        10: ireturn
+
+  public void kill(net.minecraft.server.level.ServerLevel);
+    Code:
+         0: aload_0
+         1: getstatic     #817                // Field net/minecraft/world/entity/Entity$RemovalReason.KILLED:Lnet/minecraft/world/entity/Entity$RemovalReason;
+         4: invokevirtual #820                // Method remove:(Lnet/minecraft/world/entity/Entity$RemovalReason;)V
+         7: aload_0
+         8: getstatic     #824                // Field net/minecraft/world/level/gameevent/GameEvent.ENTITY_DIE:Lnet/minecraft/core/Holder$Reference;
+        11: invokevirtual #828                // Method gameEvent:(Lnet/minecraft/core/Holder;)V
+        14: return
+
+  public final void discard();
+    Code:
+         0: aload_0
+         1: getstatic     #833                // Field net/minecraft/world/entity/Entity$RemovalReason.DISCARDED:Lnet/minecraft/world/entity/Entity$RemovalReason;
+         4: invokevirtual #820                // Method remove:(Lnet/minecraft/world/entity/Entity$RemovalReason;)V
+         7: return
+
+  protected abstract void defineSynchedData(net.minecraft.network.syncher.SynchedEntityData$Builder);
+
+  public net.minecraft.network.syncher.SynchedEntityData getEntityData();
+    Code:
+         0: aload_0
+         1: getfield      #651                // Field entityData:Lnet/minecraft/network/syncher/SynchedEntityData;
+         4: areturn
+
+  public boolean equals(java.lang.Object);
+    Code:
+         0: aload_1
+         1: instanceof    #2                  // class net/minecraft/world/entity/Entity
+         4: ifeq          29
+         7: aload_1
+         8: checkcast     #2                  // class net/minecraft/world/entity/Entity
+        11: astore_2
+        12: aload_2
+        13: invokevirtual #838                // Method getId:()I
+        16: aload_0
+        17: invokevirtual #838                // Method getId:()I
+        20: if_icmpne     27
+        23: iconst_1
+        24: goto          28
+        27: iconst_0
+        28: ireturn
+        29: iconst_0
+        30: ireturn
+
+  public int hashCode();
+    Code:
+         0: aload_0
+         1: invokevirtual #838                // Method getId:()I
+         4: ireturn
+
+  public void remove(net.minecraft.world.entity.Entity$RemovalReason);
+    Code:
+         0: aload_0
+         1: aload_1
+         2: invokevirtual #845                // Method setRemoved:(Lnet/minecraft/world/entity/Entity$RemovalReason;)V
+         5: return
+
+  public void onClientRemoval();
+    Code:
+         0: return
+
+  public void onRemoval(net.minecraft.world.entity.Entity$RemovalReason);
+    Code:
+         0: return
+
+  public void setPose(net.minecraft.world.entity.Pose);
+    Code:
+         0: aload_0
+         1: getfield      #651                // Field entityData:Lnet/minecraft/network/syncher/SynchedEntityData;
+         4: getstatic     #633                // Field DATA_POSE:Lnet/minecraft/network/syncher/EntityDataAccessor;
+         7: aload_1
+         8: invokevirtual #854                // Method net/minecraft/network/syncher/SynchedEntityData.set:(Lnet/minecraft/network/syncher/EntityDataAccessor;Ljava/lang/Object;)V
+        11: return
+
+  public net.minecraft.world.entity.Pose getPose();
+    Code:
+         0: aload_0
+         1: getfield      #651                // Field entityData:Lnet/minecraft/network/syncher/SynchedEntityData;
+         4: getstatic     #633                // Field DATA_POSE:Lnet/minecraft/network/syncher/EntityDataAccessor;
+         7: invokevirtual #859                // Method net/minecraft/network/syncher/SynchedEntityData.get:(Lnet/minecraft/network/syncher/EntityDataAccessor;)Ljava/lang/Object;
+        10: checkcast     #635                // class net/minecraft/world/entity/Pose
+        13: areturn
+
+  public boolean hasPose(net.minecraft.world.entity.Pose);
+    Code:
+         0: aload_0
+         1: invokevirtual #863                // Method getPose:()Lnet/minecraft/world/entity/Pose;
+         4: aload_1
+         5: if_acmpne     12
+         8: iconst_1
+         9: goto          13
+        12: iconst_0
+        13: ireturn
+
+  public boolean closerThan(net.minecraft.world.entity.Entity, double);
+    Code:
+         0: aload_0
+         1: invokevirtual #870                // Method position:()Lnet/minecraft/world/phys/Vec3;
+         4: aload_1
+         5: invokevirtual #870                // Method position:()Lnet/minecraft/world/phys/Vec3;
+         8: dload_2
+         9: invokevirtual #873                // Method net/minecraft/world/phys/Vec3.closerThan:(Lnet/minecraft/core/Position;D)Z
+        12: ireturn
+
+  public boolean closerThan(net.minecraft.world.entity.Entity, double, double);
+    Code:
+         0: aload_1
+         1: invokevirtual #880                // Method getX:()D
+         4: aload_0
+         5: invokevirtual #880                // Method getX:()D
+         8: dsub
+         9: dstore        6
+        11: aload_1
+        12: invokevirtual #883                // Method getY:()D
+        15: aload_0
+        16: invokevirtual #883                // Method getY:()D
+        19: dsub
+        20: dstore        8
+        22: aload_1
+        23: invokevirtual #886                // Method getZ:()D
+        26: aload_0
+        27: invokevirtual #886                // Method getZ:()D
+        30: dsub
+        31: dstore        10
+        33: dload         6
+        35: dload         10
+        37: invokestatic  #890                // Method net/minecraft/util/Mth.lengthSquared:(DD)D
+        40: dload_2
+        41: invokestatic  #894                // Method net/minecraft/util/Mth.square:(D)D
+        44: dcmpg
+        45: ifge          66
+        48: dload         8
+        50: invokestatic  #894                // Method net/minecraft/util/Mth.square:(D)D
+        53: dload         4
+        55: invokestatic  #894                // Method net/minecraft/util/Mth.square:(D)D
+        58: dcmpg
+        59: ifge          66
+        62: iconst_1
+        63: goto          67
+        66: iconst_0
+        67: ireturn
+
+  protected void setRot(float, float);
+    Code:
+         0: aload_0
+         1: fload_1
+         2: ldc_w         #900                // float 360.0f
+         5: frem
+         6: invokevirtual #904                // Method setYRot:(F)V
+         9: aload_0
+        10: fload_2
+        11: ldc_w         #900                // float 360.0f
+        14: frem
+        15: invokevirtual #907                // Method setXRot:(F)V
+        18: return
+
+  public final void setPos(net.minecraft.world.phys.Vec3);
+    Code:
+         0: aload_0
+         1: aload_1
+         2: invokevirtual #909                // Method net/minecraft/world/phys/Vec3.x:()D
+         5: aload_1
+         6: invokevirtual #911                // Method net/minecraft/world/phys/Vec3.y:()D
+         9: aload_1
+        10: invokevirtual #913                // Method net/minecraft/world/phys/Vec3.z:()D
+        13: invokevirtual #655                // Method setPos:(DDD)V
+        16: return
+
+  public void setPos(double, double, double);
+    Code:
+         0: aload_0
+         1: dload_1
+         2: dload_3
+         3: dload         5
+         5: invokevirtual #916                // Method setPosRaw:(DDD)V
+         8: aload_0
+         9: aload_0
+        10: invokevirtual #919                // Method makeBoundingBox:()Lnet/minecraft/world/phys/AABB;
+        13: invokevirtual #923                // Method setBoundingBox:(Lnet/minecraft/world/phys/AABB;)V
+        16: return
+
+  protected final net.minecraft.world.phys.AABB makeBoundingBox();
+    Code:
+         0: aload_0
+         1: aload_0
+         2: getfield      #583                // Field position:Lnet/minecraft/world/phys/Vec3;
+         5: invokevirtual #926                // Method makeBoundingBox:(Lnet/minecraft/world/phys/Vec3;)Lnet/minecraft/world/phys/AABB;
+         8: areturn
+
+  protected net.minecraft.world.phys.AABB makeBoundingBox(net.minecraft.world.phys.Vec3);
+    Code:
+         0: aload_0
+         1: getfield      #581                // Field dimensions:Lnet/minecraft/world/entity/EntityDimensions;
+         4: aload_1
+         5: invokevirtual #927                // Method net/minecraft/world/entity/EntityDimensions.makeBoundingBox:(Lnet/minecraft/world/phys/Vec3;)Lnet/minecraft/world/phys/AABB;
+         8: areturn
+
+  protected void reapplyPosition();
+    Code:
+         0: aload_0
+         1: aconst_null
+         2: putfield      #930                // Field lastKnownPosition:Lnet/minecraft/world/phys/Vec3;
+         5: aload_0
+         6: aload_0
+         7: getfield      #583                // Field position:Lnet/minecraft/world/phys/Vec3;
+        10: getfield      #932                // Field net/minecraft/world/phys/Vec3.x:D
+        13: aload_0
+        14: getfield      #583                // Field position:Lnet/minecraft/world/phys/Vec3;
+        17: getfield      #934                // Field net/minecraft/world/phys/Vec3.y:D
+        20: aload_0
+        21: getfield      #583                // Field position:Lnet/minecraft/world/phys/Vec3;
+        24: getfield      #936                // Field net/minecraft/world/phys/Vec3.z:D
+        27: invokevirtual #655                // Method setPos:(DDD)V
+        30: return
+
+  public void turn(double, double);
+    Code:
+         0: dload_3
+         1: d2f
+         2: ldc_w         #939                // float 0.15f
+         5: fmul
+         6: fstore        5
+         8: dload_1
+         9: d2f
+        10: ldc_w         #939                // float 0.15f
+        13: fmul
+        14: fstore        6
+        16: aload_0
+        17: aload_0
+        18: invokevirtual #942                // Method getXRot:()F
+        21: fload         5
+        23: fadd
+        24: invokevirtual #907                // Method setXRot:(F)V
+        27: aload_0
+        28: aload_0
+        29: invokevirtual #945                // Method getYRot:()F
+        32: fload         6
+        34: fadd
+        35: invokevirtual #904                // Method setYRot:(F)V
+        38: aload_0
+        39: aload_0
+        40: invokevirtual #942                // Method getXRot:()F
+        43: ldc_w         #946                // float -90.0f
+        46: ldc_w         #947                // float 90.0f
+        49: invokestatic  #951                // Method net/minecraft/util/Mth.clamp:(FFF)F
+        52: invokevirtual #907                // Method setXRot:(F)V
+        55: aload_0
+        56: dup
+        57: getfield      #953                // Field xRotO:F
+        60: fload         5
+        62: fadd
+        63: putfield      #953                // Field xRotO:F
+        66: aload_0
+        67: dup
+        68: getfield      #955                // Field yRotO:F
+        71: fload         6
+        73: fadd
+        74: putfield      #955                // Field yRotO:F
+        77: aload_0
+        78: aload_0
+        79: getfield      #953                // Field xRotO:F
+        82: ldc_w         #946                // float -90.0f
+        85: ldc_w         #947                // float 90.0f
+        88: invokestatic  #951                // Method net/minecraft/util/Mth.clamp:(FFF)F
+        91: putfield      #953                // Field xRotO:F
+        94: aload_0
+        95: getfield      #957                // Field vehicle:Lnet/minecraft/world/entity/Entity;
+        98: ifnull        109
+       101: aload_0
+       102: getfield      #957                // Field vehicle:Lnet/minecraft/world/entity/Entity;
+       105: aload_0
+       106: invokevirtual #961                // Method onPassengerTurned:(Lnet/minecraft/world/entity/Entity;)V
+       109: return
+
+  public void updateDataBeforeSync();
+    Code:
+         0: return
+
+  public void tick();
+    Code:
+         0: aload_0
+         1: invokevirtual #968                // Method baseTick:()V
+         4: return
+
+  public void baseTick();
+    Code:
+         0: invokestatic  #973                // Method net/minecraft/util/profiling/Profiler.get:()Lnet/minecraft/util/profiling/ProfilerFiller;
+         3: astore_1
+         4: aload_1
+         5: ldc_w         #975                // String entityBaseTick
+         8: invokeinterface #980,  2          // InterfaceMethod net/minecraft/util/profiling/ProfilerFiller.push:(Ljava/lang/String;)V
+        13: aload_0
+        14: invokevirtual #983                // Method computeSpeed:()V
+        17: aload_0
+        18: aconst_null
+        19: putfield      #536                // Field inBlockState:Lnet/minecraft/world/level/block/state/BlockState;
+        22: aload_0
+        23: invokevirtual #756                // Method isPassenger:()Z
+        26: ifeq          43
+        29: aload_0
+        30: invokevirtual #987                // Method getVehicle:()Lnet/minecraft/world/entity/Entity;
+        33: invokevirtual #744                // Method isRemoved:()Z
+        36: ifeq          43
+        39: aload_0
+        40: invokevirtual #759                // Method stopRiding:()V
+        43: aload_0
+        44: getfield      #989                // Field boardingCooldown:I
+        47: ifle          60
+        50: aload_0
+        51: dup
+        52: getfield      #989                // Field boardingCooldown:I
+        55: iconst_1
+        56: isub
+        57: putfield      #989                // Field boardingCooldown:I
+        60: aload_0
+        61: invokevirtual #992                // Method handlePortal:()V
+        64: aload_0
+        65: invokevirtual #995                // Method canSpawnSprintParticle:()Z
+        68: ifeq          75
+        71: aload_0
+        72: invokevirtual #998                // Method spawnSprintParticle:()V
+        75: aload_0
+        76: aload_0
+        77: getfield      #1000               // Field isInPowderSnow:Z
+        80: putfield      #1002               // Field wasInPowderSnow:Z
+        83: aload_0
+        84: iconst_0
+        85: putfield      #1000               // Field isInPowderSnow:Z
+        88: aload_0
+        89: aload_0
+        90: getstatic     #469                // Field net/minecraft/tags/FluidTags.WATER:Lnet/minecraft/tags/TagKey;
+        93: invokevirtual #1006               // Method isEyeInFluid:(Lnet/minecraft/tags/TagKey;)Z
+        96: putfield      #1008               // Field wasEyeInWater:Z
+        99: aload_0
+       100: invokevirtual #1011               // Method updateFluidInteraction:()Z
+       103: pop
+       104: aload_0
+       105: invokevirtual #1014               // Method updateSwimming:()V
+       108: aload_0
+       109: invokevirtual #672                // Method level:()Lnet/minecraft/world/level/Level;
+       112: astore_3
+       113: aload_3
+       114: instanceof    #1016               // class net/minecraft/server/level/ServerLevel
+       117: ifeq          190
+       120: aload_3
+       121: checkcast     #1016               // class net/minecraft/server/level/ServerLevel
+       124: astore_2
+       125: aload_0
+       126: getfield      #1018               // Field remainingFireTicks:I
+       129: ifle          194
+       132: aload_0
+       133: invokevirtual #1021               // Method fireImmune:()Z
+       136: ifeq          146
+       139: aload_0
+       140: invokevirtual #1024               // Method clearFire:()V
+       143: goto          194
+       146: aload_0
+       147: getfield      #1018               // Field remainingFireTicks:I
+       150: bipush        20
+       152: irem
+       153: ifne          177
+       156: aload_0
+       157: invokevirtual #1027               // Method isInLava:()Z
+       160: ifne          177
+       163: aload_0
+       164: aload_2
+       165: aload_0
+       166: invokevirtual #1031               // Method damageSources:()Lnet/minecraft/world/damagesource/DamageSources;
+       169: invokevirtual #1037               // Method net/minecraft/world/damagesource/DamageSources.onFire:()Lnet/minecraft/world/damagesource/DamageSource;
+       172: fconst_1
+       173: invokevirtual #1041               // Method hurtServer:(Lnet/minecraft/server/level/ServerLevel;Lnet/minecraft/world/damagesource/DamageSource;F)Z
+       176: pop
+       177: aload_0
+       178: aload_0
+       179: getfield      #1018               // Field remainingFireTicks:I
+       182: iconst_1
+       183: isub
+       184: invokevirtual #1044               // Method setRemainingFireTicks:(I)V
+       187: goto          194
+       190: aload_0
+       191: invokevirtual #1024               // Method clearFire:()V
+       194: aload_0
+       195: invokevirtual #1027               // Method isInLava:()Z
+       198: ifeq          213
+       201: aload_0
+       202: dup
+       203: getfield      #1046               // Field fallDistance:D
+       206: ldc2_w        #1047               // double 0.5d
+       209: dmul
+       210: putfield      #1046               // Field fallDistance:D
+       213: aload_0
+       214: invokevirtual #1051               // Method checkBelowWorld:()V
+       217: aload_0
+       218: invokevirtual #672                // Method level:()Lnet/minecraft/world/level/Level;
+       221: invokevirtual #1054               // Method net/minecraft/world/level/Level.isClientSide:()Z
+       224: ifne          243
+       227: aload_0
+       228: aload_0
+       229: getfield      #1018               // Field remainingFireTicks:I
+       232: ifle          239
+       235: iconst_1
+       236: goto          240
+       239: iconst_0
+       240: invokevirtual #1057               // Method setSharedFlagOnFire:(Z)V
+       243: aload_0
+       244: iconst_0
+       245: putfield      #484                // Field firstTick:Z
+       248: aload_0
+       249: invokevirtual #672                // Method level:()Lnet/minecraft/world/level/Level;
+       252: astore_3
+       253: aload_3
+       254: instanceof    #1016               // class net/minecraft/server/level/ServerLevel
+       257: ifeq          283
+       260: aload_3
+       261: checkcast     #1016               // class net/minecraft/server/level/ServerLevel
+       264: astore_2
+       265: aload_0
+       266: instanceof    #1059               // class net/minecraft/world/entity/Leashable
+       269: ifeq          283
+       272: aload_2
+       273: aload_0
+       274: checkcast     #1059               // class net/minecraft/world/entity/Leashable
+       277: checkcast     #2                  // class net/minecraft/world/entity/Entity
+       280: invokestatic  #1063               // InterfaceMethod net/minecraft/world/entity/Leashable.tickLeash:(Lnet/minecraft/server/level/ServerLevel;Lnet/minecraft/world/entity/Entity;)V
+       283: aload_1
+       284: invokeinterface #1066,  1         // InterfaceMethod net/minecraft/util/profiling/ProfilerFiller.pop:()V
+       289: return
+
+  protected void computeSpeed();
+    Code:
+         0: aload_0
+         1: getfield      #930                // Field lastKnownPosition:Lnet/minecraft/world/phys/Vec3;
+         4: ifnonnull     15
+         7: aload_0
+         8: aload_0
+         9: invokevirtual #870                // Method position:()Lnet/minecraft/world/phys/Vec3;
+        12: putfield      #930                // Field lastKnownPosition:Lnet/minecraft/world/phys/Vec3;
+        15: aload_0
+        16: aload_0
+        17: invokevirtual #870                // Method position:()Lnet/minecraft/world/phys/Vec3;
+        20: aload_0
+        21: getfield      #930                // Field lastKnownPosition:Lnet/minecraft/world/phys/Vec3;
+        24: invokevirtual #1073               // Method net/minecraft/world/phys/Vec3.subtract:(Lnet/minecraft/world/phys/Vec3;)Lnet/minecraft/world/phys/Vec3;
+        27: putfield      #534                // Field lastKnownSpeed:Lnet/minecraft/world/phys/Vec3;
+        30: aload_0
+        31: aload_0
+        32: invokevirtual #870                // Method position:()Lnet/minecraft/world/phys/Vec3;
+        35: putfield      #930                // Field lastKnownPosition:Lnet/minecraft/world/phys/Vec3;
+        38: return
+
+  public void setSharedFlagOnFire(boolean);
+    Code:
+         0: aload_0
+         1: iconst_0
+         2: iload_1
+         3: ifne          13
+         6: aload_0
+         7: getfield      #1076               // Field hasVisualFire:Z
+        10: ifeq          17
+        13: iconst_1
+        14: goto          18
+        17: iconst_0
+        18: invokevirtual #1080               // Method setSharedFlag:(IZ)V
+        21: return
+
+  public void checkBelowWorld();
+    Code:
+         0: aload_0
+         1: invokevirtual #883                // Method getY:()D
+         4: aload_0
+         5: invokevirtual #672                // Method level:()Lnet/minecraft/world/level/Level;
+         8: invokevirtual #1083               // Method net/minecraft/world/level/Level.getMinY:()I
+        11: bipush        64
+        13: isub
+        14: i2d
+        15: dcmpg
+        16: ifge          23
+        19: aload_0
+        20: invokevirtual #1086               // Method onBelowWorld:()V
+        23: return
+
+  public void setPortalCooldown();
+    Code:
+         0: aload_0
+         1: aload_0
+         2: invokevirtual #1090               // Method getDimensionChangingDelay:()I
+         5: putfield      #1092               // Field portalCooldown:I
+         8: return
+
+  public void setPortalCooldown(int);
+    Code:
+         0: aload_0
+         1: iload_1
+         2: putfield      #1092               // Field portalCooldown:I
+         5: return
+
+  public int getPortalCooldown();
+    Code:
+         0: aload_0
+         1: getfield      #1092               // Field portalCooldown:I
+         4: ireturn
+
+  public boolean isOnPortalCooldown();
+    Code:
+         0: aload_0
+         1: getfield      #1092               // Field portalCooldown:I
+         4: ifle          11
+         7: iconst_1
+         8: goto          12
+        11: iconst_0
+        12: ireturn
+
+  protected void processPortalCooldown();
+    Code:
+         0: aload_0
+         1: invokevirtual #1097               // Method isOnPortalCooldown:()Z
+         4: ifeq          17
+         7: aload_0
+         8: dup
+         9: getfield      #1092               // Field portalCooldown:I
+        12: iconst_1
+        13: isub
+        14: putfield      #1092               // Field portalCooldown:I
+        17: return
+
+  public void lavaIgnite();
+    Code:
+         0: aload_0
+         1: invokevirtual #1021               // Method fireImmune:()Z
+         4: ifeq          8
+         7: return
+         8: aload_0
+         9: ldc_w         #1099               // float 15.0f
+        12: invokevirtual #1102               // Method igniteForSeconds:(F)V
+        15: return
+
+  public void lavaHurt();
+    Code:
+         0: aload_0
+         1: invokevirtual #1021               // Method fireImmune:()Z
+         4: ifeq          8
+         7: return
+         8: aload_0
+         9: invokevirtual #672                // Method level:()Lnet/minecraft/world/level/Level;
+        12: astore_2
+        13: aload_2
+        14: instanceof    #1016               // class net/minecraft/server/level/ServerLevel
+        17: ifeq          99
+        20: aload_2
+        21: checkcast     #1016               // class net/minecraft/server/level/ServerLevel
+        24: astore_1
+        25: aload_0
+        26: aload_1
+        27: aload_0
+        28: invokevirtual #1031               // Method damageSources:()Lnet/minecraft/world/damagesource/DamageSources;
+        31: invokevirtual #1106               // Method net/minecraft/world/damagesource/DamageSources.lava:()Lnet/minecraft/world/damagesource/DamageSource;
+        34: ldc_w         #1107               // float 4.0f
+        37: invokevirtual #1041               // Method hurtServer:(Lnet/minecraft/server/level/ServerLevel;Lnet/minecraft/world/damagesource/DamageSource;F)Z
+        40: ifeq          99
+        43: aload_0
+        44: invokevirtual #1110               // Method shouldPlayLavaHurtSound:()Z
+        47: ifeq          99
+        50: aload_0
+        51: invokevirtual #1113               // Method isSilent:()Z
+        54: ifne          99
+        57: aload_1
+        58: aconst_null
+        59: aload_0
+        60: invokevirtual #880                // Method getX:()D
+        63: aload_0
+        64: invokevirtual #883                // Method getY:()D
+        67: aload_0
+        68: invokevirtual #886                // Method getZ:()D
+        71: getstatic     #1119               // Field net/minecraft/sounds/SoundEvents.GENERIC_BURN:Lnet/minecraft/sounds/SoundEvent;
+        74: aload_0
+        75: invokevirtual #1123               // Method getSoundSource:()Lnet/minecraft/sounds/SoundSource;
+        78: ldc_w         #1124               // float 0.4f
+        81: fconst_2
+        82: aload_0
+        83: getfield      #461                // Field random:Lnet/minecraft/util/RandomSource;
+        86: invokeinterface #1127,  1         // InterfaceMethod net/minecraft/util/RandomSource.nextFloat:()F
+        91: ldc_w         #1124               // float 0.4f
+        94: fmul
+        95: fadd
+        96: invokevirtual #1131               // Method net/minecraft/server/level/ServerLevel.playSound:(Lnet/minecraft/world/entity/Entity;DDDLnet/minecraft/sounds/SoundEvent;Lnet/minecraft/sounds/SoundSource;FF)V
+        99: return
+
+  protected boolean shouldPlayLavaHurtSound();
+    Code:
+         0: iconst_1
+         1: ireturn
+
+  public final void igniteForSeconds(float);
+    Code:
+         0: aload_0
+         1: fload_1
+         2: ldc_w         #1133               // float 20.0f
+         5: fmul
+         6: invokestatic  #1137               // Method net/minecraft/util/Mth.floor:(F)I
+         9: invokevirtual #1140               // Method igniteForTicks:(I)V
+        12: return
+
+  public void igniteForTicks(int);
+    Code:
+         0: aload_0
+         1: getfield      #1018               // Field remainingFireTicks:I
+         4: iload_1
+         5: if_icmpge     13
+         8: aload_0
+         9: iload_1
+        10: invokevirtual #1044               // Method setRemainingFireTicks:(I)V
+        13: aload_0
+        14: invokevirtual #1144               // Method clearFreeze:()V
+        17: return
+
+  public void setRemainingFireTicks(int);
+    Code:
+         0: aload_0
+         1: iload_1
+         2: putfield      #1018               // Field remainingFireTicks:I
+         5: return
+
+  public int getRemainingFireTicks();
+    Code:
+         0: aload_0
+         1: getfield      #1018               // Field remainingFireTicks:I
+         4: ireturn
+
+  public void clearFire();
+    Code:
+         0: aload_0
+         1: iconst_0
+         2: aload_0
+         3: invokevirtual #1148               // Method getRemainingFireTicks:()I
+         6: invokestatic  #1154               // Method java/lang/Math.min:(II)I
+         9: invokevirtual #1044               // Method setRemainingFireTicks:(I)V
+        12: return
+
+  protected void onBelowWorld();
+    Code:
+         0: aload_0
+         1: invokevirtual #1156               // Method discard:()V
+         4: return
+
+  public boolean isFree(double, double, double);
+    Code:
+         0: aload_0
+         1: aload_0
+         2: invokevirtual #693                // Method getBoundingBox:()Lnet/minecraft/world/phys/AABB;
+         5: dload_1
+         6: dload_3
+         7: dload         5
+         9: invokevirtual #1166               // Method net/minecraft/world/phys/AABB.move:(DDD)Lnet/minecraft/world/phys/AABB;
+        12: invokevirtual #1169               // Method isFree:(Lnet/minecraft/world/phys/AABB;)Z
+        15: ireturn
+
+  private boolean isFree(net.minecraft.world.phys.AABB);
+    Code:
+         0: aload_0
+         1: invokevirtual #672                // Method level:()Lnet/minecraft/world/level/Level;
+         4: aload_0
+         5: aload_1
+         6: invokevirtual #1174               // Method net/minecraft/world/level/Level.noCollision:(Lnet/minecraft/world/entity/Entity;Lnet/minecraft/world/phys/AABB;)Z
+         9: ifeq          27
+        12: aload_0
+        13: invokevirtual #672                // Method level:()Lnet/minecraft/world/level/Level;
+        16: aload_1
+        17: invokevirtual #1177               // Method net/minecraft/world/level/Level.containsAnyLiquid:(Lnet/minecraft/world/phys/AABB;)Z
+        20: ifne          27
+        23: iconst_1
+        24: goto          28
+        27: iconst_0
+        28: ireturn
+
+  public void setOnGround(boolean);
+    Code:
+         0: aload_0
+         1: iload_1
+         2: putfield      #1180               // Field onGround:Z
+         5: aload_0
+         6: iload_1
+         7: aconst_null
+         8: invokevirtual #1184               // Method checkSupportingBlock:(ZLnet/minecraft/world/phys/Vec3;)V
+        11: return
+
+  public void setOnGroundWithMovement(boolean, net.minecraft.world.phys.Vec3);
+    Code:
+         0: aload_0
+         1: iload_1
+         2: aload_0
+         3: getfield      #1188               // Field horizontalCollision:Z
+         6: aload_2
+         7: invokevirtual #1191               // Method setOnGroundWithMovement:(ZZLnet/minecraft/world/phys/Vec3;)V
+        10: return
+
+  public void setOnGroundWithMovement(boolean, boolean, net.minecraft.world.phys.Vec3);
+    Code:
+         0: aload_0
+         1: iload_1
+         2: putfield      #1180               // Field onGround:Z
+         5: aload_0
+         6: iload_2
+         7: putfield      #1188               // Field horizontalCollision:Z
+        10: aload_0
+        11: iload_1
+        12: aload_3
+        13: invokevirtual #1184               // Method checkSupportingBlock:(ZLnet/minecraft/world/phys/Vec3;)V
+        16: return
+
+  public boolean isSupportedBy(net.minecraft.core.BlockPos);
+    Code:
+         0: aload_0
+         1: getfield      #530                // Field mainSupportingBlockPos:Ljava/util/Optional;
+         4: invokevirtual #724                // Method java/util/Optional.isPresent:()Z
+         7: ifeq          31
+        10: aload_0
+        11: getfield      #530                // Field mainSupportingBlockPos:Ljava/util/Optional;
+        14: invokevirtual #728                // Method java/util/Optional.get:()Ljava/lang/Object;
+        17: checkcast     #122                // class net/minecraft/core/BlockPos
+        20: aload_1
+        21: invokevirtual #1195               // Method net/minecraft/core/BlockPos.equals:(Ljava/lang/Object;)Z
+        24: ifeq          31
+        27: iconst_1
+        28: goto          32
+        31: iconst_0
+        32: ireturn
+
+  protected void checkSupportingBlock(boolean, net.minecraft.world.phys.Vec3);
+    Code:
+         0: iload_1
+         1: ifeq          134
+         4: aload_0
+         5: invokevirtual #693                // Method getBoundingBox:()Lnet/minecraft/world/phys/AABB;
+         8: astore_3
+         9: new           #1163               // class net/minecraft/world/phys/AABB
+        12: dup
+        13: aload_3
+        14: getfield      #1198               // Field net/minecraft/world/phys/AABB.minX:D
+        17: aload_3
+        18: getfield      #1201               // Field net/minecraft/world/phys/AABB.minY:D
+        21: ldc2_w        #1202               // double 1.0E-6d
+        24: dsub
+        25: aload_3
+        26: getfield      #1206               // Field net/minecraft/world/phys/AABB.minZ:D
+        29: aload_3
+        30: getfield      #1209               // Field net/minecraft/world/phys/AABB.maxX:D
+        33: aload_3
+        34: getfield      #1201               // Field net/minecraft/world/phys/AABB.minY:D
+        37: aload_3
+        38: getfield      #1212               // Field net/minecraft/world/phys/AABB.maxZ:D
+        41: invokespecial #1215               // Method net/minecraft/world/phys/AABB."<init>":(DDDDDD)V
+        44: astore        4
+        46: aload_0
+        47: getfield      #567                // Field level:Lnet/minecraft/world/level/Level;
+        50: aload_0
+        51: aload         4
+        53: invokevirtual #1219               // Method net/minecraft/world/level/Level.findSupportingBlock:(Lnet/minecraft/world/entity/Entity;Lnet/minecraft/world/phys/AABB;)Ljava/util/Optional;
+        56: astore        5
+        58: aload         5
+        60: invokevirtual #724                // Method java/util/Optional.isPresent:()Z
+        63: ifne          73
+        66: aload_0
+        67: getfield      #532                // Field onGroundNoBlocks:Z
+        70: ifeq          82
+        73: aload_0
+        74: aload         5
+        76: putfield      #530                // Field mainSupportingBlockPos:Ljava/util/Optional;
+        79: goto          122
+        82: aload_2
+        83: ifnull        122
+        86: aload         4
+        88: aload_2
+        89: getfield      #932                // Field net/minecraft/world/phys/Vec3.x:D
+        92: dneg
+        93: dconst_0
+        94: aload_2
+        95: getfield      #936                // Field net/minecraft/world/phys/Vec3.z:D
+        98: dneg
+        99: invokevirtual #1166               // Method net/minecraft/world/phys/AABB.move:(DDD)Lnet/minecraft/world/phys/AABB;
+       102: astore        6
+       104: aload_0
+       105: getfield      #567                // Field level:Lnet/minecraft/world/level/Level;
+       108: aload_0
+       109: aload         6
+       111: invokevirtual #1219               // Method net/minecraft/world/level/Level.findSupportingBlock:(Lnet/minecraft/world/entity/Entity;Lnet/minecraft/world/phys/AABB;)Ljava/util/Optional;
+       114: astore        5
+       116: aload_0
+       117: aload         5
+       119: putfield      #530                // Field mainSupportingBlockPos:Ljava/util/Optional;
+       122: aload_0
+       123: aload         5
+       125: invokevirtual #1222               // Method java/util/Optional.isEmpty:()Z
+       128: putfield      #532                // Field onGroundNoBlocks:Z
+       131: goto          156
+       134: aload_0
+       135: iconst_0
+       136: putfield      #532                // Field onGroundNoBlocks:Z
+       139: aload_0
+       140: getfield      #530                // Field mainSupportingBlockPos:Ljava/util/Optional;
+       143: invokevirtual #724                // Method java/util/Optional.isPresent:()Z
+       146: ifeq          156
+       149: aload_0
+       150: invokestatic  #528                // Method java/util/Optional.empty:()Ljava/util/Optional;
+       153: putfield      #530                // Field mainSupportingBlockPos:Ljava/util/Optional;
+       156: return
+
+  public boolean onGround();
+    Code:
+         0: aload_0
+         1: getfield      #1180               // Field onGround:Z
+         4: ireturn
+
+  public void move(net.minecraft.world.entity.MoverType, net.minecraft.world.phys.Vec3);
+    Code:
+         0: aload_0
+         1: getfield      #1231               // Field noPhysics:Z
+         4: ifeq          59
+         7: aload_0
+         8: aload_0
+         9: invokevirtual #880                // Method getX:()D
+        12: aload_2
+        13: getfield      #932                // Field net/minecraft/world/phys/Vec3.x:D
+        16: dadd
+        17: aload_0
+        18: invokevirtual #883                // Method getY:()D
+        21: aload_2
+        22: getfield      #934                // Field net/minecraft/world/phys/Vec3.y:D
+        25: dadd
+        26: aload_0
+        27: invokevirtual #886                // Method getZ:()D
+        30: aload_2
+        31: getfield      #936                // Field net/minecraft/world/phys/Vec3.z:D
+        34: dadd
+        35: invokevirtual #655                // Method setPos:(DDD)V
+        38: aload_0
+        39: iconst_0
+        40: putfield      #1188               // Field horizontalCollision:Z
+        43: aload_0
+        44: iconst_0
+        45: putfield      #1233               // Field verticalCollision:Z
+        48: aload_0
+        49: iconst_0
+        50: putfield      #1235               // Field verticalCollisionBelow:Z
+        53: aload_0
+        54: iconst_0
+        55: putfield      #1237               // Field minorHorizontalCollision:Z
+        58: return
+        59: aload_1
+        60: getstatic     #1243               // Field net/minecraft/world/entity/MoverType.PISTON:Lnet/minecraft/world/entity/MoverType;
+        63: if_acmpne     83
+        66: aload_0
+        67: aload_2
+        68: invokevirtual #1246               // Method limitPistonMovement:(Lnet/minecraft/world/phys/Vec3;)Lnet/minecraft/world/phys/Vec3;
+        71: astore_2
+        72: aload_2
+        73: getstatic     #443                // Field net/minecraft/world/phys/Vec3.ZERO:Lnet/minecraft/world/phys/Vec3;
+        76: invokevirtual #1247               // Method net/minecraft/world/phys/Vec3.equals:(Ljava/lang/Object;)Z
+        79: ifeq          83
+        82: return
+        83: invokestatic  #973                // Method net/minecraft/util/profiling/Profiler.get:()Lnet/minecraft/util/profiling/ProfilerFiller;
+        86: astore_3
+        87: aload_3
+        88: ldc_w         #1248               // String move
+        91: invokeinterface #980,  2          // InterfaceMethod net/minecraft/util/profiling/ProfilerFiller.push:(Ljava/lang/String;)V
+        96: aload_0
+        97: getfield      #451                // Field stuckSpeedMultiplier:Lnet/minecraft/world/phys/Vec3;
+       100: invokevirtual #1251               // Method net/minecraft/world/phys/Vec3.lengthSqr:()D
+       103: ldc2_w        #1252               // double 1.0E-7d
+       106: dcmpl
+       107: ifle          140
+       110: aload_1
+       111: getstatic     #1243               // Field net/minecraft/world/entity/MoverType.PISTON:Lnet/minecraft/world/entity/MoverType;
+       114: if_acmpeq     126
+       117: aload_2
+       118: aload_0
+       119: getfield      #451                // Field stuckSpeedMultiplier:Lnet/minecraft/world/phys/Vec3;
+       122: invokevirtual #1256               // Method net/minecraft/world/phys/Vec3.multiply:(Lnet/minecraft/world/phys/Vec3;)Lnet/minecraft/world/phys/Vec3;
+       125: astore_2
+       126: aload_0
+       127: getstatic     #443                // Field net/minecraft/world/phys/Vec3.ZERO:Lnet/minecraft/world/phys/Vec3;
+       130: putfield      #451                // Field stuckSpeedMultiplier:Lnet/minecraft/world/phys/Vec3;
+       133: aload_0
+       134: getstatic     #443                // Field net/minecraft/world/phys/Vec3.ZERO:Lnet/minecraft/world/phys/Vec3;
+       137: invokevirtual #1259               // Method setDeltaMovement:(Lnet/minecraft/world/phys/Vec3;)V
+       140: aload_0
+       141: aload_2
+       142: aload_1
+       143: invokevirtual #1263               // Method maybeBackOffFromEdge:(Lnet/minecraft/world/phys/Vec3;Lnet/minecraft/world/entity/MoverType;)Lnet/minecraft/world/phys/Vec3;
+       146: astore_2
+       147: aload_0
+       148: aload_2
+       149: invokevirtual #1266               // Method collide:(Lnet/minecraft/world/phys/Vec3;)Lnet/minecraft/world/phys/Vec3;
+       152: astore        4
+       154: aload         4
+       156: invokevirtual #1251               // Method net/minecraft/world/phys/Vec3.lengthSqr:()D
+       159: dstore        5
+       161: dload         5
+       163: ldc2_w        #1252               // double 1.0E-7d
+       166: dcmpl
+       167: ifgt          184
+       170: aload_2
+       171: invokevirtual #1251               // Method net/minecraft/world/phys/Vec3.lengthSqr:()D
+       174: dload         5
+       176: dsub
+       177: ldc2_w        #1252               // double 1.0E-7d
+       180: dcmpg
+       181: ifge          313
+       184: aload_0
+       185: getfield      #1046               // Field fallDistance:D
+       188: dconst_0
+       189: dcmpl
+       190: ifeq          276
+       193: dload         5
+       195: dconst_1
+       196: dcmpl
+       197: iflt          276
+       200: aload         4
+       202: invokevirtual #1269               // Method net/minecraft/world/phys/Vec3.length:()D
+       205: ldc2_w        #282                // double 8.0d
+       208: invokestatic  #1271               // Method java/lang/Math.min:(DD)D
+       211: dstore        7
+       213: aload_0
+       214: invokevirtual #870                // Method position:()Lnet/minecraft/world/phys/Vec3;
+       217: aload         4
+       219: invokevirtual #1274               // Method net/minecraft/world/phys/Vec3.normalize:()Lnet/minecraft/world/phys/Vec3;
+       222: dload         7
+       224: invokevirtual #1278               // Method net/minecraft/world/phys/Vec3.scale:(D)Lnet/minecraft/world/phys/Vec3;
+       227: invokevirtual #1280               // Method net/minecraft/world/phys/Vec3.add:(Lnet/minecraft/world/phys/Vec3;)Lnet/minecraft/world/phys/Vec3;
+       230: astore        9
+       232: aload_0
+       233: invokevirtual #672                // Method level:()Lnet/minecraft/world/level/Level;
+       236: new           #64                 // class net/minecraft/world/level/ClipContext
+       239: dup
+       240: aload_0
+       241: invokevirtual #870                // Method position:()Lnet/minecraft/world/phys/Vec3;
+       244: aload         9
+       246: getstatic     #1284               // Field net/minecraft/world/level/ClipContext$Block.FALLDAMAGE_RESETTING:Lnet/minecraft/world/level/ClipContext$Block;
+       249: getstatic     #1287               // Field net/minecraft/world/level/ClipContext$Fluid.WATER:Lnet/minecraft/world/level/ClipContext$Fluid;
+       252: aload_0
+       253: invokespecial #1290               // Method net/minecraft/world/level/ClipContext."<init>":(Lnet/minecraft/world/phys/Vec3;Lnet/minecraft/world/phys/Vec3;Lnet/minecraft/world/level/ClipContext$Block;Lnet/minecraft/world/level/ClipContext$Fluid;Lnet/minecraft/world/entity/Entity;)V
+       256: invokevirtual #1294               // Method net/minecraft/world/level/Level.clip:(Lnet/minecraft/world/level/ClipContext;)Lnet/minecraft/world/phys/BlockHitResult;
+       259: astore        10
+       261: aload         10
+       263: invokevirtual #1299               // Method net/minecraft/world/phys/BlockHitResult.getType:()Lnet/minecraft/world/phys/HitResult$Type;
+       266: getstatic     #1303               // Field net/minecraft/world/phys/HitResult$Type.MISS:Lnet/minecraft/world/phys/HitResult$Type;
+       269: if_acmpeq     276
+       272: aload_0
+       273: invokevirtual #1306               // Method resetFallDistance:()V
+       276: aload_0
+       277: invokevirtual #870                // Method position:()Lnet/minecraft/world/phys/Vec3;
+       280: astore        7
+       282: aload         7
+       284: aload         4
+       286: invokevirtual #1280               // Method net/minecraft/world/phys/Vec3.add:(Lnet/minecraft/world/phys/Vec3;)Lnet/minecraft/world/phys/Vec3;
+       289: astore        8
+       291: aload_0
+       292: new           #44                 // class net/minecraft/world/entity/Entity$Movement
+       295: dup
+       296: aload         7
+       298: aload         8
+       300: aload_2
+       301: invokespecial #1309               // Method net/minecraft/world/entity/Entity$Movement."<init>":(Lnet/minecraft/world/phys/Vec3;Lnet/minecraft/world/phys/Vec3;Lnet/minecraft/world/phys/Vec3;)V
+       304: invokevirtual #1313               // Method addMovementThisTick:(Lnet/minecraft/world/entity/Entity$Movement;)V
+       307: aload_0
+       308: aload         8
+       310: invokevirtual #1315               // Method setPos:(Lnet/minecraft/world/phys/Vec3;)V
+       313: aload_3
+       314: invokeinterface #1066,  1         // InterfaceMethod net/minecraft/util/profiling/ProfilerFiller.pop:()V
+       319: aload_3
+       320: ldc_w         #1317               // String rest
+       323: invokeinterface #980,  2          // InterfaceMethod net/minecraft/util/profiling/ProfilerFiller.push:(Ljava/lang/String;)V
+       328: aload_2
+       329: getfield      #932                // Field net/minecraft/world/phys/Vec3.x:D
+       332: aload         4
+       334: getfield      #932                // Field net/minecraft/world/phys/Vec3.x:D
+       337: invokestatic  #1321               // Method net/minecraft/util/Mth.equal:(DD)Z
+       340: ifne          347
+       343: iconst_1
+       344: goto          348
+       347: iconst_0
+       348: istore        7
+       350: aload_2
+       351: getfield      #936                // Field net/minecraft/world/phys/Vec3.z:D
+       354: aload         4
+       356: getfield      #936                // Field net/minecraft/world/phys/Vec3.z:D
+       359: invokestatic  #1321               // Method net/minecraft/util/Mth.equal:(DD)Z
+       362: ifne          369
+       365: iconst_1
+       366: goto          370
+       369: iconst_0
+       370: istore        8
+       372: aload_0
+       373: iload         7
+       375: ifne          383
+       378: iload         8
+       380: ifeq          387
+       383: iconst_1
+       384: goto          388
+       387: iconst_0
+       388: putfield      #1188               // Field horizontalCollision:Z
+       391: aload_2
+       392: getfield      #934                // Field net/minecraft/world/phys/Vec3.y:D
+       395: invokestatic  #1324               // Method java/lang/Math.abs:(D)D
+       398: dconst_0
+       399: dcmpl
+       400: ifle          407
+       403: iconst_1
+       404: goto          408
+       407: iconst_0
+       408: istore        9
+       410: iload         9
+       412: ifne          422
+       415: aload_0
+       416: invokevirtual #1327               // Method isLocalInstanceAuthoritative:()Z
+       419: ifeq          483
+       422: aload_0
+       423: aload_2
+       424: getfield      #934                // Field net/minecraft/world/phys/Vec3.y:D
+       427: aload         4
+       429: getfield      #934                // Field net/minecraft/world/phys/Vec3.y:D
+       432: dcmpl
+       433: ifeq          440
+       436: iconst_1
+       437: goto          441
+       440: iconst_0
+       441: putfield      #1233               // Field verticalCollision:Z
+       444: aload_0
+       445: aload_0
+       446: getfield      #1233               // Field verticalCollision:Z
+       449: ifeq          465
+       452: aload_2
+       453: getfield      #934                // Field net/minecraft/world/phys/Vec3.y:D
+       456: dconst_0
+       457: dcmpg
+       458: ifge          465
+       461: iconst_1
+       462: goto          466
+       465: iconst_0
+       466: putfield      #1235               // Field verticalCollisionBelow:Z
+       469: aload_0
+       470: aload_0
+       471: getfield      #1235               // Field verticalCollisionBelow:Z
+       474: aload_0
+       475: getfield      #1188               // Field horizontalCollision:Z
+       478: aload         4
+       480: invokevirtual #1191               // Method setOnGroundWithMovement:(ZZLnet/minecraft/world/phys/Vec3;)V
+       483: aload_0
+       484: getfield      #1188               // Field horizontalCollision:Z
+       487: ifeq          503
+       490: aload_0
+       491: aload_0
+       492: aload         4
+       494: invokevirtual #1331               // Method isHorizontalCollisionMinor:(Lnet/minecraft/world/phys/Vec3;)Z
+       497: putfield      #1237               // Field minorHorizontalCollision:Z
+       500: goto          508
+       503: aload_0
+       504: iconst_0
+       505: putfield      #1237               // Field minorHorizontalCollision:Z
+       508: aload_0
+       509: invokevirtual #1335               // Method getOnPosLegacy:()Lnet/minecraft/core/BlockPos;
+       512: astore        10
+       514: aload_0
+       515: invokevirtual #672                // Method level:()Lnet/minecraft/world/level/Level;
+       518: aload         10
+       520: invokevirtual #1339               // Method net/minecraft/world/level/Level.getBlockState:(Lnet/minecraft/core/BlockPos;)Lnet/minecraft/world/level/block/state/BlockState;
+       523: astore        11
+       525: aload_0
+       526: invokevirtual #1327               // Method isLocalInstanceAuthoritative:()Z
+       529: ifeq          549
+       532: aload_0
+       533: aload         4
+       535: getfield      #934                // Field net/minecraft/world/phys/Vec3.y:D
+       538: aload_0
+       539: invokevirtual #1341               // Method onGround:()Z
+       542: aload         11
+       544: aload         10
+       546: invokevirtual #1345               // Method checkFallDamage:(DZLnet/minecraft/world/level/block/state/BlockState;Lnet/minecraft/core/BlockPos;)V
+       549: aload_0
+       550: invokevirtual #744                // Method isRemoved:()Z
+       553: ifeq          563
+       556: aload_3
+       557: invokeinterface #1066,  1         // InterfaceMethod net/minecraft/util/profiling/ProfilerFiller.pop:()V
+       562: return
+       563: aload_0
+       564: invokevirtual #1348               // Method canSimulateMovement:()Z
+       567: ifeq          601
+       570: iload         9
+       572: ifeq          582
+       575: aload_0
+       576: getfield      #1233               // Field verticalCollision:Z
+       579: ifne          589
+       582: aload_0
+       583: getfield      #1188               // Field horizontalCollision:Z
+       586: ifeq          601
+       589: aload_0
+       590: aload         11
+       592: iload         7
+       594: iload         8
+       596: aload         4
+       598: invokevirtual #1352               // Method restituteMovementAfterCollisions:(Lnet/minecraft/world/level/block/state/BlockState;ZZLnet/minecraft/world/phys/Vec3;)V
+       601: aload_0
+       602: invokevirtual #672                // Method level:()Lnet/minecraft/world/level/Level;
+       605: invokevirtual #1054               // Method net/minecraft/world/level/Level.isClientSide:()Z
+       608: ifeq          618
+       611: aload_0
+       612: invokevirtual #1327               // Method isLocalInstanceAuthoritative:()Z
+       615: ifeq          651
+       618: aload_0
+       619: invokevirtual #1356               // Method getMovementEmission:()Lnet/minecraft/world/entity/Entity$MovementEmission;
+       622: astore        12
+       624: aload         12
+       626: invokevirtual #1359               // Method net/minecraft/world/entity/Entity$MovementEmission.emitsAnything:()Z
+       629: ifeq          651
+       632: aload_0
+       633: invokevirtual #756                // Method isPassenger:()Z
+       636: ifne          651
+       639: aload_0
+       640: aload         12
+       642: aload         4
+       644: aload         10
+       646: aload         11
+       648: invokevirtual #1363               // Method applyMovementEmissionAndPlaySound:(Lnet/minecraft/world/entity/Entity$MovementEmission;Lnet/minecraft/world/phys/Vec3;Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/level/block/state/BlockState;)V
+       651: aload_0
+       652: invokevirtual #1366               // Method getBlockSpeedFactor:()F
+       655: fstore        12
+       657: aload_0
+       658: aload_0
+       659: invokevirtual #1369               // Method getDeltaMovement:()Lnet/minecraft/world/phys/Vec3;
+       662: fload         12
+       664: f2d
+       665: dconst_1
+       666: fload         12
+       668: f2d
+       669: invokevirtual #1372               // Method net/minecraft/world/phys/Vec3.multiply:(DDD)Lnet/minecraft/world/phys/Vec3;
+       672: invokevirtual #1259               // Method setDeltaMovement:(Lnet/minecraft/world/phys/Vec3;)V
+       675: aload_3
+       676: invokeinterface #1066,  1         // InterfaceMethod net/minecraft/util/profiling/ProfilerFiller.pop:()V
+       681: return
+
+  private void restituteMovementAfterCollisions(net.minecraft.world.level.block.state.BlockState, boolean, boolean, net.minecraft.world.phys.Vec3);
+    Code:
+         0: aload_0
+         1: invokevirtual #1389               // Method isSuppressingBounce:()Z
+         4: ifeq          11
+         7: dconst_0
+         8: goto          15
+        11: aload_0
+        12: invokevirtual #1392               // Method getEntityBounciness:()D
+        15: dstore        5
+        17: aload_0
+        18: invokevirtual #1369               // Method getDeltaMovement:()Lnet/minecraft/world/phys/Vec3;
+        21: astore        7
+        23: aload         7
+        25: astore        8
+        27: iload_2
+        28: ifeq          50
+        31: aload         8
+        33: getstatic     #1396               // Field net/minecraft/core/Direction$Axis.X:Lnet/minecraft/core/Direction$Axis;
+        36: aload         7
+        38: getfield      #932                // Field net/minecraft/world/phys/Vec3.x:D
+        41: dneg
+        42: dload         5
+        44: dmul
+        45: invokevirtual #1400               // Method net/minecraft/world/phys/Vec3.with:(Lnet/minecraft/core/Direction$Axis;D)Lnet/minecraft/world/phys/Vec3;
+        48: astore        8
+        50: iload_3
+        51: ifeq          73
+        54: aload         8
+        56: getstatic     #1402               // Field net/minecraft/core/Direction$Axis.Z:Lnet/minecraft/core/Direction$Axis;
+        59: aload         7
+        61: getfield      #936                // Field net/minecraft/world/phys/Vec3.z:D
+        64: dneg
+        65: dload         5
+        67: dmul
+        68: invokevirtual #1400               // Method net/minecraft/world/phys/Vec3.with:(Lnet/minecraft/core/Direction$Axis;D)Lnet/minecraft/world/phys/Vec3;
+        71: astore        8
+        73: dload         5
+        75: dconst_0
+        76: dcmpl
+        77: ifle          92
+        80: iload_2
+        81: ifne          88
+        84: iload_3
+        85: ifeq          92
+        88: iconst_1
+        89: goto          93
+        92: iconst_0
+        93: istore        9
+        95: aload_0
+        96: getfield      #1233               // Field verticalCollision:Z
+        99: ifeq          237
+       102: aload_0
+       103: getfield      #1235               // Field verticalCollisionBelow:Z
+       106: ifeq          159
+       109: aload         7
+       111: getfield      #934                // Field net/minecraft/world/phys/Vec3.y:D
+       114: dneg
+       115: aload_0
+       116: invokevirtual #1405               // Method getEffectiveGravity:()D
+       119: dcmpg
+       120: iflt          140
+       123: aload_0
+       124: invokevirtual #1389               // Method isSuppressingBounce:()Z
+       127: ifne          140
+       130: aload_1
+       131: getstatic     #1410               // Field net/minecraft/tags/BlockTags.SUPPRESSES_BOUNCE:Lnet/minecraft/tags/TagKey;
+       134: invokevirtual #1413               // Method net/minecraft/world/level/block/state/BlockState.is:(Lnet/minecraft/tags/TagKey;)Z
+       137: ifeq          144
+       140: dconst_0
+       141: goto          157
+       144: dload         5
+       146: aload_0
+       147: aload_1
+       148: invokevirtual #1417               // Method net/minecraft/world/level/block/state/BlockState.getBlock:()Lnet/minecraft/world/level/block/Block;
+       151: invokevirtual #1421               // Method getBlockBounciness:(Lnet/minecraft/world/level/block/Block;)D
+       154: invokestatic  #1424               // Method java/lang/Math.max:(DD)D
+       157: dstore        5
+       159: dload         5
+       161: dconst_0
+       162: dcmpl
+       163: ifle          207
+       166: aload         4
+       168: getfield      #934                // Field net/minecraft/world/phys/Vec3.y:D
+       171: aload         7
+       173: getfield      #934                // Field net/minecraft/world/phys/Vec3.y:D
+       176: ddiv
+       177: dstore        14
+       179: dload         14
+       181: aload_0
+       182: invokevirtual #1405               // Method getEffectiveGravity:()D
+       185: dmul
+       186: dstore        10
+       188: dload         14
+       190: dconst_1
+       191: aload_0
+       192: invokevirtual #1427               // Method getAirDrag:()F
+       195: f2d
+       196: invokestatic  #1431               // Method net/minecraft/util/Mth.lerp:(DDD)D
+       199: dstore        12
+       201: iconst_1
+       202: istore        9
+       204: goto          213
+       207: dconst_0
+       208: dstore        10
+       210: dconst_1
+       211: dstore        12
+       213: aload         8
+       215: getstatic     #1434               // Field net/minecraft/core/Direction$Axis.Y:Lnet/minecraft/core/Direction$Axis;
+       218: dload         10
+       220: aload         7
+       222: getfield      #934                // Field net/minecraft/world/phys/Vec3.y:D
+       225: dsub
+       226: dload         12
+       228: dmul
+       229: dload         5
+       231: dmul
+       232: invokevirtual #1400               // Method net/minecraft/world/phys/Vec3.with:(Lnet/minecraft/core/Direction$Axis;D)Lnet/minecraft/world/phys/Vec3;
+       235: astore        8
+       237: iload         9
+       239: ifeq          254
+       242: aload_0
+       243: getstatic     #1437               // Field net/minecraft/world/level/gameevent/GameEvent.BOUNCE:Lnet/minecraft/core/Holder$Reference;
+       246: invokevirtual #828                // Method gameEvent:(Lnet/minecraft/core/Holder;)V
+       249: aload_0
+       250: iconst_1
+       251: putfield      #1439               // Field syncPosition:Z
+       254: aload_0
+       255: aload         8
+       257: invokevirtual #1259               // Method setDeltaMovement:(Lnet/minecraft/world/phys/Vec3;)V
+       260: return
+
+  private double getBlockBounciness(net.minecraft.world.level.block.Block);
+    Code:
+         0: aload_1
+         1: invokevirtual #1452               // Method net/minecraft/world/level/block/Block.getBounceRestitution:()F
+         4: fstore_2
+         5: aload_0
+         6: instanceof    #1454               // class net/minecraft/world/entity/LivingEntity
+         9: ifne          18
+        12: fload_2
+        13: ldc_w         #1455               // float 0.8f
+        16: fmul
+        17: fstore_2
+        18: fload_2
+        19: f2d
+        20: dreturn
+
+  protected double getEntityBounciness();
+    Code:
+         0: dconst_0
+         1: dreturn
+
+  protected double getEffectiveGravity();
+    Code:
+         0: aload_0
+         1: invokevirtual #1460               // Method getGravity:()D
+         4: dreturn
+
+  protected boolean omnidirectionalAirMover();
+    Code:
+         0: iconst_0
+         1: ireturn
+
+  private void applyMovementEmissionAndPlaySound(net.minecraft.world.entity.Entity$MovementEmission, net.minecraft.world.phys.Vec3, net.minecraft.core.BlockPos, net.minecraft.world.level.block.state.BlockState);
+    Code:
+         0: ldc_w         #325                // float 0.6f
+         3: fstore        5
+         5: aload_2
+         6: invokevirtual #1269               // Method net/minecraft/world/phys/Vec3.length:()D
+         9: ldc2_w        #1463               // double 0.6000000238418579d
+        12: dmul
+        13: d2f
+        14: fstore        6
+        16: aload_2
+        17: invokevirtual #1467               // Method net/minecraft/world/phys/Vec3.horizontalDistance:()D
+        20: ldc2_w        #1463               // double 0.6000000238418579d
+        23: dmul
+        24: d2f
+        25: fstore        7
+        27: aload_0
+        28: invokevirtual #1470               // Method getOnPos:()Lnet/minecraft/core/BlockPos;
+        31: astore        8
+        33: aload_0
+        34: invokevirtual #672                // Method level:()Lnet/minecraft/world/level/Level;
+        37: aload         8
+        39: invokevirtual #1339               // Method net/minecraft/world/level/Level.getBlockState:(Lnet/minecraft/core/BlockPos;)Lnet/minecraft/world/level/block/state/BlockState;
+        42: astore        9
+        44: aload_0
+        45: aload         9
+        47: invokevirtual #1474               // Method isStateClimbable:(Lnet/minecraft/world/level/block/state/BlockState;)Z
+        50: istore        10
+        52: aload_0
+        53: dup
+        54: getfield      #1476               // Field moveDist:F
+        57: iload         10
+        59: ifeq          67
+        62: fload         6
+        64: goto          69
+        67: fload         7
+        69: fadd
+        70: putfield      #1476               // Field moveDist:F
+        73: aload_0
+        74: dup
+        75: getfield      #1478               // Field flyDist:F
+        78: fload         6
+        80: fadd
+        81: putfield      #1478               // Field flyDist:F
+        84: aload_0
+        85: getfield      #1476               // Field moveDist:F
+        88: aload_0
+        89: getfield      #453                // Field nextStep:F
+        92: fcmpl
+        93: ifle          211
+        96: aload         9
+        98: invokevirtual #1481               // Method net/minecraft/world/level/block/state/BlockState.isAir:()Z
+       101: ifne          211
+       104: aload         8
+       106: aload_3
+       107: invokevirtual #1195               // Method net/minecraft/core/BlockPos.equals:(Ljava/lang/Object;)Z
+       110: istore        11
+       112: aload_0
+       113: aload_3
+       114: aload         4
+       116: aload_1
+       117: invokevirtual #1484               // Method net/minecraft/world/entity/Entity$MovementEmission.emitsSounds:()Z
+       120: iload         11
+       122: aload_2
+       123: invokevirtual #1488               // Method vibrationAndSoundEffectsFromBlock:(Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/level/block/state/BlockState;ZZLnet/minecraft/world/phys/Vec3;)Z
+       126: istore        12
+       128: iload         11
+       130: ifne          152
+       133: iload         12
+       135: aload_0
+       136: aload         8
+       138: aload         9
+       140: iconst_0
+       141: aload_1
+       142: invokevirtual #1491               // Method net/minecraft/world/entity/Entity$MovementEmission.emitsEvents:()Z
+       145: aload_2
+       146: invokevirtual #1488               // Method vibrationAndSoundEffectsFromBlock:(Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/level/block/state/BlockState;ZZLnet/minecraft/world/phys/Vec3;)Z
+       149: ior
+       150: istore        12
+       152: iload         12
+       154: ifeq          168
+       157: aload_0
+       158: aload_0
+       159: invokevirtual #1493               // Method nextStep:()F
+       162: putfield      #453                // Field nextStep:F
+       165: goto          208
+       168: aload_0
+       169: invokevirtual #1496               // Method isInWater:()Z
+       172: ifeq          208
+       175: aload_0
+       176: aload_0
+       177: invokevirtual #1493               // Method nextStep:()F
+       180: putfield      #453                // Field nextStep:F
+       183: aload_1
+       184: invokevirtual #1484               // Method net/minecraft/world/entity/Entity$MovementEmission.emitsSounds:()Z
+       187: ifeq          194
+       190: aload_0
+       191: invokevirtual #1499               // Method waterSwimSound:()V
+       194: aload_1
+       195: invokevirtual #1491               // Method net/minecraft/world/entity/Entity$MovementEmission.emitsEvents:()Z
+       198: ifeq          208
+       201: aload_0
+       202: getstatic     #1502               // Field net/minecraft/world/level/gameevent/GameEvent.SWIM:Lnet/minecraft/core/Holder$Reference;
+       205: invokevirtual #828                // Method gameEvent:(Lnet/minecraft/core/Holder;)V
+       208: goto          223
+       211: aload         9
+       213: invokevirtual #1481               // Method net/minecraft/world/level/block/state/BlockState.isAir:()Z
+       216: ifeq          223
+       219: aload_0
+       220: invokevirtual #1505               // Method processFlappingMovement:()V
+       223: return
+
+  protected void applyEffectsFromBlocks();
+    Code:
+         0: aload_0
+         1: getfield      #548                // Field finalMovementsThisTick:Ljava/util/List;
+         4: invokeinterface #1519,  1         // InterfaceMethod java/util/List.clear:()V
+         9: aload_0
+        10: getfield      #548                // Field finalMovementsThisTick:Ljava/util/List;
+        13: aload_0
+        14: getfield      #543                // Field movementThisTick:Ljava/util/ArrayDeque;
+        17: invokeinterface #1523,  2         // InterfaceMethod java/util/List.addAll:(Ljava/util/Collection;)Z
+        22: pop
+        23: aload_0
+        24: getfield      #543                // Field movementThisTick:Ljava/util/ArrayDeque;
+        27: invokevirtual #1524               // Method java/util/ArrayDeque.clear:()V
+        30: aload_0
+        31: getfield      #548                // Field finalMovementsThisTick:Ljava/util/List;
+        34: invokeinterface #1525,  1         // InterfaceMethod java/util/List.isEmpty:()Z
+        39: ifeq          70
+        42: aload_0
+        43: getfield      #548                // Field finalMovementsThisTick:Ljava/util/List;
+        46: new           #44                 // class net/minecraft/world/entity/Entity$Movement
+        49: dup
+        50: aload_0
+        51: invokevirtual #1528               // Method oldPosition:()Lnet/minecraft/world/phys/Vec3;
+        54: aload_0
+        55: invokevirtual #870                // Method position:()Lnet/minecraft/world/phys/Vec3;
+        58: invokespecial #1531               // Method net/minecraft/world/entity/Entity$Movement."<init>":(Lnet/minecraft/world/phys/Vec3;Lnet/minecraft/world/phys/Vec3;)V
+        61: invokeinterface #1532,  2         // InterfaceMethod java/util/List.add:(Ljava/lang/Object;)Z
+        66: pop
+        67: goto          135
+        70: aload_0
+        71: getfield      #548                // Field finalMovementsThisTick:Ljava/util/List;
+        74: invokeinterface #1535,  1         // InterfaceMethod java/util/List.getLast:()Ljava/lang/Object;
+        79: checkcast     #44                 // class net/minecraft/world/entity/Entity$Movement
+        82: getfield      #1538               // Field net/minecraft/world/entity/Entity$Movement.to:Lnet/minecraft/world/phys/Vec3;
+        85: aload_0
+        86: invokevirtual #870                // Method position:()Lnet/minecraft/world/phys/Vec3;
+        89: invokevirtual #1542               // Method net/minecraft/world/phys/Vec3.distanceToSqr:(Lnet/minecraft/world/phys/Vec3;)D
+        92: ldc2_w        #1543               // double 9.999999439624929E-11d
+        95: dcmpl
+        96: ifle          135
+        99: aload_0
+       100: getfield      #548                // Field finalMovementsThisTick:Ljava/util/List;
+       103: new           #44                 // class net/minecraft/world/entity/Entity$Movement
+       106: dup
+       107: aload_0
+       108: getfield      #548                // Field finalMovementsThisTick:Ljava/util/List;
+       111: invokeinterface #1535,  1         // InterfaceMethod java/util/List.getLast:()Ljava/lang/Object;
+       116: checkcast     #44                 // class net/minecraft/world/entity/Entity$Movement
+       119: getfield      #1538               // Field net/minecraft/world/entity/Entity$Movement.to:Lnet/minecraft/world/phys/Vec3;
+       122: aload_0
+       123: invokevirtual #870                // Method position:()Lnet/minecraft/world/phys/Vec3;
+       126: invokespecial #1531               // Method net/minecraft/world/entity/Entity$Movement."<init>":(Lnet/minecraft/world/phys/Vec3;Lnet/minecraft/world/phys/Vec3;)V
+       129: invokeinterface #1532,  2         // InterfaceMethod java/util/List.add:(Ljava/lang/Object;)Z
+       134: pop
+       135: aload_0
+       136: aload_0
+       137: getfield      #548                // Field finalMovementsThisTick:Ljava/util/List;
+       140: invokevirtual #1547               // Method applyEffectsFromBlocks:(Ljava/util/List;)V
+       143: return
+
+  protected void applyEffectsFromBlocksForLastMovements();
+    Code:
+         0: aload_0
+         1: aload_0
+         2: getfield      #548                // Field finalMovementsThisTick:Ljava/util/List;
+         5: invokevirtual #1547               // Method applyEffectsFromBlocks:(Ljava/util/List;)V
+         8: return
+
+  private void addMovementThisTick(net.minecraft.world.entity.Entity$Movement);
+    Code:
+         0: aload_0
+         1: getfield      #543                // Field movementThisTick:Ljava/util/ArrayDeque;
+         4: invokevirtual #1549               // Method java/util/ArrayDeque.size:()I
+         7: bipush        100
+         9: if_icmplt     60
+        12: aload_0
+        13: getfield      #543                // Field movementThisTick:Ljava/util/ArrayDeque;
+        16: invokevirtual #1552               // Method java/util/ArrayDeque.removeFirst:()Ljava/lang/Object;
+        19: checkcast     #44                 // class net/minecraft/world/entity/Entity$Movement
+        22: astore_2
+        23: aload_0
+        24: getfield      #543                // Field movementThisTick:Ljava/util/ArrayDeque;
+        27: invokevirtual #1552               // Method java/util/ArrayDeque.removeFirst:()Ljava/lang/Object;
+        30: checkcast     #44                 // class net/minecraft/world/entity/Entity$Movement
+        33: astore_3
+        34: new           #44                 // class net/minecraft/world/entity/Entity$Movement
+        37: dup
+        38: aload_2
+        39: invokevirtual #1555               // Method net/minecraft/world/entity/Entity$Movement.from:()Lnet/minecraft/world/phys/Vec3;
+        42: aload_3
+        43: invokevirtual #1557               // Method net/minecraft/world/entity/Entity$Movement.to:()Lnet/minecraft/world/phys/Vec3;
+        46: invokespecial #1531               // Method net/minecraft/world/entity/Entity$Movement."<init>":(Lnet/minecraft/world/phys/Vec3;Lnet/minecraft/world/phys/Vec3;)V
+        49: astore        4
+        51: aload_0
+        52: getfield      #543                // Field movementThisTick:Ljava/util/ArrayDeque;
+        55: aload         4
+        57: invokevirtual #1561               // Method java/util/ArrayDeque.addFirst:(Ljava/lang/Object;)V
+        60: aload_0
+        61: getfield      #543                // Field movementThisTick:Ljava/util/ArrayDeque;
+        64: aload_1
+        65: invokevirtual #1562               // Method java/util/ArrayDeque.add:(Ljava/lang/Object;)Z
+        68: pop
+        69: return
+
+  public void removeLatestMovementRecording();
+    Code:
+         0: aload_0
+         1: getfield      #543                // Field movementThisTick:Ljava/util/ArrayDeque;
+         4: invokevirtual #1568               // Method java/util/ArrayDeque.isEmpty:()Z
+         7: ifne          18
+        10: aload_0
+        11: getfield      #543                // Field movementThisTick:Ljava/util/ArrayDeque;
+        14: invokevirtual #1571               // Method java/util/ArrayDeque.removeLast:()Ljava/lang/Object;
+        17: pop
+        18: return
+
+  protected void clearMovementThisTick();
+    Code:
+         0: aload_0
+         1: getfield      #543                // Field movementThisTick:Ljava/util/ArrayDeque;
+         4: invokevirtual #1524               // Method java/util/ArrayDeque.clear:()V
+         7: return
+
+  public boolean hasMovedHorizontallyRecently();
+    Code:
+         0: aload_0
+         1: getfield      #534                // Field lastKnownSpeed:Lnet/minecraft/world/phys/Vec3;
+         4: invokevirtual #1467               // Method net/minecraft/world/phys/Vec3.horizontalDistance:()D
+         7: invokestatic  #1324               // Method java/lang/Math.abs:(D)D
+        10: ldc2_w        #1574               // double 9.999999747378752E-6d
+        13: dcmpl
+        14: ifle          21
+        17: iconst_1
+        18: goto          22
+        21: iconst_0
+        22: ireturn
+
+  public void applyEffectsFromBlocks(net.minecraft.world.phys.Vec3, net.minecraft.world.phys.Vec3);
+    Code:
+         0: aload_0
+         1: new           #44                 // class net/minecraft/world/entity/Entity$Movement
+         4: dup
+         5: aload_1
+         6: aload_2
+         7: invokespecial #1531               // Method net/minecraft/world/entity/Entity$Movement."<init>":(Lnet/minecraft/world/phys/Vec3;Lnet/minecraft/world/phys/Vec3;)V
+        10: invokestatic  #1578               // InterfaceMethod java/util/List.of:(Ljava/lang/Object;)Ljava/util/List;
+        13: invokevirtual #1547               // Method applyEffectsFromBlocks:(Ljava/util/List;)V
+        16: return
+
+  private void applyEffectsFromBlocks(java.util.List<net.minecraft.world.entity.Entity$Movement>);
+    Code:
+         0: aload_0
+         1: invokevirtual #1583               // Method isAffectedByBlocks:()Z
+         4: ifne          8
+         7: return
+         8: aload_0
+         9: invokevirtual #1341               // Method onGround:()Z
+        12: ifeq          43
+        15: aload_0
+        16: invokevirtual #1335               // Method getOnPosLegacy:()Lnet/minecraft/core/BlockPos;
+        19: astore_2
+        20: aload_0
+        21: invokevirtual #672                // Method level:()Lnet/minecraft/world/level/Level;
+        24: aload_2
+        25: invokevirtual #1339               // Method net/minecraft/world/level/Level.getBlockState:(Lnet/minecraft/core/BlockPos;)Lnet/minecraft/world/level/block/state/BlockState;
+        28: astore_3
+        29: aload_3
+        30: invokevirtual #1417               // Method net/minecraft/world/level/block/state/BlockState.getBlock:()Lnet/minecraft/world/level/block/Block;
+        33: aload_0
+        34: invokevirtual #672                // Method level:()Lnet/minecraft/world/level/Level;
+        37: aload_2
+        38: aload_3
+        39: aload_0
+        40: invokevirtual #1587               // Method net/minecraft/world/level/block/Block.stepOn:(Lnet/minecraft/world/level/Level;Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/level/block/state/BlockState;Lnet/minecraft/world/entity/Entity;)V
+        43: aload_0
+        44: invokevirtual #1590               // Method isOnFire:()Z
+        47: istore_2
+        48: aload_0
+        49: invokevirtual #1593               // Method isFreezing:()Z
+        52: istore_3
+        53: aload_0
+        54: invokevirtual #1148               // Method getRemainingFireTicks:()I
+        57: istore        4
+        59: aload_0
+        60: aload_1
+        61: aload_0
+        62: getfield      #556                // Field insideEffectCollector:Lnet/minecraft/world/entity/InsideBlockEffectApplier$StepBasedCollector;
+        65: invokevirtual #1597               // Method checkInsideBlocks:(Ljava/util/List;Lnet/minecraft/world/entity/InsideBlockEffectApplier$StepBasedCollector;)V
+        68: aload_0
+        69: getfield      #556                // Field insideEffectCollector:Lnet/minecraft/world/entity/InsideBlockEffectApplier$StepBasedCollector;
+        72: aload_0
+        73: invokevirtual #1600               // Method net/minecraft/world/entity/InsideBlockEffectApplier$StepBasedCollector.applyAndClear:(Lnet/minecraft/world/entity/Entity;)V
+        76: aload_0
+        77: invokevirtual #1603               // Method isInRain:()Z
+        80: ifeq          87
+        83: aload_0
+        84: invokevirtual #1024               // Method clearFire:()V
+        87: iload_2
+        88: ifeq          98
+        91: aload_0
+        92: invokevirtual #1590               // Method isOnFire:()Z
+        95: ifeq          109
+        98: iload_3
+        99: ifeq          113
+       102: aload_0
+       103: invokevirtual #1593               // Method isFreezing:()Z
+       106: ifne          113
+       109: aload_0
+       110: invokevirtual #1606               // Method playEntityOnFireExtinguishedSound:()V
+       113: aload_0
+       114: invokevirtual #1148               // Method getRemainingFireTicks:()I
+       117: iload         4
+       119: if_icmple     126
+       122: iconst_1
+       123: goto          127
+       126: iconst_0
+       127: istore        5
+       129: aload_0
+       130: invokevirtual #672                // Method level:()Lnet/minecraft/world/level/Level;
+       133: invokevirtual #1054               // Method net/minecraft/world/level/Level.isClientSide:()Z
+       136: ifne          160
+       139: aload_0
+       140: invokevirtual #1590               // Method isOnFire:()Z
+       143: ifne          160
+       146: iload         5
+       148: ifne          160
+       151: aload_0
+       152: aload_0
+       153: invokevirtual #1609               // Method getFireImmuneTicks:()I
+       156: ineg
+       157: invokevirtual #1044               // Method setRemainingFireTicks:(I)V
+       160: return
+
+  protected boolean isAffectedByBlocks();
+    Code:
+         0: aload_0
+         1: invokevirtual #744                // Method isRemoved:()Z
+         4: ifne          18
+         7: aload_0
+         8: getfield      #1231               // Field noPhysics:Z
+        11: ifne          18
+        14: iconst_1
+        15: goto          19
+        18: iconst_0
+        19: ireturn
+
+  private boolean isStateClimbable(net.minecraft.world.level.block.state.BlockState);
+    Code:
+         0: aload_1
+         1: getstatic     #1616               // Field net/minecraft/tags/BlockTags.CLIMBABLE:Lnet/minecraft/tags/TagKey;
+         4: invokevirtual #1413               // Method net/minecraft/world/level/block/state/BlockState.is:(Lnet/minecraft/tags/TagKey;)Z
+         7: ifne          20
+        10: aload_1
+        11: getstatic     #1621               // Field net/minecraft/world/level/block/Blocks.POWDER_SNOW:Lnet/minecraft/world/level/block/Block;
+        14: invokevirtual #1623               // Method net/minecraft/world/level/block/state/BlockState.is:(Ljava/lang/Object;)Z
+        17: ifeq          24
+        20: iconst_1
+        21: goto          25
+        24: iconst_0
+        25: ireturn
+
+  private boolean vibrationAndSoundEffectsFromBlock(net.minecraft.core.BlockPos, net.minecraft.world.level.block.state.BlockState, boolean, boolean, net.minecraft.world.phys.Vec3);
+    Code:
+         0: aload_2
+         1: invokevirtual #1481               // Method net/minecraft/world/level/block/state/BlockState.isAir:()Z
+         4: ifeq          9
+         7: iconst_0
+         8: ireturn
+         9: aload_0
+        10: aload_2
+        11: invokevirtual #1474               // Method isStateClimbable:(Lnet/minecraft/world/level/block/state/BlockState;)Z
+        14: istore        6
+        16: aload_0
+        17: invokevirtual #1341               // Method onGround:()Z
+        20: ifne          52
+        23: iload         6
+        25: ifne          52
+        28: aload_0
+        29: invokevirtual #1629               // Method isCrouching:()Z
+        32: ifeq          45
+        35: aload         5
+        37: getfield      #934                // Field net/minecraft/world/phys/Vec3.y:D
+        40: dconst_0
+        41: dcmpl
+        42: ifeq          52
+        45: aload_0
+        46: invokevirtual #1632               // Method isOnRails:()Z
+        49: ifeq          95
+        52: aload_0
+        53: invokevirtual #1635               // Method isSwimming:()Z
+        56: ifne          95
+        59: iload_3
+        60: ifeq          69
+        63: aload_0
+        64: aload_1
+        65: aload_2
+        66: invokevirtual #1639               // Method walkingStepSound:(Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/level/block/state/BlockState;)V
+        69: iload         4
+        71: ifeq          93
+        74: aload_0
+        75: invokevirtual #672                // Method level:()Lnet/minecraft/world/level/Level;
+        78: getstatic     #1642               // Field net/minecraft/world/level/gameevent/GameEvent.STEP:Lnet/minecraft/core/Holder$Reference;
+        81: aload_0
+        82: invokevirtual #870                // Method position:()Lnet/minecraft/world/phys/Vec3;
+        85: aload_0
+        86: aload_2
+        87: invokestatic  #1645               // Method net/minecraft/world/level/gameevent/GameEvent$Context.of:(Lnet/minecraft/world/entity/Entity;Lnet/minecraft/world/level/block/state/BlockState;)Lnet/minecraft/world/level/gameevent/GameEvent$Context;
+        90: invokevirtual #1648               // Method net/minecraft/world/level/Level.gameEvent:(Lnet/minecraft/core/Holder;Lnet/minecraft/world/phys/Vec3;Lnet/minecraft/world/level/gameevent/GameEvent$Context;)V
+        93: iconst_1
+        94: ireturn
+        95: iconst_0
+        96: ireturn
+
+  protected boolean isHorizontalCollisionMinor(net.minecraft.world.phys.Vec3);
+    Code:
+         0: iconst_0
+         1: ireturn
+
+  protected void playEntityOnFireExtinguishedSound();
+    Code:
+         0: aload_0
+         1: getfield      #567                // Field level:Lnet/minecraft/world/level/Level;
+         4: invokevirtual #1054               // Method net/minecraft/world/level/Level.isClientSide:()Z
+         7: ifne          67
+        10: aload_0
+        11: invokevirtual #672                // Method level:()Lnet/minecraft/world/level/Level;
+        14: aconst_null
+        15: aload_0
+        16: invokevirtual #880                // Method getX:()D
+        19: aload_0
+        20: invokevirtual #883                // Method getY:()D
+        23: aload_0
+        24: invokevirtual #886                // Method getZ:()D
+        27: getstatic     #1652               // Field net/minecraft/sounds/SoundEvents.GENERIC_EXTINGUISH_FIRE:Lnet/minecraft/sounds/SoundEvent;
+        30: aload_0
+        31: invokevirtual #1123               // Method getSoundSource:()Lnet/minecraft/sounds/SoundSource;
+        34: ldc_w         #1653               // float 0.7f
+        37: ldc_w         #1654               // float 1.6f
+        40: aload_0
+        41: getfield      #461                // Field random:Lnet/minecraft/util/RandomSource;
+        44: invokeinterface #1127,  1         // InterfaceMethod net/minecraft/util/RandomSource.nextFloat:()F
+        49: aload_0
+        50: getfield      #461                // Field random:Lnet/minecraft/util/RandomSource;
+        53: invokeinterface #1127,  1         // InterfaceMethod net/minecraft/util/RandomSource.nextFloat:()F
+        58: fsub
+        59: ldc_w         #1124               // float 0.4f
+        62: fmul
+        63: fadd
+        64: invokevirtual #1655               // Method net/minecraft/world/level/Level.playSound:(Lnet/minecraft/world/entity/Entity;DDDLnet/minecraft/sounds/SoundEvent;Lnet/minecraft/sounds/SoundSource;FF)V
+        67: return
+
+  public void extinguishFire();
+    Code:
+         0: aload_0
+         1: invokevirtual #1590               // Method isOnFire:()Z
+         4: ifeq          11
+         7: aload_0
+         8: invokevirtual #1606               // Method playEntityOnFireExtinguishedSound:()V
+        11: aload_0
+        12: invokevirtual #1024               // Method clearFire:()V
+        15: return
+
+  protected void processFlappingMovement();
+    Code:
+         0: aload_0
+         1: invokevirtual #1659               // Method isFlapping:()Z
+         4: ifeq          28
+         7: aload_0
+         8: invokevirtual #1662               // Method onFlap:()V
+        11: aload_0
+        12: invokevirtual #1356               // Method getMovementEmission:()Lnet/minecraft/world/entity/Entity$MovementEmission;
+        15: invokevirtual #1491               // Method net/minecraft/world/entity/Entity$MovementEmission.emitsEvents:()Z
+        18: ifeq          28
+        21: aload_0
+        22: getstatic     #1665               // Field net/minecraft/world/level/gameevent/GameEvent.FLAP:Lnet/minecraft/core/Holder$Reference;
+        25: invokevirtual #828                // Method gameEvent:(Lnet/minecraft/core/Holder;)V
+        28: return
+
+  public net.minecraft.core.BlockPos getOnPosLegacy();
+    Code:
+         0: aload_0
+         1: ldc           #255                // float 0.2f
+         3: invokevirtual #1669               // Method getOnPos:(F)Lnet/minecraft/core/BlockPos;
+         6: areturn
+
+  public net.minecraft.core.BlockPos getBlockPosBelowThatAffectsMyMovement();
+    Code:
+         0: aload_0
+         1: ldc_w         #1671               // float 0.500001f
+         4: invokevirtual #1669               // Method getOnPos:(F)Lnet/minecraft/core/BlockPos;
+         7: areturn
+
+  public net.minecraft.core.BlockPos getOnPos();
+    Code:
+         0: aload_0
+         1: ldc_w         #1672               // float 1.0E-5f
+         4: invokevirtual #1669               // Method getOnPos:(F)Lnet/minecraft/core/BlockPos;
+         7: areturn
+
+  protected net.minecraft.core.BlockPos getOnPos(float);
+    Code:
+         0: aload_0
+         1: getfield      #530                // Field mainSupportingBlockPos:Ljava/util/Optional;
+         4: invokevirtual #724                // Method java/util/Optional.isPresent:()Z
+         7: ifeq          99
+        10: aload_0
+        11: getfield      #530                // Field mainSupportingBlockPos:Ljava/util/Optional;
+        14: invokevirtual #728                // Method java/util/Optional.get:()Ljava/lang/Object;
+        17: checkcast     #122                // class net/minecraft/core/BlockPos
+        20: astore_2
+        21: fload_1
+        22: ldc_w         #1672               // float 1.0E-5f
+        25: fcmpl
+        26: ifle          97
+        29: aload_0
+        30: invokevirtual #672                // Method level:()Lnet/minecraft/world/level/Level;
+        33: aload_2
+        34: invokevirtual #1339               // Method net/minecraft/world/level/Level.getBlockState:(Lnet/minecraft/core/BlockPos;)Lnet/minecraft/world/level/block/state/BlockState;
+        37: astore_3
+        38: fload_1
+        39: f2d
+        40: ldc2_w        #1047               // double 0.5d
+        43: dcmpg
+        44: ifgt          57
+        47: aload_3
+        48: getstatic     #1676               // Field net/minecraft/tags/BlockTags.FENCES:Lnet/minecraft/tags/TagKey;
+        51: invokevirtual #1413               // Method net/minecraft/world/level/block/state/BlockState.is:(Lnet/minecraft/tags/TagKey;)Z
+        54: ifne          77
+        57: aload_3
+        58: getstatic     #1679               // Field net/minecraft/tags/BlockTags.WALLS:Lnet/minecraft/tags/TagKey;
+        61: invokevirtual #1413               // Method net/minecraft/world/level/block/state/BlockState.is:(Lnet/minecraft/tags/TagKey;)Z
+        64: ifne          77
+        67: aload_3
+        68: invokevirtual #1417               // Method net/minecraft/world/level/block/state/BlockState.getBlock:()Lnet/minecraft/world/level/block/Block;
+        71: instanceof    #1681               // class net/minecraft/world/level/block/FenceGateBlock
+        74: ifeq          79
+        77: aload_2
+        78: areturn
+        79: aload_2
+        80: aload_0
+        81: getfield      #583                // Field position:Lnet/minecraft/world/phys/Vec3;
+        84: getfield      #934                // Field net/minecraft/world/phys/Vec3.y:D
+        87: fload_1
+        88: f2d
+        89: dsub
+        90: invokestatic  #1684               // Method net/minecraft/util/Mth.floor:(D)I
+        93: invokevirtual #1688               // Method net/minecraft/core/BlockPos.atY:(I)Lnet/minecraft/core/BlockPos;
+        96: areturn
+        97: aload_2
+        98: areturn
+        99: aload_0
+       100: getfield      #583                // Field position:Lnet/minecraft/world/phys/Vec3;
+       103: getfield      #932                // Field net/minecraft/world/phys/Vec3.x:D
+       106: invokestatic  #1684               // Method net/minecraft/util/Mth.floor:(D)I
+       109: istore_2
+       110: aload_0
+       111: getfield      #583                // Field position:Lnet/minecraft/world/phys/Vec3;
+       114: getfield      #934                // Field net/minecraft/world/phys/Vec3.y:D
+       117: fload_1
+       118: f2d
+       119: dsub
+       120: invokestatic  #1684               // Method net/minecraft/util/Mth.floor:(D)I
+       123: istore_3
+       124: aload_0
+       125: getfield      #583                // Field position:Lnet/minecraft/world/phys/Vec3;
+       128: getfield      #936                // Field net/minecraft/world/phys/Vec3.z:D
+       131: invokestatic  #1684               // Method net/minecraft/util/Mth.floor:(D)I
+       134: istore        4
+       136: new           #122                // class net/minecraft/core/BlockPos
+       139: dup
+       140: iload_2
+       141: iload_3
+       142: iload         4
+       144: invokespecial #1691               // Method net/minecraft/core/BlockPos."<init>":(III)V
+       147: areturn
+
+  protected float getBlockJumpFactor();
+    Code:
+         0: aload_0
+         1: invokevirtual #672                // Method level:()Lnet/minecraft/world/level/Level;
+         4: aload_0
+         5: invokevirtual #1698               // Method blockPosition:()Lnet/minecraft/core/BlockPos;
+         8: invokevirtual #1339               // Method net/minecraft/world/level/Level.getBlockState:(Lnet/minecraft/core/BlockPos;)Lnet/minecraft/world/level/block/state/BlockState;
+        11: invokevirtual #1417               // Method net/minecraft/world/level/block/state/BlockState.getBlock:()Lnet/minecraft/world/level/block/Block;
+        14: invokevirtual #1701               // Method net/minecraft/world/level/block/Block.getJumpFactor:()F
+        17: fstore_1
+        18: aload_0
+        19: invokevirtual #672                // Method level:()Lnet/minecraft/world/level/Level;
+        22: aload_0
+        23: invokevirtual #1703               // Method getBlockPosBelowThatAffectsMyMovement:()Lnet/minecraft/core/BlockPos;
+        26: invokevirtual #1339               // Method net/minecraft/world/level/Level.getBlockState:(Lnet/minecraft/core/BlockPos;)Lnet/minecraft/world/level/block/state/BlockState;
+        29: invokevirtual #1417               // Method net/minecraft/world/level/block/state/BlockState.getBlock:()Lnet/minecraft/world/level/block/Block;
+        32: invokevirtual #1701               // Method net/minecraft/world/level/block/Block.getJumpFactor:()F
+        35: fstore_2
+        36: fload_1
+        37: f2d
+        38: dconst_1
+        39: dcmpl
+        40: ifne          47
+        43: fload_2
+        44: goto          48
+        47: fload_1
+        48: freturn
+
+  protected float getBlockSpeedFactor();
+    Code:
+         0: aload_0
+         1: invokevirtual #672                // Method level:()Lnet/minecraft/world/level/Level;
+         4: aload_0
+         5: invokevirtual #1698               // Method blockPosition:()Lnet/minecraft/core/BlockPos;
+         8: invokevirtual #1339               // Method net/minecraft/world/level/Level.getBlockState:(Lnet/minecraft/core/BlockPos;)Lnet/minecraft/world/level/block/state/BlockState;
+        11: astore_1
+        12: aload_1
+        13: invokevirtual #1417               // Method net/minecraft/world/level/block/state/BlockState.getBlock:()Lnet/minecraft/world/level/block/Block;
+        16: invokevirtual #1708               // Method net/minecraft/world/level/block/Block.getSpeedFactor:()F
+        19: fstore_2
+        20: aload_1
+        21: getstatic     #1710               // Field net/minecraft/world/level/block/Blocks.WATER:Lnet/minecraft/world/level/block/Block;
+        24: invokevirtual #1623               // Method net/minecraft/world/level/block/state/BlockState.is:(Ljava/lang/Object;)Z
+        27: ifne          40
+        30: aload_1
+        31: getstatic     #1713               // Field net/minecraft/world/level/block/Blocks.BUBBLE_COLUMN:Lnet/minecraft/world/level/block/Block;
+        34: invokevirtual #1623               // Method net/minecraft/world/level/block/state/BlockState.is:(Ljava/lang/Object;)Z
+        37: ifeq          42
+        40: fload_2
+        41: freturn
+        42: fload_2
+        43: f2d
+        44: dconst_1
+        45: dcmpl
+        46: ifne          69
+        49: aload_0
+        50: invokevirtual #672                // Method level:()Lnet/minecraft/world/level/Level;
+        53: aload_0
+        54: invokevirtual #1703               // Method getBlockPosBelowThatAffectsMyMovement:()Lnet/minecraft/core/BlockPos;
+        57: invokevirtual #1339               // Method net/minecraft/world/level/Level.getBlockState:(Lnet/minecraft/core/BlockPos;)Lnet/minecraft/world/level/block/state/BlockState;
+        60: invokevirtual #1417               // Method net/minecraft/world/level/block/state/BlockState.getBlock:()Lnet/minecraft/world/level/block/Block;
+        63: invokevirtual #1708               // Method net/minecraft/world/level/block/Block.getSpeedFactor:()F
+        66: goto          70
+        69: fload_2
+        70: freturn
+
+  protected net.minecraft.world.phys.Vec3 maybeBackOffFromEdge(net.minecraft.world.phys.Vec3, net.minecraft.world.entity.MoverType);
+    Code:
+         0: aload_1
+         1: areturn
+
+  protected net.minecraft.world.phys.Vec3 limitPistonMovement(net.minecraft.world.phys.Vec3);
+    Code:
+         0: aload_1
+         1: invokevirtual #1251               // Method net/minecraft/world/phys/Vec3.lengthSqr:()D
+         4: ldc2_w        #1252               // double 1.0E-7d
+         7: dcmpg
+         8: ifgt          13
+        11: aload_1
+        12: areturn
+        13: aload_0
+        14: invokevirtual #672                // Method level:()Lnet/minecraft/world/level/Level;
+        17: invokevirtual #1719               // Method net/minecraft/world/level/Level.getGameTime:()J
+        20: lstore_2
+        21: lload_2
+        22: aload_0
+        23: getfield      #1721               // Field pistonDeltasGameTime:J
+        26: lcmp
+        27: ifeq          43
+        30: aload_0
+        31: getfield      #522                // Field pistonDeltas:[D
+        34: dconst_0
+        35: invokestatic  #1727               // Method java/util/Arrays.fill:([DD)V
+        38: aload_0
+        39: lload_2
+        40: putfield      #1721               // Field pistonDeltasGameTime:J
+        43: aload_1
+        44: getfield      #932                // Field net/minecraft/world/phys/Vec3.x:D
+        47: dconst_0
+        48: dcmpl
+        49: ifeq          95
+        52: aload_0
+        53: getstatic     #1396               // Field net/minecraft/core/Direction$Axis.X:Lnet/minecraft/core/Direction$Axis;
+        56: aload_1
+        57: getfield      #932                // Field net/minecraft/world/phys/Vec3.x:D
+        60: invokevirtual #1731               // Method applyPistonMovementRestriction:(Lnet/minecraft/core/Direction$Axis;D)D
+        63: dstore        4
+        65: dload         4
+        67: invokestatic  #1324               // Method java/lang/Math.abs:(D)D
+        70: ldc2_w        #1574               // double 9.999999747378752E-6d
+        73: dcmpg
+        74: ifgt          83
+        77: getstatic     #443                // Field net/minecraft/world/phys/Vec3.ZERO:Lnet/minecraft/world/phys/Vec3;
+        80: goto          94
+        83: new           #440                // class net/minecraft/world/phys/Vec3
+        86: dup
+        87: dload         4
+        89: dconst_0
+        90: dconst_0
+        91: invokespecial #765                // Method net/minecraft/world/phys/Vec3."<init>":(DDD)V
+        94: areturn
+        95: aload_1
+        96: getfield      #934                // Field net/minecraft/world/phys/Vec3.y:D
+        99: dconst_0
+       100: dcmpl
+       101: ifeq          147
+       104: aload_0
+       105: getstatic     #1434               // Field net/minecraft/core/Direction$Axis.Y:Lnet/minecraft/core/Direction$Axis;
+       108: aload_1
+       109: getfield      #934                // Field net/minecraft/world/phys/Vec3.y:D
+       112: invokevirtual #1731               // Method applyPistonMovementRestriction:(Lnet/minecraft/core/Direction$Axis;D)D
+       115: dstore        4
+       117: dload         4
+       119: invokestatic  #1324               // Method java/lang/Math.abs:(D)D
+       122: ldc2_w        #1574               // double 9.999999747378752E-6d
+       125: dcmpg
+       126: ifgt          135
+       129: getstatic     #443                // Field net/minecraft/world/phys/Vec3.ZERO:Lnet/minecraft/world/phys/Vec3;
+       132: goto          146
+       135: new           #440                // class net/minecraft/world/phys/Vec3
+       138: dup
+       139: dconst_0
+       140: dload         4
+       142: dconst_0
+       143: invokespecial #765                // Method net/minecraft/world/phys/Vec3."<init>":(DDD)V
+       146: areturn
+       147: aload_1
+       148: getfield      #936                // Field net/minecraft/world/phys/Vec3.z:D
+       151: dconst_0
+       152: dcmpl
+       153: ifeq          199
+       156: aload_0
+       157: getstatic     #1402               // Field net/minecraft/core/Direction$Axis.Z:Lnet/minecraft/core/Direction$Axis;
+       160: aload_1
+       161: getfield      #936                // Field net/minecraft/world/phys/Vec3.z:D
+       164: invokevirtual #1731               // Method applyPistonMovementRestriction:(Lnet/minecraft/core/Direction$Axis;D)D
+       167: dstore        4
+       169: dload         4
+       171: invokestatic  #1324               // Method java/lang/Math.abs:(D)D
+       174: ldc2_w        #1574               // double 9.999999747378752E-6d
+       177: dcmpg
+       178: ifgt          187
+       181: getstatic     #443                // Field net/minecraft/world/phys/Vec3.ZERO:Lnet/minecraft/world/phys/Vec3;
+       184: goto          198
+       187: new           #440                // class net/minecraft/world/phys/Vec3
+       190: dup
+       191: dconst_0
+       192: dconst_0
+       193: dload         4
+       195: invokespecial #765                // Method net/minecraft/world/phys/Vec3."<init>":(DDD)V
+       198: areturn
+       199: getstatic     #443                // Field net/minecraft/world/phys/Vec3.ZERO:Lnet/minecraft/world/phys/Vec3;
+       202: areturn
+
+  private double applyPistonMovementRestriction(net.minecraft.core.Direction$Axis, double);
+    Code:
+         0: aload_1
+         1: invokevirtual #1737               // Method net/minecraft/core/Direction$Axis.ordinal:()I
+         4: istore        4
+         6: dload_2
+         7: aload_0
+         8: getfield      #522                // Field pistonDeltas:[D
+        11: iload         4
+        13: daload
+        14: dadd
+        15: ldc2_w        #1738               // double -0.51d
+        18: ldc2_w        #1740               // double 0.51d
+        21: invokestatic  #1743               // Method net/minecraft/util/Mth.clamp:(DDD)D
+        24: dstore        5
+        26: dload         5
+        28: aload_0
+        29: getfield      #522                // Field pistonDeltas:[D
+        32: iload         4
+        34: daload
+        35: dsub
+        36: dstore_2
+        37: aload_0
+        38: getfield      #522                // Field pistonDeltas:[D
+        41: iload         4
+        43: dload         5
+        45: dastore
+        46: dload_2
+        47: dreturn
+
+  public double getAvailableSpaceBelow(double);
+    Code:
+         0: aload_0
+         1: invokevirtual #693                // Method getBoundingBox:()Lnet/minecraft/world/phys/AABB;
+         4: astore_3
+         5: aload_3
+         6: aload_3
+         7: getfield      #1201               // Field net/minecraft/world/phys/AABB.minY:D
+        10: dload_1
+        11: dsub
+        12: invokevirtual #1749               // Method net/minecraft/world/phys/AABB.setMinY:(D)Lnet/minecraft/world/phys/AABB;
+        15: aload_3
+        16: getfield      #1201               // Field net/minecraft/world/phys/AABB.minY:D
+        19: invokevirtual #1752               // Method net/minecraft/world/phys/AABB.setMaxY:(D)Lnet/minecraft/world/phys/AABB;
+        22: astore        4
+        24: aload_0
+        25: aload_0
+        26: getfield      #567                // Field level:Lnet/minecraft/world/level/Level;
+        29: aload         4
+        31: invokestatic  #1756               // Method collectAllColliders:(Lnet/minecraft/world/entity/Entity;Lnet/minecraft/world/level/Level;Lnet/minecraft/world/phys/AABB;)Ljava/util/List;
+        34: astore        5
+        36: aload         5
+        38: invokeinterface #1525,  1         // InterfaceMethod java/util/List.isEmpty:()Z
+        43: ifeq          48
+        46: dload_1
+        47: dreturn
+        48: getstatic     #1434               // Field net/minecraft/core/Direction$Axis.Y:Lnet/minecraft/core/Direction$Axis;
+        51: aload_3
+        52: aload         5
+        54: dload_1
+        55: dneg
+        56: invokestatic  #1759               // Method net/minecraft/world/phys/shapes/Shapes.collide:(Lnet/minecraft/core/Direction$Axis;Lnet/minecraft/world/phys/AABB;Ljava/lang/Iterable;D)D
+        59: dneg
+        60: dreturn
+
+  private net.minecraft.world.phys.Vec3 collide(net.minecraft.world.phys.Vec3);
+    Code:
+         0: aload_0
+         1: invokevirtual #693                // Method getBoundingBox:()Lnet/minecraft/world/phys/AABB;
+         4: astore_2
+         5: aload_0
+         6: invokevirtual #672                // Method level:()Lnet/minecraft/world/level/Level;
+         9: aload_0
+        10: aload_2
+        11: aload_1
+        12: invokevirtual #1766               // Method net/minecraft/world/phys/AABB.expandTowards:(Lnet/minecraft/world/phys/Vec3;)Lnet/minecraft/world/phys/AABB;
+        15: invokevirtual #1770               // Method net/minecraft/world/level/Level.getEntityCollisions:(Lnet/minecraft/world/entity/Entity;Lnet/minecraft/world/phys/AABB;)Ljava/util/List;
+        18: astore_3
+        19: aload_1
+        20: invokevirtual #1251               // Method net/minecraft/world/phys/Vec3.lengthSqr:()D
+        23: dconst_0
+        24: dcmpl
+        25: ifne          32
+        28: aload_1
+        29: goto          43
+        32: aload_0
+        33: aload_1
+        34: aload_2
+        35: aload_0
+        36: invokevirtual #672                // Method level:()Lnet/minecraft/world/level/Level;
+        39: aload_3
+        40: invokestatic  #1774               // Method collideBoundingBox:(Lnet/minecraft/world/entity/Entity;Lnet/minecraft/world/phys/Vec3;Lnet/minecraft/world/phys/AABB;Lnet/minecraft/world/level/Level;Ljava/util/List;)Lnet/minecraft/world/phys/Vec3;
+        43: astore        4
+        45: aload_1
+        46: getfield      #932                // Field net/minecraft/world/phys/Vec3.x:D
+        49: aload         4
+        51: getfield      #932                // Field net/minecraft/world/phys/Vec3.x:D
+        54: dcmpl
+        55: ifeq          62
+        58: iconst_1
+        59: goto          63
+        62: iconst_0
+        63: istore        5
+        65: aload_1
+        66: getfield      #934                // Field net/minecraft/world/phys/Vec3.y:D
+        69: aload         4
+        71: getfield      #934                // Field net/minecraft/world/phys/Vec3.y:D
+        74: dcmpl
+        75: ifeq          82
+        78: iconst_1
+        79: goto          83
+        82: iconst_0
+        83: istore        6
+        85: aload_1
+        86: getfield      #936                // Field net/minecraft/world/phys/Vec3.z:D
+        89: aload         4
+        91: getfield      #936                // Field net/minecraft/world/phys/Vec3.z:D
+        94: dcmpl
+        95: ifeq          102
+        98: iconst_1
+        99: goto          103
+       102: iconst_0
+       103: istore        7
+       105: iload         6
+       107: ifeq          123
+       110: aload_1
+       111: getfield      #934                // Field net/minecraft/world/phys/Vec3.y:D
+       114: dconst_0
+       115: dcmpg
+       116: ifge          123
+       119: iconst_1
+       120: goto          124
+       123: iconst_0
+       124: istore        8
+       126: aload_0
+       127: invokevirtual #1777               // Method maxUpStep:()F
+       130: fconst_0
+       131: fcmpl
+       132: ifle          347
+       135: iload         8
+       137: ifne          147
+       140: aload_0
+       141: invokevirtual #1341               // Method onGround:()Z
+       144: ifeq          347
+       147: iload         5
+       149: ifne          157
+       152: iload         7
+       154: ifeq          347
+       157: iload         8
+       159: ifeq          176
+       162: aload_2
+       163: dconst_0
+       164: aload         4
+       166: getfield      #934                // Field net/minecraft/world/phys/Vec3.y:D
+       169: dconst_0
+       170: invokevirtual #1166               // Method net/minecraft/world/phys/AABB.move:(DDD)Lnet/minecraft/world/phys/AABB;
+       173: goto          177
+       176: aload_2
+       177: astore        9
+       179: aload         9
+       181: aload_1
+       182: getfield      #932                // Field net/minecraft/world/phys/Vec3.x:D
+       185: aload_0
+       186: invokevirtual #1777               // Method maxUpStep:()F
+       189: f2d
+       190: aload_1
+       191: getfield      #936                // Field net/minecraft/world/phys/Vec3.z:D
+       194: invokevirtual #1779               // Method net/minecraft/world/phys/AABB.expandTowards:(DDD)Lnet/minecraft/world/phys/AABB;
+       197: astore        10
+       199: iload         8
+       201: ifne          216
+       204: aload         10
+       206: dconst_0
+       207: ldc2_w        #1780               // double -9.999999747378752E-6d
+       210: dconst_0
+       211: invokevirtual #1779               // Method net/minecraft/world/phys/AABB.expandTowards:(DDD)Lnet/minecraft/world/phys/AABB;
+       214: astore        10
+       216: aload_0
+       217: aload_0
+       218: getfield      #567                // Field level:Lnet/minecraft/world/level/Level;
+       221: aload_3
+       222: aload         10
+       224: invokestatic  #1785               // Method collectCollidersIgnoringWorldBorder:(Lnet/minecraft/world/entity/Entity;Lnet/minecraft/world/level/Level;Ljava/util/List;Lnet/minecraft/world/phys/AABB;)Ljava/util/List;
+       227: astore        11
+       229: aload         4
+       231: getfield      #934                // Field net/minecraft/world/phys/Vec3.y:D
+       234: d2f
+       235: fstore        12
+       237: aload         9
+       239: aload         11
+       241: aload_0
+       242: invokevirtual #1777               // Method maxUpStep:()F
+       245: fload         12
+       247: invokestatic  #1789               // Method collectCandidateStepUpHeights:(Lnet/minecraft/world/phys/AABB;Ljava/util/List;FF)[F
+       250: astore        13
+       252: aload         13
+       254: astore        14
+       256: aload         14
+       258: arraylength
+       259: istore        15
+       261: iconst_0
+       262: istore        16
+       264: iload         16
+       266: iload         15
+       268: if_icmpge     347
+       271: aload         14
+       273: iload         16
+       275: faload
+       276: fstore        17
+       278: new           #440                // class net/minecraft/world/phys/Vec3
+       281: dup
+       282: aload_1
+       283: getfield      #932                // Field net/minecraft/world/phys/Vec3.x:D
+       286: fload         17
+       288: f2d
+       289: aload_1
+       290: getfield      #936                // Field net/minecraft/world/phys/Vec3.z:D
+       293: invokespecial #765                // Method net/minecraft/world/phys/Vec3."<init>":(DDD)V
+       296: aload         9
+       298: aload         11
+       300: invokestatic  #1795               // Method collideWithShapes:(Lnet/minecraft/world/phys/Vec3;Lnet/minecraft/world/phys/AABB;Ljava/util/List;)Lnet/minecraft/world/phys/Vec3;
+       303: astore        18
+       305: aload         18
+       307: invokevirtual #1798               // Method net/minecraft/world/phys/Vec3.horizontalDistanceSqr:()D
+       310: aload         4
+       312: invokevirtual #1798               // Method net/minecraft/world/phys/Vec3.horizontalDistanceSqr:()D
+       315: dcmpl
+       316: ifle          341
+       319: aload_2
+       320: getfield      #1201               // Field net/minecraft/world/phys/AABB.minY:D
+       323: aload         9
+       325: getfield      #1201               // Field net/minecraft/world/phys/AABB.minY:D
+       328: dsub
+       329: dstore        19
+       331: aload         18
+       333: dconst_0
+       334: dload         19
+       336: dconst_0
+       337: invokevirtual #1800               // Method net/minecraft/world/phys/Vec3.subtract:(DDD)Lnet/minecraft/world/phys/Vec3;
+       340: areturn
+       341: iinc          16, 1
+       344: goto          264
+       347: aload         4
+       349: areturn
+
+  private static float[] collectCandidateStepUpHeights(net.minecraft.world.phys.AABB, java.util.List<net.minecraft.world.phys.shapes.VoxelShape>, float, float);
+    Code:
+         0: new           #1815               // class it/unimi/dsi/fastutil/floats/FloatArraySet
+         3: dup
+         4: iconst_4
+         5: invokespecial #1816               // Method it/unimi/dsi/fastutil/floats/FloatArraySet."<init>":(I)V
+         8: astore        4
+        10: aload_1
+        11: invokeinterface #1820,  1         // InterfaceMethod java/util/List.iterator:()Ljava/util/Iterator;
+        16: astore        5
+        18: aload         5
+        20: invokeinterface #1827,  1         // InterfaceMethod java/util/Iterator.hasNext:()Z
+        25: ifeq          140
+        28: aload         5
+        30: invokeinterface #1830,  1         // InterfaceMethod java/util/Iterator.next:()Ljava/lang/Object;
+        35: checkcast     #685                // class net/minecraft/world/phys/shapes/VoxelShape
+        38: astore        6
+        40: aload         6
+        42: getstatic     #1434               // Field net/minecraft/core/Direction$Axis.Y:Lnet/minecraft/core/Direction$Axis;
+        45: invokevirtual #1834               // Method net/minecraft/world/phys/shapes/VoxelShape.getCoords:(Lnet/minecraft/core/Direction$Axis;)Lit/unimi/dsi/fastutil/doubles/DoubleList;
+        48: astore        7
+        50: aload         7
+        52: invokeinterface #1839,  1         // InterfaceMethod it/unimi/dsi/fastutil/doubles/DoubleList.iterator:()Lit/unimi/dsi/fastutil/doubles/DoubleListIterator;
+        57: astore        8
+        59: aload         8
+        61: invokeinterface #1827,  1         // InterfaceMethod java/util/Iterator.hasNext:()Z
+        66: ifeq          137
+        69: aload         8
+        71: invokeinterface #1830,  1         // InterfaceMethod java/util/Iterator.next:()Ljava/lang/Object;
+        76: checkcast     #1841               // class java/lang/Double
+        79: invokevirtual #1844               // Method java/lang/Double.doubleValue:()D
+        82: dstore        9
+        84: dload         9
+        86: aload_0
+        87: getfield      #1201               // Field net/minecraft/world/phys/AABB.minY:D
+        90: dsub
+        91: d2f
+        92: fstore        11
+        94: fload         11
+        96: fconst_0
+        97: fcmpg
+        98: ifge          104
+       101: goto          59
+       104: fload         11
+       106: fload_3
+       107: fcmpl
+       108: ifne          114
+       111: goto          59
+       114: fload         11
+       116: fload_2
+       117: fcmpl
+       118: ifle          124
+       121: goto          137
+       124: aload         4
+       126: fload         11
+       128: invokeinterface #1847,  2         // InterfaceMethod it/unimi/dsi/fastutil/floats/FloatSet.add:(F)Z
+       133: pop
+       134: goto          59
+       137: goto          18
+       140: aload         4
+       142: invokeinterface #1851,  1         // InterfaceMethod it/unimi/dsi/fastutil/floats/FloatSet.toFloatArray:()[F
+       147: astore        5
+       149: aload         5
+       151: invokestatic  #1857               // Method it/unimi/dsi/fastutil/floats/FloatArrays.unstableSort:([F)V
+       154: aload         5
+       156: areturn
+
+  public static net.minecraft.world.phys.Vec3 collideBoundingBox(net.minecraft.world.entity.Entity, net.minecraft.world.phys.Vec3, net.minecraft.world.phys.AABB, net.minecraft.world.level.Level, java.util.List<net.minecraft.world.phys.shapes.VoxelShape>);
+    Code:
+         0: aload_0
+         1: aload_3
+         2: aload         4
+         4: aload_2
+         5: aload_1
+         6: invokevirtual #1766               // Method net/minecraft/world/phys/AABB.expandTowards:(Lnet/minecraft/world/phys/Vec3;)Lnet/minecraft/world/phys/AABB;
+         9: invokestatic  #1785               // Method collectCollidersIgnoringWorldBorder:(Lnet/minecraft/world/entity/Entity;Lnet/minecraft/world/level/Level;Ljava/util/List;Lnet/minecraft/world/phys/AABB;)Ljava/util/List;
+        12: astore        5
+        14: aload_1
+        15: aload_2
+        16: aload         5
+        18: invokestatic  #1795               // Method collideWithShapes:(Lnet/minecraft/world/phys/Vec3;Lnet/minecraft/world/phys/AABB;Ljava/util/List;)Lnet/minecraft/world/phys/Vec3;
+        21: areturn
+
+  public static net.minecraft.world.phys.Vec3 collideBoundingBox(net.minecraft.world.phys.shapes.CollisionContext, net.minecraft.world.phys.Vec3, net.minecraft.world.phys.AABB, net.minecraft.world.level.Level, java.util.List<net.minecraft.world.phys.shapes.VoxelShape>);
+    Code:
+         0: aload_0
+         1: aload_3
+         2: aload         4
+         4: aload_2
+         5: aload_1
+         6: invokevirtual #1766               // Method net/minecraft/world/phys/AABB.expandTowards:(Lnet/minecraft/world/phys/Vec3;)Lnet/minecraft/world/phys/AABB;
+         9: invokestatic  #1872               // Method collectCollidersIgnoringWorldBorder:(Lnet/minecraft/world/phys/shapes/CollisionContext;Lnet/minecraft/world/level/Level;Ljava/util/List;Lnet/minecraft/world/phys/AABB;)Ljava/util/List;
+        12: astore        5
+        14: aload_1
+        15: aload_2
+        16: aload         5
+        18: invokestatic  #1795               // Method collideWithShapes:(Lnet/minecraft/world/phys/Vec3;Lnet/minecraft/world/phys/AABB;Ljava/util/List;)Lnet/minecraft/world/phys/Vec3;
+        21: areturn
+
+  public static java.util.List<net.minecraft.world.phys.shapes.VoxelShape> collectAllColliders(net.minecraft.world.entity.Entity, net.minecraft.world.level.Level, net.minecraft.world.phys.AABB);
+    Code:
+         0: aload_1
+         1: aload_0
+         2: aload_2
+         3: invokevirtual #1770               // Method net/minecraft/world/level/Level.getEntityCollisions:(Lnet/minecraft/world/entity/Entity;Lnet/minecraft/world/phys/AABB;)Ljava/util/List;
+         6: astore_3
+         7: aload_0
+         8: aload_1
+         9: aload_3
+        10: aload_2
+        11: invokestatic  #1785               // Method collectCollidersIgnoringWorldBorder:(Lnet/minecraft/world/entity/Entity;Lnet/minecraft/world/level/Level;Ljava/util/List;Lnet/minecraft/world/phys/AABB;)Ljava/util/List;
+        14: areturn
+
+  private static java.util.List<net.minecraft.world.phys.shapes.VoxelShape> collectCollidersIgnoringWorldBorder(net.minecraft.world.entity.Entity, net.minecraft.world.level.Level, java.util.List<net.minecraft.world.phys.shapes.VoxelShape>, net.minecraft.world.phys.AABB);
+    Code:
+         0: aload_2
+         1: invokeinterface #1876,  1         // InterfaceMethod java/util/List.size:()I
+         6: iconst_1
+         7: iadd
+         8: invokestatic  #1880               // Method com/google/common/collect/ImmutableList.builderWithExpectedSize:(I)Lcom/google/common/collect/ImmutableList$Builder;
+        11: astore        4
+        13: aload_2
+        14: invokeinterface #1525,  1         // InterfaceMethod java/util/List.isEmpty:()Z
+        19: ifne          29
+        22: aload         4
+        24: aload_2
+        25: invokevirtual #1883               // Method com/google/common/collect/ImmutableList$Builder.addAll:(Ljava/lang/Iterable;)Lcom/google/common/collect/ImmutableList$Builder;
+        28: pop
+        29: aload_1
+        30: invokevirtual #1887               // Method net/minecraft/world/level/Level.getWorldBorder:()Lnet/minecraft/world/level/border/WorldBorder;
+        33: astore        5
+        35: aload_0
+        36: ifnull        53
+        39: aload         5
+        41: aload_0
+        42: aload_3
+        43: invokevirtual #1892               // Method net/minecraft/world/level/border/WorldBorder.isInsideCloseToBorder:(Lnet/minecraft/world/entity/Entity;Lnet/minecraft/world/phys/AABB;)Z
+        46: ifeq          53
+        49: iconst_1
+        50: goto          54
+        53: iconst_0
+        54: istore        6
+        56: iload         6
+        58: ifeq          72
+        61: aload         4
+        63: aload         5
+        65: invokevirtual #1895               // Method net/minecraft/world/level/border/WorldBorder.getCollisionShape:()Lnet/minecraft/world/phys/shapes/VoxelShape;
+        68: invokevirtual #1898               // Method com/google/common/collect/ImmutableList$Builder.add:(Ljava/lang/Object;)Lcom/google/common/collect/ImmutableList$Builder;
+        71: pop
+        72: aload         4
+        74: aload_1
+        75: aload_0
+        76: aload_3
+        77: invokevirtual #1902               // Method net/minecraft/world/level/Level.getBlockCollisions:(Lnet/minecraft/world/entity/Entity;Lnet/minecraft/world/phys/AABB;)Ljava/lang/Iterable;
+        80: invokevirtual #1883               // Method com/google/common/collect/ImmutableList$Builder.addAll:(Ljava/lang/Iterable;)Lcom/google/common/collect/ImmutableList$Builder;
+        83: pop
+        84: aload         4
+        86: invokevirtual #1904               // Method com/google/common/collect/ImmutableList$Builder.build:()Lcom/google/common/collect/ImmutableList;
+        89: areturn
+
+  private static java.util.List<net.minecraft.world.phys.shapes.VoxelShape> collectCollidersIgnoringWorldBorder(net.minecraft.world.phys.shapes.CollisionContext, net.minecraft.world.level.Level, java.util.List<net.minecraft.world.phys.shapes.VoxelShape>, net.minecraft.world.phys.AABB);
+    Code:
+         0: aload_2
+         1: invokeinterface #1876,  1         // InterfaceMethod java/util/List.size:()I
+         6: iconst_1
+         7: iadd
+         8: invokestatic  #1880               // Method com/google/common/collect/ImmutableList.builderWithExpectedSize:(I)Lcom/google/common/collect/ImmutableList$Builder;
+        11: astore        4
+        13: aload_2
+        14: invokeinterface #1525,  1         // InterfaceMethod java/util/List.isEmpty:()Z
+        19: ifne          29
+        22: aload         4
+        24: aload_2
+        25: invokevirtual #1883               // Method com/google/common/collect/ImmutableList$Builder.addAll:(Ljava/lang/Iterable;)Lcom/google/common/collect/ImmutableList$Builder;
+        28: pop
+        29: aload         4
+        31: aload_1
+        32: aload_0
+        33: aload_3
+        34: invokevirtual #1914               // Method net/minecraft/world/level/Level.getBlockCollisionsFromContext:(Lnet/minecraft/world/phys/shapes/CollisionContext;Lnet/minecraft/world/phys/AABB;)Ljava/lang/Iterable;
+        37: invokevirtual #1883               // Method com/google/common/collect/ImmutableList$Builder.addAll:(Ljava/lang/Iterable;)Lcom/google/common/collect/ImmutableList$Builder;
+        40: pop
+        41: aload         4
+        43: invokevirtual #1904               // Method com/google/common/collect/ImmutableList$Builder.build:()Lcom/google/common/collect/ImmutableList;
+        46: areturn
+
+  private static net.minecraft.world.phys.Vec3 collideWithShapes(net.minecraft.world.phys.Vec3, net.minecraft.world.phys.AABB, java.util.List<net.minecraft.world.phys.shapes.VoxelShape>);
+    Code:
+         0: aload_2
+         1: invokeinterface #1525,  1         // InterfaceMethod java/util/List.isEmpty:()Z
+         6: ifeq          11
+         9: aload_0
+        10: areturn
+        11: getstatic     #443                // Field net/minecraft/world/phys/Vec3.ZERO:Lnet/minecraft/world/phys/Vec3;
+        14: astore_3
+        15: aload_0
+        16: invokestatic  #1920               // Method net/minecraft/core/Direction.axisStepOrder:(Lnet/minecraft/world/phys/Vec3;)Lcom/google/common/collect/ImmutableList;
+        19: invokevirtual #1923               // Method com/google/common/collect/ImmutableList.iterator:()Lcom/google/common/collect/UnmodifiableIterator;
+        22: astore        4
+        24: aload         4
+        26: invokeinterface #1827,  1         // InterfaceMethod java/util/Iterator.hasNext:()Z
+        31: ifeq          91
+        34: aload         4
+        36: invokeinterface #1830,  1         // InterfaceMethod java/util/Iterator.next:()Ljava/lang/Object;
+        41: checkcast     #77                 // class net/minecraft/core/Direction$Axis
+        44: astore        5
+        46: aload_0
+        47: aload         5
+        49: invokevirtual #1926               // Method net/minecraft/world/phys/Vec3.get:(Lnet/minecraft/core/Direction$Axis;)D
+        52: dstore        6
+        54: dload         6
+        56: dconst_0
+        57: dcmpl
+        58: ifne          64
+        61: goto          24
+        64: aload         5
+        66: aload_1
+        67: aload_3
+        68: invokevirtual #1928               // Method net/minecraft/world/phys/AABB.move:(Lnet/minecraft/world/phys/Vec3;)Lnet/minecraft/world/phys/AABB;
+        71: aload_2
+        72: dload         6
+        74: invokestatic  #1759               // Method net/minecraft/world/phys/shapes/Shapes.collide:(Lnet/minecraft/core/Direction$Axis;Lnet/minecraft/world/phys/AABB;Ljava/lang/Iterable;D)D
+        77: dstore        8
+        79: aload_3
+        80: aload         5
+        82: dload         8
+        84: invokevirtual #1400               // Method net/minecraft/world/phys/Vec3.with:(Lnet/minecraft/core/Direction$Axis;D)Lnet/minecraft/world/phys/Vec3;
+        87: astore_3
+        88: goto          24
+        91: aload_3
+        92: areturn
+
+  protected float nextStep();
+    Code:
+         0: aload_0
+         1: getfield      #1476               // Field moveDist:F
+         4: f2i
+         5: iconst_1
+         6: iadd
+         7: i2f
+         8: freturn
+
+  protected net.minecraft.sounds.SoundEvent getSwimSound();
+    Code:
+         0: getstatic     #1936               // Field net/minecraft/sounds/SoundEvents.GENERIC_SWIM:Lnet/minecraft/sounds/SoundEvent;
+         3: areturn
+
+  protected net.minecraft.sounds.SoundEvent getSwimSplashSound();
+    Code:
+         0: getstatic     #1940               // Field net/minecraft/sounds/SoundEvents.GENERIC_SPLASH:Lnet/minecraft/sounds/SoundEvent;
+         3: areturn
+
+  protected net.minecraft.sounds.SoundEvent getSwimHighSpeedSplashSound();
+    Code:
+         0: getstatic     #1940               // Field net/minecraft/sounds/SoundEvents.GENERIC_SPLASH:Lnet/minecraft/sounds/SoundEvent;
+         3: areturn
+
+  private void checkInsideBlocks(java.util.List<net.minecraft.world.entity.Entity$Movement>, net.minecraft.world.entity.InsideBlockEffectApplier$StepBasedCollector);
+    Code:
+         0: aload_0
+         1: invokevirtual #1583               // Method isAffectedByBlocks:()Z
+         4: ifne          8
+         7: return
+         8: aload_0
+         9: getfield      #553                // Field visitedBlocks:Lit/unimi/dsi/fastutil/longs/LongSet;
+        12: astore_3
+        13: aload_1
+        14: invokeinterface #1820,  1         // InterfaceMethod java/util/List.iterator:()Ljava/util/Iterator;
+        19: astore        4
+        21: aload         4
+        23: invokeinterface #1827,  1         // InterfaceMethod java/util/Iterator.hasNext:()Z
+        28: ifeq          237
+        31: aload         4
+        33: invokeinterface #1830,  1         // InterfaceMethod java/util/Iterator.next:()Ljava/lang/Object;
+        38: checkcast     #44                 // class net/minecraft/world/entity/Entity$Movement
+        41: astore        5
+        43: aload         5
+        45: getfield      #1947               // Field net/minecraft/world/entity/Entity$Movement.from:Lnet/minecraft/world/phys/Vec3;
+        48: astore        6
+        50: aload         5
+        52: invokevirtual #1557               // Method net/minecraft/world/entity/Entity$Movement.to:()Lnet/minecraft/world/phys/Vec3;
+        55: aload         5
+        57: invokevirtual #1555               // Method net/minecraft/world/entity/Entity$Movement.from:()Lnet/minecraft/world/phys/Vec3;
+        60: invokevirtual #1073               // Method net/minecraft/world/phys/Vec3.subtract:(Lnet/minecraft/world/phys/Vec3;)Lnet/minecraft/world/phys/Vec3;
+        63: astore        7
+        65: bipush        16
+        67: istore        8
+        69: aload         5
+        71: invokevirtual #1950               // Method net/minecraft/world/entity/Entity$Movement.axisDependentOriginalMovement:()Ljava/util/Optional;
+        74: invokevirtual #724                // Method java/util/Optional.isPresent:()Z
+        77: ifeq          188
+        80: aload         7
+        82: invokevirtual #1251               // Method net/minecraft/world/phys/Vec3.lengthSqr:()D
+        85: dconst_0
+        86: dcmpl
+        87: ifle          188
+        90: aload         5
+        92: invokevirtual #1950               // Method net/minecraft/world/entity/Entity$Movement.axisDependentOriginalMovement:()Ljava/util/Optional;
+        95: invokevirtual #728                // Method java/util/Optional.get:()Ljava/lang/Object;
+        98: checkcast     #440                // class net/minecraft/world/phys/Vec3
+       101: invokestatic  #1920               // Method net/minecraft/core/Direction.axisStepOrder:(Lnet/minecraft/world/phys/Vec3;)Lcom/google/common/collect/ImmutableList;
+       104: invokevirtual #1923               // Method com/google/common/collect/ImmutableList.iterator:()Lcom/google/common/collect/UnmodifiableIterator;
+       107: astore        9
+       109: aload         9
+       111: invokeinterface #1827,  1         // InterfaceMethod java/util/Iterator.hasNext:()Z
+       116: ifeq          185
+       119: aload         9
+       121: invokeinterface #1830,  1         // InterfaceMethod java/util/Iterator.next:()Ljava/lang/Object;
+       126: checkcast     #77                 // class net/minecraft/core/Direction$Axis
+       129: astore        10
+       131: aload         7
+       133: aload         10
+       135: invokevirtual #1926               // Method net/minecraft/world/phys/Vec3.get:(Lnet/minecraft/core/Direction$Axis;)D
+       138: dstore        11
+       140: dload         11
+       142: dconst_0
+       143: dcmpl
+       144: ifeq          182
+       147: aload         6
+       149: aload         10
+       151: invokevirtual #1954               // Method net/minecraft/core/Direction$Axis.getPositive:()Lnet/minecraft/core/Direction;
+       154: dload         11
+       156: invokevirtual #1958               // Method net/minecraft/world/phys/Vec3.relative:(Lnet/minecraft/core/Direction;D)Lnet/minecraft/world/phys/Vec3;
+       159: astore        13
+       161: iload         8
+       163: aload_0
+       164: aload         6
+       166: aload         13
+       168: aload_2
+       169: aload_3
+       170: iload         8
+       172: invokevirtual #1961               // Method checkInsideBlocks:(Lnet/minecraft/world/phys/Vec3;Lnet/minecraft/world/phys/Vec3;Lnet/minecraft/world/entity/InsideBlockEffectApplier$StepBasedCollector;Lit/unimi/dsi/fastutil/longs/LongSet;I)I
+       175: isub
+       176: istore        8
+       178: aload         13
+       180: astore        6
+       182: goto          109
+       185: goto          211
+       188: iload         8
+       190: aload_0
+       191: aload         5
+       193: invokevirtual #1555               // Method net/minecraft/world/entity/Entity$Movement.from:()Lnet/minecraft/world/phys/Vec3;
+       196: aload         5
+       198: invokevirtual #1557               // Method net/minecraft/world/entity/Entity$Movement.to:()Lnet/minecraft/world/phys/Vec3;
+       201: aload_2
+       202: aload_3
+       203: bipush        16
+       205: invokevirtual #1961               // Method checkInsideBlocks:(Lnet/minecraft/world/phys/Vec3;Lnet/minecraft/world/phys/Vec3;Lnet/minecraft/world/entity/InsideBlockEffectApplier$StepBasedCollector;Lit/unimi/dsi/fastutil/longs/LongSet;I)I
+       208: isub
+       209: istore        8
+       211: iload         8
+       213: ifgt          234
+       216: aload_0
+       217: aload         5
+       219: invokevirtual #1557               // Method net/minecraft/world/entity/Entity$Movement.to:()Lnet/minecraft/world/phys/Vec3;
+       222: aload         5
+       224: invokevirtual #1557               // Method net/minecraft/world/entity/Entity$Movement.to:()Lnet/minecraft/world/phys/Vec3;
+       227: aload_2
+       228: aload_3
+       229: iconst_1
+       230: invokevirtual #1961               // Method checkInsideBlocks:(Lnet/minecraft/world/phys/Vec3;Lnet/minecraft/world/phys/Vec3;Lnet/minecraft/world/entity/InsideBlockEffectApplier$StepBasedCollector;Lit/unimi/dsi/fastutil/longs/LongSet;I)I
+       233: pop
+       234: goto          21
+       237: aload_3
+       238: invokeinterface #1962,  1         // InterfaceMethod it/unimi/dsi/fastutil/longs/LongSet.clear:()V
+       243: return
+
+  private int checkInsideBlocks(net.minecraft.world.phys.Vec3, net.minecraft.world.phys.Vec3, net.minecraft.world.entity.InsideBlockEffectApplier$StepBasedCollector, it.unimi.dsi.fastutil.longs.LongSet, int);
+    Code:
+         0: aload_0
+         1: aload_2
+         2: invokevirtual #926                // Method makeBoundingBox:(Lnet/minecraft/world/phys/Vec3;)Lnet/minecraft/world/phys/AABB;
+         5: ldc2_w        #1574               // double 9.999999747378752E-6d
+         8: invokevirtual #1967               // Method net/minecraft/world/phys/AABB.deflate:(D)Lnet/minecraft/world/phys/AABB;
+        11: astore        6
+        13: aload_1
+        14: aload_2
+        15: invokevirtual #1542               // Method net/minecraft/world/phys/Vec3.distanceToSqr:(Lnet/minecraft/world/phys/Vec3;)D
+        18: ldc2_w        #1968               // double 0.9999900000002526d
+        21: invokestatic  #894                // Method net/minecraft/util/Mth.square:(D)D
+        24: dcmpl
+        25: ifle          32
+        28: iconst_1
+        29: goto          33
+        32: iconst_0
+        33: istore        7
+        35: aload_0
+        36: getfield      #567                // Field level:Lnet/minecraft/world/level/Level;
+        39: astore        10
+        41: aload         10
+        43: instanceof    #1016               // class net/minecraft/server/level/ServerLevel
+        46: ifeq          77
+        49: aload         10
+        51: checkcast     #1016               // class net/minecraft/server/level/ServerLevel
+        54: astore        9
+        56: aload         9
+        58: invokevirtual #1973               // Method net/minecraft/server/level/ServerLevel.getServer:()Lnet/minecraft/server/MinecraftServer;
+        61: invokevirtual #1979               // Method net/minecraft/server/MinecraftServer.debugSubscribers:()Lnet/minecraft/util/debug/ServerDebugSubscribers;
+        64: getstatic     #1985               // Field net/minecraft/util/debug/DebugSubscriptions.ENTITY_BLOCK_INTERSECTIONS:Lnet/minecraft/util/debug/DebugSubscription;
+        67: invokevirtual #1991               // Method net/minecraft/util/debug/ServerDebugSubscribers.hasAnySubscriberFor:(Lnet/minecraft/util/debug/DebugSubscription;)Z
+        70: ifeq          77
+        73: iconst_1
+        74: goto          78
+        77: iconst_0
+        78: istore        8
+        80: new           #1993               // class java/util/concurrent/atomic/AtomicInteger
+        83: dup
+        84: invokespecial #1994               // Method java/util/concurrent/atomic/AtomicInteger."<init>":()V
+        87: astore        9
+        89: aload_1
+        90: aload_2
+        91: aload         6
+        93: aload_0
+        94: iload         5
+        96: aload         9
+        98: iload         8
+       100: aload_1
+       101: aload_2
+       102: aload         4
+       104: iload         7
+       106: aload         6
+       108: aload_3
+       109: invokedynamic #2012,  0           // InvokeDynamic #0:visit:(Lnet/minecraft/world/entity/Entity;ILjava/util/concurrent/atomic/AtomicInteger;ZLnet/minecraft/world/phys/Vec3;Lnet/minecraft/world/phys/Vec3;Lit/unimi/dsi/fastutil/longs/LongSet;ZLnet/minecraft/world/phys/AABB;Lnet/minecraft/world/entity/InsideBlockEffectApplier$StepBasedCollector;)Lnet/minecraft/world/level/BlockGetter$BlockStepVisitor;
+       114: invokestatic  #2016               // InterfaceMethod net/minecraft/world/level/BlockGetter.forEachBlockIntersectedBetween:(Lnet/minecraft/world/phys/Vec3;Lnet/minecraft/world/phys/Vec3;Lnet/minecraft/world/phys/AABB;Lnet/minecraft/world/level/BlockGetter$BlockStepVisitor;)Z
+       117: pop
+       118: aload         9
+       120: invokevirtual #2018               // Method java/util/concurrent/atomic/AtomicInteger.get:()I
+       123: iconst_1
+       124: iadd
+       125: ireturn
+
+  private void debugBlockIntersection(net.minecraft.server.level.ServerLevel, net.minecraft.core.BlockPos, boolean, boolean);
+    Code:
+         0: iload         4
+         2: ifeq          13
+         5: getstatic     #2033               // Field net/minecraft/util/debug/DebugEntityBlockIntersection.IN_FLUID:Lnet/minecraft/util/debug/DebugEntityBlockIntersection;
+         8: astore        5
+        10: goto          30
+        13: iload_3
+        14: ifeq          25
+        17: getstatic     #2036               // Field net/minecraft/util/debug/DebugEntityBlockIntersection.IN_BLOCK:Lnet/minecraft/util/debug/DebugEntityBlockIntersection;
+        20: astore        5
+        22: goto          30
+        25: getstatic     #2039               // Field net/minecraft/util/debug/DebugEntityBlockIntersection.IN_AIR:Lnet/minecraft/util/debug/DebugEntityBlockIntersection;
+        28: astore        5
+        30: aload_1
+        31: invokevirtual #2043               // Method net/minecraft/server/level/ServerLevel.debugSynchronizers:()Lnet/minecraft/util/debug/LevelDebugSynchronizers;
+        34: aload_2
+        35: getstatic     #1985               // Field net/minecraft/util/debug/DebugSubscriptions.ENTITY_BLOCK_INTERSECTIONS:Lnet/minecraft/util/debug/DebugSubscription;
+        38: aload         5
+        40: invokevirtual #2049               // Method net/minecraft/util/debug/LevelDebugSynchronizers.sendBlockValue:(Lnet/minecraft/core/BlockPos;Lnet/minecraft/util/debug/DebugSubscription;Ljava/lang/Object;)V
+        43: return
+
+  public boolean collidedWithFluid(net.minecraft.world.level.material.FluidState, net.minecraft.core.BlockPos, net.minecraft.world.phys.Vec3, net.minecraft.world.phys.Vec3);
+    Code:
+         0: aload_1
+         1: aload_0
+         2: invokevirtual #672                // Method level:()Lnet/minecraft/world/level/Level;
+         5: aload_2
+         6: invokevirtual #2059               // Method net/minecraft/world/level/material/FluidState.getAABB:(Lnet/minecraft/world/level/BlockGetter;Lnet/minecraft/core/BlockPos;)Lnet/minecraft/world/phys/AABB;
+         9: astore        5
+        11: aload         5
+        13: ifnull        35
+        16: aload_0
+        17: aload_3
+        18: aload         4
+        20: aload         5
+        22: invokestatic  #1578               // InterfaceMethod java/util/List.of:(Ljava/lang/Object;)Ljava/util/List;
+        25: invokevirtual #2063               // Method collidedWithShapeMovingFrom:(Lnet/minecraft/world/phys/Vec3;Lnet/minecraft/world/phys/Vec3;Ljava/util/List;)Z
+        28: ifeq          35
+        31: iconst_1
+        32: goto          36
+        35: iconst_0
+        36: ireturn
+
+  public boolean collidedWithShapeMovingFrom(net.minecraft.world.phys.Vec3, net.minecraft.world.phys.Vec3, java.util.List<net.minecraft.world.phys.AABB>);
+    Code:
+         0: aload_0
+         1: aload_1
+         2: invokevirtual #926                // Method makeBoundingBox:(Lnet/minecraft/world/phys/Vec3;)Lnet/minecraft/world/phys/AABB;
+         5: astore        4
+         7: aload_2
+         8: aload_1
+         9: invokevirtual #1073               // Method net/minecraft/world/phys/Vec3.subtract:(Lnet/minecraft/world/phys/Vec3;)Lnet/minecraft/world/phys/Vec3;
+        12: astore        5
+        14: aload         4
+        16: aload         5
+        18: aload_3
+        19: invokevirtual #2071               // Method net/minecraft/world/phys/AABB.collidedAlongVector:(Lnet/minecraft/world/phys/Vec3;Ljava/util/List;)Z
+        22: ireturn
+
+  protected void onInsideBlock(net.minecraft.world.level.block.state.BlockState);
+    Code:
+         0: return
+
+  public net.minecraft.core.BlockPos adjustSpawnLocation(net.minecraft.server.level.ServerLevel, net.minecraft.core.BlockPos);
+    Code:
+         0: aload_1
+         1: invokevirtual #2083               // Method net/minecraft/server/level/ServerLevel.getRespawnData:()Lnet/minecraft/world/level/storage/LevelData$RespawnData;
+         4: invokevirtual #2085               // Method net/minecraft/world/level/storage/LevelData$RespawnData.pos:()Lnet/minecraft/core/BlockPos;
+         7: astore_3
+         8: aload_3
+         9: invokestatic  #2089               // Method net/minecraft/world/phys/Vec3.atCenterOf:(Lnet/minecraft/core/Vec3i;)Lnet/minecraft/world/phys/Vec3;
+        12: astore        4
+        14: aload_1
+        15: aload_3
+        16: invokevirtual #2093               // Method net/minecraft/server/level/ServerLevel.getChunkAt:(Lnet/minecraft/core/BlockPos;)Lnet/minecraft/world/level/chunk/LevelChunk;
+        19: getstatic     #2097               // Field net/minecraft/world/level/levelgen/Heightmap$Types.MOTION_BLOCKING_NO_LEAVES:Lnet/minecraft/world/level/levelgen/Heightmap$Types;
+        22: aload_3
+        23: invokevirtual #2099               // Method net/minecraft/core/BlockPos.getX:()I
+        26: aload_3
+        27: invokevirtual #2101               // Method net/minecraft/core/BlockPos.getZ:()I
+        30: invokevirtual #2107               // Method net/minecraft/world/level/chunk/LevelChunk.getHeight:(Lnet/minecraft/world/level/levelgen/Heightmap$Types;II)I
+        33: iconst_1
+        34: iadd
+        35: istore        5
+        37: aload         4
+        39: getfield      #932                // Field net/minecraft/world/phys/Vec3.x:D
+        42: iload         5
+        44: i2d
+        45: aload         4
+        47: getfield      #936                // Field net/minecraft/world/phys/Vec3.z:D
+        50: invokestatic  #2111               // Method net/minecraft/core/BlockPos.containing:(DDD)Lnet/minecraft/core/BlockPos;
+        53: areturn
+
+  public void gameEvent(net.minecraft.core.Holder<net.minecraft.world.level.gameevent.GameEvent>, net.minecraft.world.entity.Entity);
+    Code:
+         0: aload_0
+         1: invokevirtual #672                // Method level:()Lnet/minecraft/world/level/Level;
+         4: aload_2
+         5: aload_1
+         6: aload_0
+         7: getfield      #583                // Field position:Lnet/minecraft/world/phys/Vec3;
+        10: invokevirtual #2121               // Method net/minecraft/world/level/Level.gameEvent:(Lnet/minecraft/world/entity/Entity;Lnet/minecraft/core/Holder;Lnet/minecraft/world/phys/Vec3;)V
+        13: return
+
+  public void gameEvent(net.minecraft.core.Holder<net.minecraft.world.level.gameevent.GameEvent>);
+    Code:
+         0: aload_0
+         1: aload_1
+         2: aload_0
+         3: invokevirtual #2126               // Method gameEvent:(Lnet/minecraft/core/Holder;Lnet/minecraft/world/entity/Entity;)V
+         6: return
+
+  private void walkingStepSound(net.minecraft.core.BlockPos, net.minecraft.world.level.block.state.BlockState);
+    Code:
+         0: aload_0
+         1: aload_1
+         2: aload_2
+         3: invokevirtual #2131               // Method playStepSound:(Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/level/block/state/BlockState;)V
+         6: aload_0
+         7: aload_2
+         8: invokevirtual #2134               // Method shouldPlayAmethystStepSound:(Lnet/minecraft/world/level/block/state/BlockState;)Z
+        11: ifeq          18
+        14: aload_0
+        15: invokevirtual #2137               // Method playAmethystStepSound:()V
+        18: return
+
+  protected void waterSwimSound();
+    Code:
+         0: aload_0
+         1: invokevirtual #2141               // Method getControllingPassenger:()Lnet/minecraft/world/entity/LivingEntity;
+         4: aload_0
+         5: invokestatic  #2147               // Method java/util/Objects.requireNonNullElse:(Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;
+         8: checkcast     #2                  // class net/minecraft/world/entity/Entity
+        11: astore_1
+        12: aload_1
+        13: aload_0
+        14: if_acmpne     23
+        17: ldc_w         #2148               // float 0.35f
+        20: goto          26
+        23: ldc_w         #1124               // float 0.4f
+        26: fstore_2
+        27: aload_1
+        28: invokevirtual #1369               // Method getDeltaMovement:()Lnet/minecraft/world/phys/Vec3;
+        31: astore_3
+        32: fconst_1
+        33: aload_3
+        34: getfield      #932                // Field net/minecraft/world/phys/Vec3.x:D
+        37: aload_3
+        38: getfield      #932                // Field net/minecraft/world/phys/Vec3.x:D
+        41: dmul
+        42: ldc2_w        #2149               // double 0.20000000298023224d
+        45: dmul
+        46: aload_3
+        47: getfield      #934                // Field net/minecraft/world/phys/Vec3.y:D
+        50: aload_3
+        51: getfield      #934                // Field net/minecraft/world/phys/Vec3.y:D
+        54: dmul
+        55: dadd
+        56: aload_3
+        57: getfield      #936                // Field net/minecraft/world/phys/Vec3.z:D
+        60: aload_3
+        61: getfield      #936                // Field net/minecraft/world/phys/Vec3.z:D
+        64: dmul
+        65: ldc2_w        #2149               // double 0.20000000298023224d
+        68: dmul
+        69: dadd
+        70: invokestatic  #2153               // Method java/lang/Math.sqrt:(D)D
+        73: d2f
+        74: fload_2
+        75: fmul
+        76: invokestatic  #2156               // Method java/lang/Math.min:(FF)F
+        79: fstore        4
+        81: aload_0
+        82: fload         4
+        84: invokevirtual #2159               // Method playSwimSound:(F)V
+        87: return
+
+  protected net.minecraft.core.BlockPos getPrimaryStepSoundBlockPos(net.minecraft.core.BlockPos);
+    Code:
+         0: aload_1
+         1: invokevirtual #2167               // Method net/minecraft/core/BlockPos.above:()Lnet/minecraft/core/BlockPos;
+         4: astore_2
+         5: aload_0
+         6: invokevirtual #672                // Method level:()Lnet/minecraft/world/level/Level;
+         9: aload_2
+        10: invokevirtual #1339               // Method net/minecraft/world/level/Level.getBlockState:(Lnet/minecraft/core/BlockPos;)Lnet/minecraft/world/level/block/state/BlockState;
+        13: astore_3
+        14: aload_3
+        15: getstatic     #2170               // Field net/minecraft/tags/BlockTags.INSIDE_STEP_SOUND_BLOCKS:Lnet/minecraft/tags/TagKey;
+        18: invokevirtual #1413               // Method net/minecraft/world/level/block/state/BlockState.is:(Lnet/minecraft/tags/TagKey;)Z
+        21: ifne          34
+        24: aload_3
+        25: getstatic     #2173               // Field net/minecraft/tags/BlockTags.COMBINATION_STEP_SOUND_BLOCKS:Lnet/minecraft/tags/TagKey;
+        28: invokevirtual #1413               // Method net/minecraft/world/level/block/state/BlockState.is:(Lnet/minecraft/tags/TagKey;)Z
+        31: ifeq          36
+        34: aload_2
+        35: areturn
+        36: aload_1
+        37: areturn
+
+  protected void playCombinationStepSounds(net.minecraft.world.level.block.state.BlockState, net.minecraft.world.level.block.state.BlockState);
+    Code:
+         0: aload_1
+         1: invokevirtual #2183               // Method net/minecraft/world/level/block/state/BlockState.getSoundType:()Lnet/minecraft/world/level/block/SoundType;
+         4: astore_3
+         5: aload_0
+         6: aload_3
+         7: invokevirtual #2188               // Method net/minecraft/world/level/block/SoundType.getStepSound:()Lnet/minecraft/sounds/SoundEvent;
+        10: aload_3
+        11: invokevirtual #2191               // Method net/minecraft/world/level/block/SoundType.getVolume:()F
+        14: ldc_w         #939                // float 0.15f
+        17: fmul
+        18: aload_3
+        19: invokevirtual #2194               // Method net/minecraft/world/level/block/SoundType.getPitch:()F
+        22: invokevirtual #2197               // Method playSound:(Lnet/minecraft/sounds/SoundEvent;FF)V
+        25: aload_0
+        26: aload_2
+        27: invokevirtual #2200               // Method playMuffledStepSound:(Lnet/minecraft/world/level/block/state/BlockState;)V
+        30: return
+
+  protected void playMuffledStepSound(net.minecraft.world.level.block.state.BlockState);
+    Code:
+         0: aload_1
+         1: invokevirtual #2183               // Method net/minecraft/world/level/block/state/BlockState.getSoundType:()Lnet/minecraft/world/level/block/SoundType;
+         4: astore_2
+         5: aload_0
+         6: aload_2
+         7: invokevirtual #2188               // Method net/minecraft/world/level/block/SoundType.getStepSound:()Lnet/minecraft/sounds/SoundEvent;
+        10: aload_2
+        11: invokevirtual #2191               // Method net/minecraft/world/level/block/SoundType.getVolume:()F
+        14: ldc_w         #2203               // float 0.05f
+        17: fmul
+        18: aload_2
+        19: invokevirtual #2194               // Method net/minecraft/world/level/block/SoundType.getPitch:()F
+        22: ldc_w         #1455               // float 0.8f
+        25: fmul
+        26: invokevirtual #2197               // Method playSound:(Lnet/minecraft/sounds/SoundEvent;FF)V
+        29: return
+
+  protected void playStepSound(net.minecraft.core.BlockPos, net.minecraft.world.level.block.state.BlockState);
+    Code:
+         0: aload_2
+         1: invokevirtual #2183               // Method net/minecraft/world/level/block/state/BlockState.getSoundType:()Lnet/minecraft/world/level/block/SoundType;
+         4: astore_3
+         5: aload_0
+         6: aload_3
+         7: invokevirtual #2188               // Method net/minecraft/world/level/block/SoundType.getStepSound:()Lnet/minecraft/sounds/SoundEvent;
+        10: aload_3
+        11: invokevirtual #2191               // Method net/minecraft/world/level/block/SoundType.getVolume:()F
+        14: ldc_w         #939                // float 0.15f
+        17: fmul
+        18: aload_3
+        19: invokevirtual #2194               // Method net/minecraft/world/level/block/SoundType.getPitch:()F
+        22: invokevirtual #2197               // Method playSound:(Lnet/minecraft/sounds/SoundEvent;FF)V
+        25: return
+
+  private boolean shouldPlayAmethystStepSound(net.minecraft.world.level.block.state.BlockState);
+    Code:
+         0: aload_1
+         1: getstatic     #2209               // Field net/minecraft/tags/BlockTags.CRYSTAL_SOUND_BLOCKS:Lnet/minecraft/tags/TagKey;
+         4: invokevirtual #1413               // Method net/minecraft/world/level/block/state/BlockState.is:(Lnet/minecraft/tags/TagKey;)Z
+         7: ifeq          28
+        10: aload_0
+        11: getfield      #2211               // Field tickCount:I
+        14: aload_0
+        15: getfield      #2213               // Field lastCrystalSoundPlayTick:I
+        18: bipush        20
+        20: iadd
+        21: if_icmplt     28
+        24: iconst_1
+        25: goto          29
+        28: iconst_0
+        29: ireturn
+
+  private void playAmethystStepSound();
+    Code:
+         0: aload_0
+         1: dup
+         2: getfield      #2215               // Field crystalSoundIntensity:F
+         5: ldc2_w        #2216               // double 0.997d
+         8: aload_0
+         9: getfield      #2211               // Field tickCount:I
+        12: aload_0
+        13: getfield      #2213               // Field lastCrystalSoundPlayTick:I
+        16: isub
+        17: i2d
+        18: invokestatic  #2220               // Method java/lang/Math.pow:(DD)D
+        21: d2f
+        22: fmul
+        23: putfield      #2215               // Field crystalSoundIntensity:F
+        26: aload_0
+        27: fconst_1
+        28: aload_0
+        29: getfield      #2215               // Field crystalSoundIntensity:F
+        32: ldc_w         #2221               // float 0.07f
+        35: fadd
+        36: invokestatic  #2156               // Method java/lang/Math.min:(FF)F
+        39: putfield      #2215               // Field crystalSoundIntensity:F
+        42: ldc_w         #2222               // float 0.5f
+        45: aload_0
+        46: getfield      #2215               // Field crystalSoundIntensity:F
+        49: aload_0
+        50: getfield      #461                // Field random:Lnet/minecraft/util/RandomSource;
+        53: invokeinterface #1127,  1         // InterfaceMethod net/minecraft/util/RandomSource.nextFloat:()F
+        58: fmul
+        59: ldc_w         #2223               // float 1.2f
+        62: fmul
+        63: fadd
+        64: fstore_1
+        65: ldc_w         #2224               // float 0.1f
+        68: aload_0
+        69: getfield      #2215               // Field crystalSoundIntensity:F
+        72: ldc_w         #2223               // float 1.2f
+        75: fmul
+        76: fadd
+        77: fstore_2
+        78: aload_0
+        79: getstatic     #2227               // Field net/minecraft/sounds/SoundEvents.AMETHYST_BLOCK_CHIME:Lnet/minecraft/sounds/SoundEvent;
+        82: fload_2
+        83: fload_1
+        84: invokevirtual #2197               // Method playSound:(Lnet/minecraft/sounds/SoundEvent;FF)V
+        87: aload_0
+        88: aload_0
+        89: getfield      #2211               // Field tickCount:I
+        92: putfield      #2213               // Field lastCrystalSoundPlayTick:I
+        95: return
+
+  protected void playSwimSound(float);
+    Code:
+         0: aload_0
+         1: aload_0
+         2: invokevirtual #2231               // Method getSwimSound:()Lnet/minecraft/sounds/SoundEvent;
+         5: fload_1
+         6: fconst_1
+         7: aload_0
+         8: getfield      #461                // Field random:Lnet/minecraft/util/RandomSource;
+        11: invokeinterface #1127,  1         // InterfaceMethod net/minecraft/util/RandomSource.nextFloat:()F
+        16: aload_0
+        17: getfield      #461                // Field random:Lnet/minecraft/util/RandomSource;
+        20: invokeinterface #1127,  1         // InterfaceMethod net/minecraft/util/RandomSource.nextFloat:()F
+        25: fsub
+        26: ldc_w         #1124               // float 0.4f
+        29: fmul
+        30: fadd
+        31: invokevirtual #2197               // Method playSound:(Lnet/minecraft/sounds/SoundEvent;FF)V
+        34: return
+
+  protected void onFlap();
+    Code:
+         0: return
+
+  protected boolean isFlapping();
+    Code:
+         0: iconst_0
+         1: ireturn
+
+  public void playSound(net.minecraft.sounds.SoundEvent, float, float);
+    Code:
+         0: aload_0
+         1: invokevirtual #1113               // Method isSilent:()Z
+         4: ifne          34
+         7: aload_0
+         8: invokevirtual #672                // Method level:()Lnet/minecraft/world/level/Level;
+        11: aconst_null
+        12: aload_0
+        13: invokevirtual #880                // Method getX:()D
+        16: aload_0
+        17: invokevirtual #883                // Method getY:()D
+        20: aload_0
+        21: invokevirtual #886                // Method getZ:()D
+        24: aload_1
+        25: aload_0
+        26: invokevirtual #1123               // Method getSoundSource:()Lnet/minecraft/sounds/SoundSource;
+        29: fload_2
+        30: fload_3
+        31: invokevirtual #1655               // Method net/minecraft/world/level/Level.playSound:(Lnet/minecraft/world/entity/Entity;DDDLnet/minecraft/sounds/SoundEvent;Lnet/minecraft/sounds/SoundSource;FF)V
+        34: return
+
+  public void playSound(net.minecraft.sounds.SoundEvent);
+    Code:
+         0: aload_0
+         1: invokevirtual #1113               // Method isSilent:()Z
+         4: ifne          14
+         7: aload_0
+         8: aload_1
+         9: fconst_1
+        10: fconst_1
+        11: invokevirtual #2197               // Method playSound:(Lnet/minecraft/sounds/SoundEvent;FF)V
+        14: return
+
+  public boolean isSilent();
+    Code:
+         0: aload_0
+         1: getfield      #651                // Field entityData:Lnet/minecraft/network/syncher/SynchedEntityData;
+         4: getstatic     #629                // Field DATA_SILENT:Lnet/minecraft/network/syncher/EntityDataAccessor;
+         7: invokevirtual #859                // Method net/minecraft/network/syncher/SynchedEntityData.get:(Lnet/minecraft/network/syncher/EntityDataAccessor;)Ljava/lang/Object;
+        10: checkcast     #622                // class java/lang/Boolean
+        13: invokevirtual #2236               // Method java/lang/Boolean.booleanValue:()Z
+        16: ireturn
+
+  public void setSilent(boolean);
+    Code:
+         0: aload_0
+         1: getfield      #651                // Field entityData:Lnet/minecraft/network/syncher/SynchedEntityData;
+         4: getstatic     #629                // Field DATA_SILENT:Lnet/minecraft/network/syncher/EntityDataAccessor;
+         7: iload_1
+         8: invokestatic  #625                // Method java/lang/Boolean.valueOf:(Z)Ljava/lang/Boolean;
+        11: invokevirtual #854                // Method net/minecraft/network/syncher/SynchedEntityData.set:(Lnet/minecraft/network/syncher/EntityDataAccessor;Ljava/lang/Object;)V
+        14: return
+
+  public boolean isNoGravity();
+    Code:
+         0: aload_0
+         1: getfield      #651                // Field entityData:Lnet/minecraft/network/syncher/SynchedEntityData;
+         4: getstatic     #631                // Field DATA_NO_GRAVITY:Lnet/minecraft/network/syncher/EntityDataAccessor;
+         7: invokevirtual #859                // Method net/minecraft/network/syncher/SynchedEntityData.get:(Lnet/minecraft/network/syncher/EntityDataAccessor;)Ljava/lang/Object;
+        10: checkcast     #622                // class java/lang/Boolean
+        13: invokevirtual #2236               // Method java/lang/Boolean.booleanValue:()Z
+        16: ireturn
+
+  public void setNoGravity(boolean);
+    Code:
+         0: aload_0
+         1: getfield      #651                // Field entityData:Lnet/minecraft/network/syncher/SynchedEntityData;
+         4: getstatic     #631                // Field DATA_NO_GRAVITY:Lnet/minecraft/network/syncher/EntityDataAccessor;
+         7: iload_1
+         8: invokestatic  #625                // Method java/lang/Boolean.valueOf:(Z)Ljava/lang/Boolean;
+        11: invokevirtual #854                // Method net/minecraft/network/syncher/SynchedEntityData.set:(Lnet/minecraft/network/syncher/EntityDataAccessor;Ljava/lang/Object;)V
+        14: return
+
+  protected double getDefaultGravity();
+    Code:
+         0: dconst_0
+         1: dreturn
+
+  public final double getGravity();
+    Code:
+         0: aload_0
+         1: invokevirtual #2244               // Method isNoGravity:()Z
+         4: ifeq          11
+         7: dconst_0
+         8: goto          15
+        11: aload_0
+        12: invokevirtual #2246               // Method getDefaultGravity:()D
+        15: dreturn
+
+  protected void applyGravity();
+    Code:
+         0: aload_0
+         1: invokevirtual #1460               // Method getGravity:()D
+         4: dstore_1
+         5: dload_1
+         6: dconst_0
+         7: dcmpl
+         8: ifeq          26
+        11: aload_0
+        12: aload_0
+        13: invokevirtual #1369               // Method getDeltaMovement:()Lnet/minecraft/world/phys/Vec3;
+        16: dconst_0
+        17: dload_1
+        18: dneg
+        19: dconst_0
+        20: invokevirtual #2249               // Method net/minecraft/world/phys/Vec3.add:(DDD)Lnet/minecraft/world/phys/Vec3;
+        23: invokevirtual #1259               // Method setDeltaMovement:(Lnet/minecraft/world/phys/Vec3;)V
+        26: return
+
+  protected float getAirDrag();
+    Code:
+         0: ldc_w         #2251               // float 0.98f
+         3: freturn
+
+  protected net.minecraft.world.entity.Entity$MovementEmission getMovementEmission();
+    Code:
+         0: getstatic     #2254               // Field net/minecraft/world/entity/Entity$MovementEmission.ALL:Lnet/minecraft/world/entity/Entity$MovementEmission;
+         3: areturn
+
+  public boolean dampensVibrations();
+    Code:
+         0: iconst_0
+         1: ireturn
+
+  public final void doCheckFallDamage(double, double, double, boolean);
+    Code:
+         0: aload_0
+         1: invokevirtual #2260               // Method touchingUnloadedChunk:()Z
+         4: ifeq          8
+         7: return
+         8: aload_0
+         9: iload         7
+        11: new           #440                // class net/minecraft/world/phys/Vec3
+        14: dup
+        15: dload_1
+        16: dload_3
+        17: dload         5
+        19: invokespecial #765                // Method net/minecraft/world/phys/Vec3."<init>":(DDD)V
+        22: invokevirtual #1184               // Method checkSupportingBlock:(ZLnet/minecraft/world/phys/Vec3;)V
+        25: aload_0
+        26: invokevirtual #1335               // Method getOnPosLegacy:()Lnet/minecraft/core/BlockPos;
+        29: astore        8
+        31: aload_0
+        32: invokevirtual #672                // Method level:()Lnet/minecraft/world/level/Level;
+        35: aload         8
+        37: invokevirtual #1339               // Method net/minecraft/world/level/Level.getBlockState:(Lnet/minecraft/core/BlockPos;)Lnet/minecraft/world/level/block/state/BlockState;
+        40: astore        9
+        42: aload_0
+        43: dload_3
+        44: iload         7
+        46: aload         9
+        48: aload         8
+        50: invokevirtual #1345               // Method checkFallDamage:(DZLnet/minecraft/world/level/block/state/BlockState;Lnet/minecraft/core/BlockPos;)V
+        53: return
+
+  protected void checkFallDamage(double, boolean, net.minecraft.world.level.block.state.BlockState, net.minecraft.core.BlockPos);
+    Code:
+         0: aload_0
+         1: invokevirtual #1496               // Method isInWater:()Z
+         4: ifne          25
+         7: dload_1
+         8: dconst_0
+         9: dcmpg
+        10: ifge          25
+        13: aload_0
+        14: dup
+        15: getfield      #1046               // Field fallDistance:D
+        18: dload_1
+        19: d2f
+        20: f2d
+        21: dsub
+        22: putfield      #1046               // Field fallDistance:D
+        25: iload_3
+        26: ifeq          102
+        29: aload_0
+        30: getfield      #1046               // Field fallDistance:D
+        33: dconst_0
+        34: dcmpl
+        35: ifle          98
+        38: aload         4
+        40: invokevirtual #1417               // Method net/minecraft/world/level/block/state/BlockState.getBlock:()Lnet/minecraft/world/level/block/Block;
+        43: aload_0
+        44: invokevirtual #672                // Method level:()Lnet/minecraft/world/level/Level;
+        47: aload         4
+        49: aload         5
+        51: aload_0
+        52: aload_0
+        53: getfield      #1046               // Field fallDistance:D
+        56: invokevirtual #2264               // Method net/minecraft/world/level/block/Block.fallOn:(Lnet/minecraft/world/level/Level;Lnet/minecraft/world/level/block/state/BlockState;Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/entity/Entity;D)V
+        59: aload_0
+        60: invokevirtual #672                // Method level:()Lnet/minecraft/world/level/Level;
+        63: getstatic     #2267               // Field net/minecraft/world/level/gameevent/GameEvent.HIT_GROUND:Lnet/minecraft/core/Holder$Reference;
+        66: aload_0
+        67: getfield      #583                // Field position:Lnet/minecraft/world/phys/Vec3;
+        70: aload_0
+        71: aload_0
+        72: getfield      #530                // Field mainSupportingBlockPos:Ljava/util/Optional;
+        75: aload_0
+        76: invokedynamic #2278,  0           // InvokeDynamic #1:apply:(Lnet/minecraft/world/entity/Entity;)Ljava/util/function/Function;
+        81: invokevirtual #2282               // Method java/util/Optional.map:(Ljava/util/function/Function;)Ljava/util/Optional;
+        84: aload         4
+        86: invokevirtual #2285               // Method java/util/Optional.orElse:(Ljava/lang/Object;)Ljava/lang/Object;
+        89: checkcast     #679                // class net/minecraft/world/level/block/state/BlockState
+        92: invokestatic  #1645               // Method net/minecraft/world/level/gameevent/GameEvent$Context.of:(Lnet/minecraft/world/entity/Entity;Lnet/minecraft/world/level/block/state/BlockState;)Lnet/minecraft/world/level/gameevent/GameEvent$Context;
+        95: invokevirtual #1648               // Method net/minecraft/world/level/Level.gameEvent:(Lnet/minecraft/core/Holder;Lnet/minecraft/world/phys/Vec3;Lnet/minecraft/world/level/gameevent/GameEvent$Context;)V
+        98: aload_0
+        99: invokevirtual #1306               // Method resetFallDistance:()V
+       102: return
+
+  public boolean fireImmune();
+    Code:
+         0: aload_0
+         1: invokevirtual #2287               // Method getType:()Lnet/minecraft/world/entity/EntityType;
+         4: invokevirtual #2288               // Method net/minecraft/world/entity/EntityType.fireImmune:()Z
+         7: ireturn
+
+  public boolean causeFallDamage(double, float, net.minecraft.world.damagesource.DamageSource);
+    Code:
+         0: aload_0
+         1: getstatic     #2297               // Field net/minecraft/tags/EntityTypeTags.FALL_DAMAGE_IMMUNE:Lnet/minecraft/tags/TagKey;
+         4: invokevirtual #2298               // Method is:(Lnet/minecraft/tags/TagKey;)Z
+         7: ifeq          12
+        10: iconst_0
+        11: ireturn
+        12: aload_0
+        13: dload_1
+        14: fload_3
+        15: aload         4
+        17: invokevirtual #2302               // Method propagateFallToPassengers:(DFLnet/minecraft/world/damagesource/DamageSource;)V
+        20: iconst_0
+        21: ireturn
+
+  protected void propagateFallToPassengers(double, float, net.minecraft.world.damagesource.DamageSource);
+    Code:
+         0: aload_0
+         1: invokevirtual #750                // Method isVehicle:()Z
+         4: ifeq          53
+         7: aload_0
+         8: invokevirtual #2307               // Method getPassengers:()Ljava/util/List;
+        11: invokeinterface #1820,  1         // InterfaceMethod java/util/List.iterator:()Ljava/util/Iterator;
+        16: astore        5
+        18: aload         5
+        20: invokeinterface #1827,  1         // InterfaceMethod java/util/Iterator.hasNext:()Z
+        25: ifeq          53
+        28: aload         5
+        30: invokeinterface #1830,  1         // InterfaceMethod java/util/Iterator.next:()Ljava/lang/Object;
+        35: checkcast     #2                  // class net/minecraft/world/entity/Entity
+        38: astore        6
+        40: aload         6
+        42: dload_1
+        43: fload_3
+        44: aload         4
+        46: invokevirtual #2309               // Method causeFallDamage:(DFLnet/minecraft/world/damagesource/DamageSource;)Z
+        49: pop
+        50: goto          18
+        53: return
+
+  public boolean isInWater();
+    Code:
+         0: aload_0
+         1: getfield      #2312               // Field wasTouchingWater:Z
+         4: ireturn
+
+  private boolean isInRain();
+    Code:
+         0: aload_0
+         1: invokevirtual #1698               // Method blockPosition:()Lnet/minecraft/core/BlockPos;
+         4: astore_1
+         5: aload_0
+         6: invokevirtual #672                // Method level:()Lnet/minecraft/world/level/Level;
+         9: aload_1
+        10: invokevirtual #2315               // Method net/minecraft/world/level/Level.isRainingAt:(Lnet/minecraft/core/BlockPos;)Z
+        13: ifne          46
+        16: aload_0
+        17: invokevirtual #672                // Method level:()Lnet/minecraft/world/level/Level;
+        20: aload_1
+        21: invokevirtual #2099               // Method net/minecraft/core/BlockPos.getX:()I
+        24: i2d
+        25: aload_0
+        26: invokevirtual #693                // Method getBoundingBox:()Lnet/minecraft/world/phys/AABB;
+        29: getfield      #2318               // Field net/minecraft/world/phys/AABB.maxY:D
+        32: aload_1
+        33: invokevirtual #2101               // Method net/minecraft/core/BlockPos.getZ:()I
+        36: i2d
+        37: invokestatic  #2111               // Method net/minecraft/core/BlockPos.containing:(DDD)Lnet/minecraft/core/BlockPos;
+        40: invokevirtual #2315               // Method net/minecraft/world/level/Level.isRainingAt:(Lnet/minecraft/core/BlockPos;)Z
+        43: ifeq          50
+        46: iconst_1
+        47: goto          51
+        50: iconst_0
+        51: ireturn
+
+  public boolean isInWaterOrRain();
+    Code:
+         0: aload_0
+         1: invokevirtual #1496               // Method isInWater:()Z
+         4: ifne          14
+         7: aload_0
+         8: invokevirtual #1603               // Method isInRain:()Z
+        11: ifeq          18
+        14: iconst_1
+        15: goto          19
+        18: iconst_0
+        19: ireturn
+
+  public boolean isInLiquid();
+    Code:
+         0: aload_0
+         1: invokevirtual #1496               // Method isInWater:()Z
+         4: ifne          14
+         7: aload_0
+         8: invokevirtual #1027               // Method isInLava:()Z
+        11: ifeq          18
+        14: iconst_1
+        15: goto          19
+        18: iconst_0
+        19: ireturn
+
+  public boolean isUnderWater();
+    Code:
+         0: aload_0
+         1: getfield      #1008               // Field wasEyeInWater:Z
+         4: ifeq          18
+         7: aload_0
+         8: invokevirtual #1496               // Method isInWater:()Z
+        11: ifeq          18
+        14: iconst_1
+        15: goto          19
+        18: iconst_0
+        19: ireturn
+
+  public boolean isInShallowWater();
+    Code:
+         0: aload_0
+         1: invokevirtual #1496               // Method isInWater:()Z
+         4: ifeq          18
+         7: aload_0
+         8: invokevirtual #2324               // Method isUnderWater:()Z
+        11: ifne          18
+        14: iconst_1
+        15: goto          19
+        18: iconst_0
+        19: ireturn
+
+  public boolean isInClouds();
+    Code:
+         0: aload_0
+         1: getfield      #567                // Field level:Lnet/minecraft/world/level/Level;
+         4: invokevirtual #2329               // Method net/minecraft/world/level/Level.environmentAttributes:()Lnet/minecraft/world/attribute/EnvironmentAttributeSystem;
+         7: getstatic     #2335               // Field net/minecraft/world/attribute/EnvironmentAttributes.CLOUD_COLOR:Lnet/minecraft/world/attribute/EnvironmentAttribute;
+        10: aload_0
+        11: invokevirtual #870                // Method position:()Lnet/minecraft/world/phys/Vec3;
+        14: invokevirtual #2341               // Method net/minecraft/world/attribute/EnvironmentAttributeSystem.getValue:(Lnet/minecraft/world/attribute/EnvironmentAttribute;Lnet/minecraft/world/phys/Vec3;)Ljava/lang/Object;
+        17: checkcast     #615                // class java/lang/Integer
+        20: invokevirtual #2344               // Method java/lang/Integer.intValue:()I
+        23: invokestatic  #2350               // Method net/minecraft/util/ARGB.alpha:(I)I
+        26: ifne          31
+        29: iconst_0
+        30: ireturn
+        31: aload_0
+        32: getfield      #567                // Field level:Lnet/minecraft/world/level/Level;
+        35: invokevirtual #2329               // Method net/minecraft/world/level/Level.environmentAttributes:()Lnet/minecraft/world/attribute/EnvironmentAttributeSystem;
+        38: getstatic     #2353               // Field net/minecraft/world/attribute/EnvironmentAttributes.CLOUD_HEIGHT:Lnet/minecraft/world/attribute/EnvironmentAttribute;
+        41: aload_0
+        42: invokevirtual #870                // Method position:()Lnet/minecraft/world/phys/Vec3;
+        45: invokevirtual #2341               // Method net/minecraft/world/attribute/EnvironmentAttributeSystem.getValue:(Lnet/minecraft/world/attribute/EnvironmentAttribute;Lnet/minecraft/world/phys/Vec3;)Ljava/lang/Object;
+        48: checkcast     #2355               // class java/lang/Float
+        51: invokevirtual #2358               // Method java/lang/Float.floatValue:()F
+        54: fstore_1
+        55: aload_0
+        56: invokevirtual #883                // Method getY:()D
+        59: aload_0
+        60: invokevirtual #2361               // Method getBbHeight:()F
+        63: f2d
+        64: dadd
+        65: fload_1
+        66: f2d
+        67: dcmpg
+        68: ifge          73
+        71: iconst_0
+        72: ireturn
+        73: fload_1
+        74: ldc_w         #1107               // float 4.0f
+        77: fadd
+        78: fstore_2
+        79: aload_0
+        80: invokevirtual #883                // Method getY:()D
+        83: fload_2
+        84: f2d
+        85: dcmpg
+        86: ifgt          93
+        89: iconst_1
+        90: goto          94
+        93: iconst_0
+        94: ireturn
+
+  public void updateSwimming();
+    Code:
+         0: aload_0
+         1: invokevirtual #1635               // Method isSwimming:()Z
+         4: ifeq          40
+         7: aload_0
+         8: aload_0
+         9: invokevirtual #2366               // Method isSprinting:()Z
+        12: ifeq          33
+        15: aload_0
+        16: invokevirtual #1496               // Method isInWater:()Z
+        19: ifeq          33
+        22: aload_0
+        23: invokevirtual #756                // Method isPassenger:()Z
+        26: ifne          33
+        29: iconst_1
+        30: goto          34
+        33: iconst_0
+        34: invokevirtual #2369               // Method setSwimming:(Z)V
+        37: goto          90
+        40: aload_0
+        41: aload_0
+        42: invokevirtual #2366               // Method isSprinting:()Z
+        45: ifeq          86
+        48: aload_0
+        49: invokevirtual #2324               // Method isUnderWater:()Z
+        52: ifeq          86
+        55: aload_0
+        56: invokevirtual #756                // Method isPassenger:()Z
+        59: ifne          86
+        62: aload_0
+        63: invokevirtual #672                // Method level:()Lnet/minecraft/world/level/Level;
+        66: aload_0
+        67: getfield      #587                // Field blockPosition:Lnet/minecraft/core/BlockPos;
+        70: invokevirtual #2373               // Method net/minecraft/world/level/Level.getFluidState:(Lnet/minecraft/core/BlockPos;)Lnet/minecraft/world/level/material/FluidState;
+        73: getstatic     #469                // Field net/minecraft/tags/FluidTags.WATER:Lnet/minecraft/tags/TagKey;
+        76: invokevirtual #2374               // Method net/minecraft/world/level/material/FluidState.is:(Lnet/minecraft/tags/TagKey;)Z
+        79: ifeq          86
+        82: iconst_1
+        83: goto          87
+        86: iconst_0
+        87: invokevirtual #2369               // Method setSwimming:(Z)V
+        90: return
+
+  protected boolean updateFluidInteraction();
+    Code:
+         0: aload_0
+         1: getfield      #482                // Field fluidInteraction:Lnet/minecraft/world/entity/EntityFluidInteraction;
+         4: aload_0
+         5: aload_0
+         6: invokevirtual #2377               // Method isPushedByFluid:()Z
+         9: ifne          16
+        12: iconst_1
+        13: goto          17
+        16: iconst_0
+        17: invokevirtual #2381               // Method net/minecraft/world/entity/EntityFluidInteraction.update:(Lnet/minecraft/world/entity/Entity;Z)V
+        20: aload_0
+        21: getfield      #482                // Field fluidInteraction:Lnet/minecraft/world/entity/EntityFluidInteraction;
+        24: getstatic     #469                // Field net/minecraft/tags/FluidTags.WATER:Lnet/minecraft/tags/TagKey;
+        27: invokevirtual #2384               // Method net/minecraft/world/entity/EntityFluidInteraction.isInFluid:(Lnet/minecraft/tags/TagKey;)Z
+        30: istore_1
+        31: aload_0
+        32: getfield      #482                // Field fluidInteraction:Lnet/minecraft/world/entity/EntityFluidInteraction;
+        35: getstatic     #472                // Field net/minecraft/tags/FluidTags.LAVA:Lnet/minecraft/tags/TagKey;
+        38: invokevirtual #2384               // Method net/minecraft/world/entity/EntityFluidInteraction.isInFluid:(Lnet/minecraft/tags/TagKey;)Z
+        41: istore_2
+        42: iload_1
+        43: ifeq          68
+        46: aload_0
+        47: invokevirtual #1306               // Method resetFallDistance:()V
+        50: aload_0
+        51: getfield      #2312               // Field wasTouchingWater:Z
+        54: ifne          68
+        57: aload_0
+        58: getfield      #484                // Field firstTick:Z
+        61: ifne          68
+        64: aload_0
+        65: invokevirtual #2387               // Method doWaterSplashEffect:()V
+        68: aload_0
+        69: iload_1
+        70: putfield      #2312               // Field wasTouchingWater:Z
+        73: aload_0
+        74: invokevirtual #2377               // Method isPushedByFluid:()Z
+        77: ifeq          146
+        80: iload_1
+        81: ifeq          98
+        84: aload_0
+        85: getfield      #482                // Field fluidInteraction:Lnet/minecraft/world/entity/EntityFluidInteraction;
+        88: getstatic     #469                // Field net/minecraft/tags/FluidTags.WATER:Lnet/minecraft/tags/TagKey;
+        91: aload_0
+        92: ldc2_w        #271                // double 0.014d
+        95: invokevirtual #2391               // Method net/minecraft/world/entity/EntityFluidInteraction.applyCurrentTo:(Lnet/minecraft/tags/TagKey;Lnet/minecraft/world/entity/Entity;D)V
+        98: iload_2
+        99: ifeq          146
+       102: aload_0
+       103: getfield      #567                // Field level:Lnet/minecraft/world/level/Level;
+       106: invokevirtual #2329               // Method net/minecraft/world/level/Level.environmentAttributes:()Lnet/minecraft/world/attribute/EnvironmentAttributeSystem;
+       109: getstatic     #2394               // Field net/minecraft/world/attribute/EnvironmentAttributes.FAST_LAVA:Lnet/minecraft/world/attribute/EnvironmentAttribute;
+       112: invokevirtual #2398               // Method net/minecraft/world/attribute/EnvironmentAttributeSystem.getDimensionValue:(Lnet/minecraft/world/attribute/EnvironmentAttribute;)Ljava/lang/Object;
+       115: checkcast     #622                // class java/lang/Boolean
+       118: invokevirtual #2236               // Method java/lang/Boolean.booleanValue:()Z
+       121: ifeq          130
+       124: ldc2_w        #274                // double 0.007d
+       127: goto          133
+       130: ldc2_w        #277                // double 0.0023333333333333335d
+       133: dstore_3
+       134: aload_0
+       135: getfield      #482                // Field fluidInteraction:Lnet/minecraft/world/entity/EntityFluidInteraction;
+       138: getstatic     #472                // Field net/minecraft/tags/FluidTags.LAVA:Lnet/minecraft/tags/TagKey;
+       141: aload_0
+       142: dload_3
+       143: invokevirtual #2391               // Method net/minecraft/world/entity/EntityFluidInteraction.applyCurrentTo:(Lnet/minecraft/tags/TagKey;Lnet/minecraft/world/entity/Entity;D)V
+       146: iload_1
+       147: ifne          154
+       150: iload_2
+       151: ifeq          158
+       154: iconst_1
+       155: goto          159
+       158: iconst_0
+       159: ireturn
+
+  protected void doWaterSplashEffect();
+    Code:
+         0: aload_0
+         1: invokevirtual #2141               // Method getControllingPassenger:()Lnet/minecraft/world/entity/LivingEntity;
+         4: aload_0
+         5: invokestatic  #2147               // Method java/util/Objects.requireNonNullElse:(Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;
+         8: checkcast     #2                  // class net/minecraft/world/entity/Entity
+        11: astore_1
+        12: aload_1
+        13: aload_0
+        14: if_acmpne     22
+        17: ldc           #255                // float 0.2f
+        19: goto          25
+        22: ldc_w         #2402               // float 0.9f
+        25: fstore_2
+        26: aload_1
+        27: invokevirtual #1369               // Method getDeltaMovement:()Lnet/minecraft/world/phys/Vec3;
+        30: astore_3
+        31: fconst_1
+        32: aload_3
+        33: getfield      #932                // Field net/minecraft/world/phys/Vec3.x:D
+        36: aload_3
+        37: getfield      #932                // Field net/minecraft/world/phys/Vec3.x:D
+        40: dmul
+        41: ldc2_w        #2149               // double 0.20000000298023224d
+        44: dmul
+        45: aload_3
+        46: getfield      #934                // Field net/minecraft/world/phys/Vec3.y:D
+        49: aload_3
+        50: getfield      #934                // Field net/minecraft/world/phys/Vec3.y:D
+        53: dmul
+        54: dadd
+        55: aload_3
+        56: getfield      #936                // Field net/minecraft/world/phys/Vec3.z:D
+        59: aload_3
+        60: getfield      #936                // Field net/minecraft/world/phys/Vec3.z:D
+        63: dmul
+        64: ldc2_w        #2149               // double 0.20000000298023224d
+        67: dmul
+        68: dadd
+        69: invokestatic  #2153               // Method java/lang/Math.sqrt:(D)D
+        72: d2f
+        73: fload_2
+        74: fmul
+        75: invokestatic  #2156               // Method java/lang/Math.min:(FF)F
+        78: fstore        4
+        80: fload         4
+        82: ldc_w         #2403               // float 0.25f
+        85: fcmpg
+        86: ifge          127
+        89: aload_0
+        90: aload_0
+        91: invokevirtual #2405               // Method getSwimSplashSound:()Lnet/minecraft/sounds/SoundEvent;
+        94: fload         4
+        96: fconst_1
+        97: aload_0
+        98: getfield      #461                // Field random:Lnet/minecraft/util/RandomSource;
+       101: invokeinterface #1127,  1         // InterfaceMethod net/minecraft/util/RandomSource.nextFloat:()F
+       106: aload_0
+       107: getfield      #461                // Field random:Lnet/minecraft/util/RandomSource;
+       110: invokeinterface #1127,  1         // InterfaceMethod net/minecraft/util/RandomSource.nextFloat:()F
+       115: fsub
+       116: ldc_w         #1124               // float 0.4f
+       119: fmul
+       120: fadd
+       121: invokevirtual #2197               // Method playSound:(Lnet/minecraft/sounds/SoundEvent;FF)V
+       124: goto          162
+       127: aload_0
+       128: aload_0
+       129: invokevirtual #2407               // Method getSwimHighSpeedSplashSound:()Lnet/minecraft/sounds/SoundEvent;
+       132: fload         4
+       134: fconst_1
+       135: aload_0
+       136: getfield      #461                // Field random:Lnet/minecraft/util/RandomSource;
+       139: invokeinterface #1127,  1         // InterfaceMethod net/minecraft/util/RandomSource.nextFloat:()F
+       144: aload_0
+       145: getfield      #461                // Field random:Lnet/minecraft/util/RandomSource;
+       148: invokeinterface #1127,  1         // InterfaceMethod net/minecraft/util/RandomSource.nextFloat:()F
+       153: fsub
+       154: ldc_w         #1124               // float 0.4f
+       157: fmul
+       158: fadd
+       159: invokevirtual #2197               // Method playSound:(Lnet/minecraft/sounds/SoundEvent;FF)V
+       162: aload_0
+       163: invokevirtual #883                // Method getY:()D
+       166: invokestatic  #1684               // Method net/minecraft/util/Mth.floor:(D)I
+       169: i2f
+       170: fstore        5
+       172: iconst_0
+       173: istore        6
+       175: iload         6
+       177: i2f
+       178: fconst_1
+       179: aload_0
+       180: getfield      #581                // Field dimensions:Lnet/minecraft/world/entity/EntityDimensions;
+       183: invokevirtual #2410               // Method net/minecraft/world/entity/EntityDimensions.width:()F
+       186: ldc_w         #1133               // float 20.0f
+       189: fmul
+       190: fadd
+       191: fcmpg
+       192: ifge          308
+       195: aload_0
+       196: getfield      #461                // Field random:Lnet/minecraft/util/RandomSource;
+       199: invokeinterface #2413,  1         // InterfaceMethod net/minecraft/util/RandomSource.nextDouble:()D
+       204: ldc2_w        #2414               // double 2.0d
+       207: dmul
+       208: dconst_1
+       209: dsub
+       210: aload_0
+       211: getfield      #581                // Field dimensions:Lnet/minecraft/world/entity/EntityDimensions;
+       214: invokevirtual #2410               // Method net/minecraft/world/entity/EntityDimensions.width:()F
+       217: f2d
+       218: dmul
+       219: dstore        7
+       221: aload_0
+       222: getfield      #461                // Field random:Lnet/minecraft/util/RandomSource;
+       225: invokeinterface #2413,  1         // InterfaceMethod net/minecraft/util/RandomSource.nextDouble:()D
+       230: ldc2_w        #2414               // double 2.0d
+       233: dmul
+       234: dconst_1
+       235: dsub
+       236: aload_0
+       237: getfield      #581                // Field dimensions:Lnet/minecraft/world/entity/EntityDimensions;
+       240: invokevirtual #2410               // Method net/minecraft/world/entity/EntityDimensions.width:()F
+       243: f2d
+       244: dmul
+       245: dstore        9
+       247: aload_0
+       248: invokevirtual #672                // Method level:()Lnet/minecraft/world/level/Level;
+       251: getstatic     #2421               // Field net/minecraft/core/particles/ParticleTypes.BUBBLE:Lnet/minecraft/core/particles/SimpleParticleType;
+       254: aload_0
+       255: invokevirtual #880                // Method getX:()D
+       258: dload         7
+       260: dadd
+       261: fload         5
+       263: fconst_1
+       264: fadd
+       265: f2d
+       266: aload_0
+       267: invokevirtual #886                // Method getZ:()D
+       270: dload         9
+       272: dadd
+       273: aload_3
+       274: getfield      #932                // Field net/minecraft/world/phys/Vec3.x:D
+       277: aload_3
+       278: getfield      #934                // Field net/minecraft/world/phys/Vec3.y:D
+       281: aload_0
+       282: getfield      #461                // Field random:Lnet/minecraft/util/RandomSource;
+       285: invokeinterface #2413,  1         // InterfaceMethod net/minecraft/util/RandomSource.nextDouble:()D
+       290: ldc2_w        #2149               // double 0.20000000298023224d
+       293: dmul
+       294: dsub
+       295: aload_3
+       296: getfield      #936                // Field net/minecraft/world/phys/Vec3.z:D
+       299: invokevirtual #2425               // Method net/minecraft/world/level/Level.addParticle:(Lnet/minecraft/core/particles/ParticleOptions;DDDDDD)V
+       302: iinc          6, 1
+       305: goto          175
+       308: iconst_0
+       309: istore        6
+       311: iload         6
+       313: i2f
+       314: fconst_1
+       315: aload_0
+       316: getfield      #581                // Field dimensions:Lnet/minecraft/world/entity/EntityDimensions;
+       319: invokevirtual #2410               // Method net/minecraft/world/entity/EntityDimensions.width:()F
+       322: ldc_w         #1133               // float 20.0f
+       325: fmul
+       326: fadd
+       327: fcmpg
+       328: ifge          430
+       331: aload_0
+       332: getfield      #461                // Field random:Lnet/minecraft/util/RandomSource;
+       335: invokeinterface #2413,  1         // InterfaceMethod net/minecraft/util/RandomSource.nextDouble:()D
+       340: ldc2_w        #2414               // double 2.0d
+       343: dmul
+       344: dconst_1
+       345: dsub
+       346: aload_0
+       347: getfield      #581                // Field dimensions:Lnet/minecraft/world/entity/EntityDimensions;
+       350: invokevirtual #2410               // Method net/minecraft/world/entity/EntityDimensions.width:()F
+       353: f2d
+       354: dmul
+       355: dstore        7
+       357: aload_0
+       358: getfield      #461                // Field random:Lnet/minecraft/util/RandomSource;
+       361: invokeinterface #2413,  1         // InterfaceMethod net/minecraft/util/RandomSource.nextDouble:()D
+       366: ldc2_w        #2414               // double 2.0d
+       369: dmul
+       370: dconst_1
+       371: dsub
+       372: aload_0
+       373: getfield      #581                // Field dimensions:Lnet/minecraft/world/entity/EntityDimensions;
+       376: invokevirtual #2410               // Method net/minecraft/world/entity/EntityDimensions.width:()F
+       379: f2d
+       380: dmul
+       381: dstore        9
+       383: aload_0
+       384: invokevirtual #672                // Method level:()Lnet/minecraft/world/level/Level;
+       387: getstatic     #2428               // Field net/minecraft/core/particles/ParticleTypes.SPLASH:Lnet/minecraft/core/particles/SimpleParticleType;
+       390: aload_0
+       391: invokevirtual #880                // Method getX:()D
+       394: dload         7
+       396: dadd
+       397: fload         5
+       399: fconst_1
+       400: fadd
+       401: f2d
+       402: aload_0
+       403: invokevirtual #886                // Method getZ:()D
+       406: dload         9
+       408: dadd
+       409: aload_3
+       410: getfield      #932                // Field net/minecraft/world/phys/Vec3.x:D
+       413: aload_3
+       414: getfield      #934                // Field net/minecraft/world/phys/Vec3.y:D
+       417: aload_3
+       418: getfield      #936                // Field net/minecraft/world/phys/Vec3.z:D
+       421: invokevirtual #2425               // Method net/minecraft/world/level/Level.addParticle:(Lnet/minecraft/core/particles/ParticleOptions;DDDDDD)V
+       424: iinc          6, 1
+       427: goto          311
+       430: aload_0
+       431: getstatic     #2430               // Field net/minecraft/world/level/gameevent/GameEvent.SPLASH:Lnet/minecraft/core/Holder$Reference;
+       434: invokevirtual #828                // Method gameEvent:(Lnet/minecraft/core/Holder;)V
+       437: return
+
+  protected net.minecraft.world.level.block.state.BlockState getBlockStateOnLegacy();
+    Code:
+         0: aload_0
+         1: invokevirtual #672                // Method level:()Lnet/minecraft/world/level/Level;
+         4: aload_0
+         5: invokevirtual #1335               // Method getOnPosLegacy:()Lnet/minecraft/core/BlockPos;
+         8: invokevirtual #1339               // Method net/minecraft/world/level/Level.getBlockState:(Lnet/minecraft/core/BlockPos;)Lnet/minecraft/world/level/block/state/BlockState;
+        11: areturn
+
+  public net.minecraft.world.level.block.state.BlockState getBlockStateOn();
+    Code:
+         0: aload_0
+         1: invokevirtual #672                // Method level:()Lnet/minecraft/world/level/Level;
+         4: aload_0
+         5: invokevirtual #1470               // Method getOnPos:()Lnet/minecraft/core/BlockPos;
+         8: invokevirtual #1339               // Method net/minecraft/world/level/Level.getBlockState:(Lnet/minecraft/core/BlockPos;)Lnet/minecraft/world/level/block/state/BlockState;
+        11: areturn
+
+  public boolean canSpawnSprintParticle();
+    Code:
+         0: aload_0
+         1: invokevirtual #2366               // Method isSprinting:()Z
+         4: ifeq          46
+         7: aload_0
+         8: invokevirtual #1496               // Method isInWater:()Z
+        11: ifne          46
+        14: aload_0
+        15: invokevirtual #746                // Method isSpectator:()Z
+        18: ifne          46
+        21: aload_0
+        22: invokevirtual #1629               // Method isCrouching:()Z
+        25: ifne          46
+        28: aload_0
+        29: invokevirtual #1027               // Method isInLava:()Z
+        32: ifne          46
+        35: aload_0
+        36: invokevirtual #741                // Method isAlive:()Z
+        39: ifeq          46
+        42: iconst_1
+        43: goto          47
+        46: iconst_0
+        47: ireturn
+
+  protected void spawnSprintParticle();
+    Code:
+         0: aload_0
+         1: invokevirtual #1335               // Method getOnPosLegacy:()Lnet/minecraft/core/BlockPos;
+         4: astore_1
+         5: aload_0
+         6: invokevirtual #672                // Method level:()Lnet/minecraft/world/level/Level;
+         9: aload_1
+        10: invokevirtual #1339               // Method net/minecraft/world/level/Level.getBlockState:(Lnet/minecraft/core/BlockPos;)Lnet/minecraft/world/level/block/state/BlockState;
+        13: astore_2
+        14: aload_2
+        15: invokevirtual #2439               // Method net/minecraft/world/level/block/state/BlockState.getRenderShape:()Lnet/minecraft/world/level/block/RenderShape;
+        18: getstatic     #2445               // Field net/minecraft/world/level/block/RenderShape.INVISIBLE:Lnet/minecraft/world/level/block/RenderShape;
+        21: if_acmpeq     204
+        24: aload_0
+        25: invokevirtual #1369               // Method getDeltaMovement:()Lnet/minecraft/world/phys/Vec3;
+        28: astore_3
+        29: aload_0
+        30: invokevirtual #1698               // Method blockPosition:()Lnet/minecraft/core/BlockPos;
+        33: astore        4
+        35: aload_0
+        36: invokevirtual #880                // Method getX:()D
+        39: aload_0
+        40: getfield      #461                // Field random:Lnet/minecraft/util/RandomSource;
+        43: invokeinterface #2413,  1         // InterfaceMethod net/minecraft/util/RandomSource.nextDouble:()D
+        48: ldc2_w        #1047               // double 0.5d
+        51: dsub
+        52: aload_0
+        53: getfield      #581                // Field dimensions:Lnet/minecraft/world/entity/EntityDimensions;
+        56: invokevirtual #2410               // Method net/minecraft/world/entity/EntityDimensions.width:()F
+        59: f2d
+        60: dmul
+        61: dadd
+        62: dstore        5
+        64: aload_0
+        65: invokevirtual #886                // Method getZ:()D
+        68: aload_0
+        69: getfield      #461                // Field random:Lnet/minecraft/util/RandomSource;
+        72: invokeinterface #2413,  1         // InterfaceMethod net/minecraft/util/RandomSource.nextDouble:()D
+        77: ldc2_w        #1047               // double 0.5d
+        80: dsub
+        81: aload_0
+        82: getfield      #581                // Field dimensions:Lnet/minecraft/world/entity/EntityDimensions;
+        85: invokevirtual #2410               // Method net/minecraft/world/entity/EntityDimensions.width:()F
+        88: f2d
+        89: dmul
+        90: dadd
+        91: dstore        7
+        93: aload         4
+        95: invokevirtual #2099               // Method net/minecraft/core/BlockPos.getX:()I
+        98: aload_1
+        99: invokevirtual #2099               // Method net/minecraft/core/BlockPos.getX:()I
+       102: if_icmpeq     124
+       105: dload         5
+       107: aload_1
+       108: invokevirtual #2099               // Method net/minecraft/core/BlockPos.getX:()I
+       111: i2d
+       112: aload_1
+       113: invokevirtual #2099               // Method net/minecraft/core/BlockPos.getX:()I
+       116: i2d
+       117: dconst_1
+       118: dadd
+       119: invokestatic  #1743               // Method net/minecraft/util/Mth.clamp:(DDD)D
+       122: dstore        5
+       124: aload         4
+       126: invokevirtual #2101               // Method net/minecraft/core/BlockPos.getZ:()I
+       129: aload_1
+       130: invokevirtual #2101               // Method net/minecraft/core/BlockPos.getZ:()I
+       133: if_icmpeq     155
+       136: dload         7
+       138: aload_1
+       139: invokevirtual #2101               // Method net/minecraft/core/BlockPos.getZ:()I
+       142: i2d
+       143: aload_1
+       144: invokevirtual #2101               // Method net/minecraft/core/BlockPos.getZ:()I
+       147: i2d
+       148: dconst_1
+       149: dadd
+       150: invokestatic  #1743               // Method net/minecraft/util/Mth.clamp:(DDD)D
+       153: dstore        7
+       155: aload_0
+       156: invokevirtual #672                // Method level:()Lnet/minecraft/world/level/Level;
+       159: new           #2447               // class net/minecraft/core/particles/BlockParticleOption
+       162: dup
+       163: getstatic     #2451               // Field net/minecraft/core/particles/ParticleTypes.BLOCK:Lnet/minecraft/core/particles/ParticleType;
+       166: aload_2
+       167: invokespecial #2454               // Method net/minecraft/core/particles/BlockParticleOption."<init>":(Lnet/minecraft/core/particles/ParticleType;Lnet/minecraft/world/level/block/state/BlockState;)V
+       170: dload         5
+       172: aload_0
+       173: invokevirtual #883                // Method getY:()D
+       176: ldc2_w        #2455               // double 0.1d
+       179: dadd
+       180: dload         7
+       182: aload_3
+       183: getfield      #932                // Field net/minecraft/world/phys/Vec3.x:D
+       186: ldc2_w        #2457               // double -4.0d
+       189: dmul
+       190: ldc2_w        #2459               // double 1.5d
+       193: aload_3
+       194: getfield      #936                // Field net/minecraft/world/phys/Vec3.z:D
+       197: ldc2_w        #2457               // double -4.0d
+       200: dmul
+       201: invokevirtual #2425               // Method net/minecraft/world/level/Level.addParticle:(Lnet/minecraft/core/particles/ParticleOptions;DDDDDD)V
+       204: return
+
+  public boolean isEyeInFluid(net.minecraft.tags.TagKey<net.minecraft.world.level.material.Fluid>);
+    Code:
+         0: aload_0
+         1: getfield      #482                // Field fluidInteraction:Lnet/minecraft/world/entity/EntityFluidInteraction;
+         4: aload_1
+         5: invokevirtual #2463               // Method net/minecraft/world/entity/EntityFluidInteraction.isEyeInFluid:(Lnet/minecraft/tags/TagKey;)Z
+         8: ireturn
+
+  public boolean isInLava();
+    Code:
+         0: aload_0
+         1: getfield      #484                // Field firstTick:Z
+         4: ifne          24
+         7: aload_0
+         8: getfield      #482                // Field fluidInteraction:Lnet/minecraft/world/entity/EntityFluidInteraction;
+        11: getstatic     #472                // Field net/minecraft/tags/FluidTags.LAVA:Lnet/minecraft/tags/TagKey;
+        14: invokevirtual #2384               // Method net/minecraft/world/entity/EntityFluidInteraction.isInFluid:(Lnet/minecraft/tags/TagKey;)Z
+        17: ifeq          24
+        20: iconst_1
+        21: goto          25
+        24: iconst_0
+        25: ireturn
+
+  public void moveRelative(float, net.minecraft.world.phys.Vec3);
+    Code:
+         0: aload_2
+         1: fload_1
+         2: aload_0
+         3: invokevirtual #945                // Method getYRot:()F
+         6: invokestatic  #2471               // Method getInputVector:(Lnet/minecraft/world/phys/Vec3;FF)Lnet/minecraft/world/phys/Vec3;
+         9: astore_3
+        10: aload_0
+        11: aload_0
+        12: invokevirtual #1369               // Method getDeltaMovement:()Lnet/minecraft/world/phys/Vec3;
+        15: aload_3
+        16: invokevirtual #1280               // Method net/minecraft/world/phys/Vec3.add:(Lnet/minecraft/world/phys/Vec3;)Lnet/minecraft/world/phys/Vec3;
+        19: invokevirtual #1259               // Method setDeltaMovement:(Lnet/minecraft/world/phys/Vec3;)V
+        22: return
+
+  protected static net.minecraft.world.phys.Vec3 getInputVector(net.minecraft.world.phys.Vec3, float, float);
+    Code:
+         0: aload_0
+         1: invokevirtual #1251               // Method net/minecraft/world/phys/Vec3.lengthSqr:()D
+         4: dstore_3
+         5: dload_3
+         6: ldc2_w        #1252               // double 1.0E-7d
+         9: dcmpg
+        10: ifge          17
+        13: getstatic     #443                // Field net/minecraft/world/phys/Vec3.ZERO:Lnet/minecraft/world/phys/Vec3;
+        16: areturn
+        17: dload_3
+        18: dconst_1
+        19: dcmpl
+        20: ifle          30
+        23: aload_0
+        24: invokevirtual #1274               // Method net/minecraft/world/phys/Vec3.normalize:()Lnet/minecraft/world/phys/Vec3;
+        27: goto          31
+        30: aload_0
+        31: fload_1
+        32: f2d
+        33: invokevirtual #1278               // Method net/minecraft/world/phys/Vec3.scale:(D)Lnet/minecraft/world/phys/Vec3;
+        36: astore        5
+        38: fload_2
+        39: ldc_w         #2472               // float 0.017453292f
+        42: fmul
+        43: f2d
+        44: invokestatic  #2476               // Method net/minecraft/util/Mth.sin:(D)F
+        47: fstore        6
+        49: fload_2
+        50: ldc_w         #2472               // float 0.017453292f
+        53: fmul
+        54: f2d
+        55: invokestatic  #2479               // Method net/minecraft/util/Mth.cos:(D)F
+        58: fstore        7
+        60: new           #440                // class net/minecraft/world/phys/Vec3
+        63: dup
+        64: aload         5
+        66: getfield      #932                // Field net/minecraft/world/phys/Vec3.x:D
+        69: fload         7
+        71: f2d
+        72: dmul
+        73: aload         5
+        75: getfield      #936                // Field net/minecraft/world/phys/Vec3.z:D
+        78: fload         6
+        80: f2d
+        81: dmul
+        82: dsub
+        83: aload         5
+        85: getfield      #934                // Field net/minecraft/world/phys/Vec3.y:D
+        88: aload         5
+        90: getfield      #936                // Field net/minecraft/world/phys/Vec3.z:D
+        93: fload         7
+        95: f2d
+        96: dmul
+        97: aload         5
+        99: getfield      #932                // Field net/minecraft/world/phys/Vec3.x:D
+       102: fload         6
+       104: f2d
+       105: dmul
+       106: dadd
+       107: invokespecial #765                // Method net/minecraft/world/phys/Vec3."<init>":(DDD)V
+       110: areturn
+
+  public float getLightLevelDependentMagicValue();
+    Code:
+         0: aload_0
+         1: invokevirtual #672                // Method level:()Lnet/minecraft/world/level/Level;
+         4: aload_0
+         5: invokevirtual #2483               // Method getBlockX:()I
+         8: aload_0
+         9: invokevirtual #2486               // Method getBlockZ:()I
+        12: invokevirtual #2490               // Method net/minecraft/world/level/Level.hasChunkAt:(II)Z
+        15: ifeq          41
+        18: aload_0
+        19: invokevirtual #672                // Method level:()Lnet/minecraft/world/level/Level;
+        22: aload_0
+        23: invokevirtual #880                // Method getX:()D
+        26: aload_0
+        27: invokevirtual #2493               // Method getEyeY:()D
+        30: aload_0
+        31: invokevirtual #886                // Method getZ:()D
+        34: invokestatic  #2111               // Method net/minecraft/core/BlockPos.containing:(DDD)Lnet/minecraft/core/BlockPos;
+        37: invokevirtual #2496               // Method net/minecraft/world/level/Level.getLightLevelDependentMagicValue:(Lnet/minecraft/core/BlockPos;)F
+        40: freturn
+        41: fconst_0
+        42: freturn
+
+  public void absSnapTo(double, double, double, float, float);
+    Code:
+         0: aload_0
+         1: dload_1
+         2: dload_3
+         3: dload         5
+         5: invokevirtual #2500               // Method absSnapTo:(DDD)V
+         8: aload_0
+         9: fload         7
+        11: fload         8
+        13: invokevirtual #2503               // Method absSnapRotationTo:(FF)V
+        16: return
+
+  public void absSnapRotationTo(float, float);
+    Code:
+         0: aload_0
+         1: fload_1
+         2: ldc_w         #900                // float 360.0f
+         5: frem
+         6: invokevirtual #904                // Method setYRot:(F)V
+         9: aload_0
+        10: fload_2
+        11: ldc_w         #946                // float -90.0f
+        14: ldc_w         #947                // float 90.0f
+        17: invokestatic  #951                // Method net/minecraft/util/Mth.clamp:(FFF)F
+        20: ldc_w         #900                // float 360.0f
+        23: frem
+        24: invokevirtual #907                // Method setXRot:(F)V
+        27: aload_0
+        28: aload_0
+        29: invokevirtual #945                // Method getYRot:()F
+        32: putfield      #955                // Field yRotO:F
+        35: aload_0
+        36: aload_0
+        37: invokevirtual #942                // Method getXRot:()F
+        40: putfield      #953                // Field xRotO:F
+        43: return
+
+  public void absSnapTo(double, double, double);
+    Code:
+         0: dload_1
+         1: ldc2_w        #2504               // double -3.0E7d
+         4: ldc2_w        #2506               // double 3.0E7d
+         7: invokestatic  #1743               // Method net/minecraft/util/Mth.clamp:(DDD)D
+        10: dstore        7
+        12: dload         5
+        14: ldc2_w        #2504               // double -3.0E7d
+        17: ldc2_w        #2506               // double 3.0E7d
+        20: invokestatic  #1743               // Method net/minecraft/util/Mth.clamp:(DDD)D
+        23: dstore        9
+        25: aload_0
+        26: dload         7
+        28: putfield      #2509               // Field xo:D
+        31: aload_0
+        32: dload_3
+        33: putfield      #2511               // Field yo:D
+        36: aload_0
+        37: dload         9
+        39: putfield      #2513               // Field zo:D
+        42: aload_0
+        43: dload         7
+        45: dload_3
+        46: dload         9
+        48: invokevirtual #655                // Method setPos:(DDD)V
+        51: return
+
+  public void snapTo(net.minecraft.world.phys.Vec3);
+    Code:
+         0: aload_0
+         1: aload_1
+         2: getfield      #932                // Field net/minecraft/world/phys/Vec3.x:D
+         5: aload_1
+         6: getfield      #934                // Field net/minecraft/world/phys/Vec3.y:D
+         9: aload_1
+        10: getfield      #936                // Field net/minecraft/world/phys/Vec3.z:D
+        13: invokevirtual #2518               // Method snapTo:(DDD)V
+        16: return
+
+  public void snapTo(double, double, double);
+    Code:
+         0: aload_0
+         1: dload_1
+         2: dload_3
+         3: dload         5
+         5: aload_0
+         6: invokevirtual #945                // Method getYRot:()F
+         9: aload_0
+        10: invokevirtual #942                // Method getXRot:()F
+        13: invokevirtual #2520               // Method snapTo:(DDDFF)V
+        16: return
+
+  public void snapTo(net.minecraft.core.BlockPos, float, float);
+    Code:
+         0: aload_0
+         1: aload_1
+         2: invokestatic  #2524               // Method net/minecraft/world/phys/Vec3.atBottomCenterOf:(Lnet/minecraft/core/Vec3i;)Lnet/minecraft/world/phys/Vec3;
+         5: fload_2
+         6: fload_3
+         7: invokevirtual #2527               // Method snapTo:(Lnet/minecraft/world/phys/Vec3;FF)V
+        10: return
+
+  public void snapTo(net.minecraft.world.phys.Vec3, float, float);
+    Code:
+         0: aload_0
+         1: aload_1
+         2: getfield      #932                // Field net/minecraft/world/phys/Vec3.x:D
+         5: aload_1
+         6: getfield      #934                // Field net/minecraft/world/phys/Vec3.y:D
+         9: aload_1
+        10: getfield      #936                // Field net/minecraft/world/phys/Vec3.z:D
+        13: fload_2
+        14: fload_3
+        15: invokevirtual #2520               // Method snapTo:(DDDFF)V
+        18: return
+
+  public void snapTo(double, double, double, float, float);
+    Code:
+         0: aload_0
+         1: dload_1
+         2: dload_3
+         3: dload         5
+         5: invokevirtual #916                // Method setPosRaw:(DDD)V
+         8: aload_0
+         9: fload         7
+        11: invokevirtual #904                // Method setYRot:(F)V
+        14: aload_0
+        15: fload         8
+        17: invokevirtual #907                // Method setXRot:(F)V
+        20: aload_0
+        21: invokevirtual #2530               // Method setOldPosAndRot:()V
+        24: aload_0
+        25: invokevirtual #2532               // Method reapplyPosition:()V
+        28: return
+
+  public final void setOldPosAndRot();
+    Code:
+         0: aload_0
+         1: invokevirtual #2535               // Method setOldPos:()V
+         4: aload_0
+         5: invokevirtual #2538               // Method setOldRot:()V
+         8: return
+
+  public final void setOldPosAndRot(net.minecraft.world.phys.Vec3, float, float);
+    Code:
+         0: aload_0
+         1: aload_1
+         2: invokevirtual #2540               // Method setOldPos:(Lnet/minecraft/world/phys/Vec3;)V
+         5: aload_0
+         6: fload_2
+         7: fload_3
+         8: invokevirtual #2542               // Method setOldRot:(FF)V
+        11: return
+
+  protected void setOldPos();
+    Code:
+         0: aload_0
+         1: aload_0
+         2: getfield      #583                // Field position:Lnet/minecraft/world/phys/Vec3;
+         5: invokevirtual #2540               // Method setOldPos:(Lnet/minecraft/world/phys/Vec3;)V
+         8: return
+
+  public void setOldRot();
+    Code:
+         0: aload_0
+         1: aload_0
+         2: invokevirtual #945                // Method getYRot:()F
+         5: aload_0
+         6: invokevirtual #942                // Method getXRot:()F
+         9: invokevirtual #2542               // Method setOldRot:(FF)V
+        12: return
+
+  private void setOldPos(net.minecraft.world.phys.Vec3);
+    Code:
+         0: aload_0
+         1: aload_0
+         2: aload_1
+         3: getfield      #932                // Field net/minecraft/world/phys/Vec3.x:D
+         6: dup2_x1
+         7: putfield      #2544               // Field xOld:D
+        10: putfield      #2509               // Field xo:D
+        13: aload_0
+        14: aload_0
+        15: aload_1
+        16: getfield      #934                // Field net/minecraft/world/phys/Vec3.y:D
+        19: dup2_x1
+        20: putfield      #2546               // Field yOld:D
+        23: putfield      #2511               // Field yo:D
+        26: aload_0
+        27: aload_0
+        28: aload_1
+        29: getfield      #936                // Field net/minecraft/world/phys/Vec3.z:D
+        32: dup2_x1
+        33: putfield      #2548               // Field zOld:D
+        36: putfield      #2513               // Field zo:D
+        39: return
+
+  private void setOldRot(float, float);
+    Code:
+         0: aload_0
+         1: fload_1
+         2: putfield      #955                // Field yRotO:F
+         5: aload_0
+         6: fload_2
+         7: putfield      #953                // Field xRotO:F
+        10: return
+
+  public final net.minecraft.world.phys.Vec3 oldPosition();
+    Code:
+         0: new           #440                // class net/minecraft/world/phys/Vec3
+         3: dup
+         4: aload_0
+         5: getfield      #2544               // Field xOld:D
+         8: aload_0
+         9: getfield      #2546               // Field yOld:D
+        12: aload_0
+        13: getfield      #2548               // Field zOld:D
+        16: invokespecial #765                // Method net/minecraft/world/phys/Vec3."<init>":(DDD)V
+        19: areturn
+
+  public float distanceTo(net.minecraft.world.entity.Entity);
+    Code:
+         0: aload_0
+         1: invokevirtual #880                // Method getX:()D
+         4: aload_1
+         5: invokevirtual #880                // Method getX:()D
+         8: dsub
+         9: d2f
+        10: fstore_2
+        11: aload_0
+        12: invokevirtual #883                // Method getY:()D
+        15: aload_1
+        16: invokevirtual #883                // Method getY:()D
+        19: dsub
+        20: d2f
+        21: fstore_3
+        22: aload_0
+        23: invokevirtual #886                // Method getZ:()D
+        26: aload_1
+        27: invokevirtual #886                // Method getZ:()D
+        30: dsub
+        31: d2f
+        32: fstore        4
+        34: fload_2
+        35: fload_2
+        36: fmul
+        37: fload_3
+        38: fload_3
+        39: fmul
+        40: fadd
+        41: fload         4
+        43: fload         4
+        45: fmul
+        46: fadd
+        47: invokestatic  #2553               // Method net/minecraft/util/Mth.sqrt:(F)F
+        50: freturn
+
+  public double distanceToSqr(double, double, double);
+    Code:
+         0: aload_0
+         1: invokevirtual #880                // Method getX:()D
+         4: dload_1
+         5: dsub
+         6: dstore        7
+         8: aload_0
+         9: invokevirtual #883                // Method getY:()D
+        12: dload_3
+        13: dsub
+        14: dstore        9
+        16: aload_0
+        17: invokevirtual #886                // Method getZ:()D
+        20: dload         5
+        22: dsub
+        23: dstore        11
+        25: dload         7
+        27: dload         7
+        29: dmul
+        30: dload         9
+        32: dload         9
+        34: dmul
+        35: dadd
+        36: dload         11
+        38: dload         11
+        40: dmul
+        41: dadd
+        42: dreturn
+
+  public double distanceToSqr(net.minecraft.world.entity.Entity);
+    Code:
+         0: aload_0
+         1: aload_1
+         2: invokevirtual #870                // Method position:()Lnet/minecraft/world/phys/Vec3;
+         5: invokevirtual #2561               // Method distanceToSqr:(Lnet/minecraft/world/phys/Vec3;)D
+         8: dreturn
+
+  public double distanceToSqr(net.minecraft.world.phys.Vec3);
+    Code:
+         0: aload_0
+         1: invokevirtual #880                // Method getX:()D
+         4: aload_1
+         5: getfield      #932                // Field net/minecraft/world/phys/Vec3.x:D
+         8: dsub
+         9: dstore_2
+        10: aload_0
+        11: invokevirtual #883                // Method getY:()D
+        14: aload_1
+        15: getfield      #934                // Field net/minecraft/world/phys/Vec3.y:D
+        18: dsub
+        19: dstore        4
+        21: aload_0
+        22: invokevirtual #886                // Method getZ:()D
+        25: aload_1
+        26: getfield      #936                // Field net/minecraft/world/phys/Vec3.z:D
+        29: dsub
+        30: dstore        6
+        32: dload_2
+        33: dload_2
+        34: dmul
+        35: dload         4
+        37: dload         4
+        39: dmul
+        40: dadd
+        41: dload         6
+        43: dload         6
+        45: dmul
+        46: dadd
+        47: dreturn
+
+  public void playerTouch(net.minecraft.world.entity.player.Player);
+    Code:
+         0: return
+
+  public void push(net.minecraft.world.entity.Entity);
+    Code:
+         0: aload_0
+         1: aload_1
+         2: invokevirtual #2569               // Method isPassengerOfSameVehicle:(Lnet/minecraft/world/entity/Entity;)Z
+         5: ifeq          9
+         8: return
+         9: aload_1
+        10: getfield      #1231               // Field noPhysics:Z
+        13: ifne          23
+        16: aload_0
+        17: getfield      #1231               // Field noPhysics:Z
+        20: ifeq          24
+        23: return
+        24: aload_1
+        25: invokevirtual #880                // Method getX:()D
+        28: aload_0
+        29: invokevirtual #880                // Method getX:()D
+        32: dsub
+        33: dstore_2
+        34: aload_1
+        35: invokevirtual #886                // Method getZ:()D
+        38: aload_0
+        39: invokevirtual #886                // Method getZ:()D
+        42: dsub
+        43: dstore        4
+        45: dload_2
+        46: dload         4
+        48: invokestatic  #2572               // Method net/minecraft/util/Mth.absMax:(DD)D
+        51: dstore        6
+        53: dload         6
+        55: ldc2_w        #2573               // double 0.009999999776482582d
+        58: dcmpl
+        59: iflt          169
+        62: dload         6
+        64: invokestatic  #2153               // Method java/lang/Math.sqrt:(D)D
+        67: dstore        6
+        69: dload_2
+        70: dload         6
+        72: ddiv
+        73: dstore_2
+        74: dload         4
+        76: dload         6
+        78: ddiv
+        79: dstore        4
+        81: dconst_1
+        82: dload         6
+        84: ddiv
+        85: dstore        8
+        87: dload         8
+        89: dconst_1
+        90: dcmpl
+        91: ifle          97
+        94: dconst_1
+        95: dstore        8
+        97: dload_2
+        98: dload         8
+       100: dmul
+       101: dstore_2
+       102: dload         4
+       104: dload         8
+       106: dmul
+       107: dstore        4
+       109: dload_2
+       110: ldc2_w        #2575               // double 0.05000000074505806d
+       113: dmul
+       114: dstore_2
+       115: dload         4
+       117: ldc2_w        #2575               // double 0.05000000074505806d
+       120: dmul
+       121: dstore        4
+       123: aload_0
+       124: invokevirtual #750                // Method isVehicle:()Z
+       127: ifne          147
+       130: aload_0
+       131: invokevirtual #2579               // Method isPushable:()Z
+       134: ifeq          147
+       137: aload_0
+       138: dload_2
+       139: dneg
+       140: dconst_0
+       141: dload         4
+       143: dneg
+       144: invokevirtual #2581               // Method push:(DDD)V
+       147: aload_1
+       148: invokevirtual #750                // Method isVehicle:()Z
+       151: ifne          169
+       154: aload_1
+       155: invokevirtual #2579               // Method isPushable:()Z
+       158: ifeq          169
+       161: aload_1
+       162: dload_2
+       163: dconst_0
+       164: dload         4
+       166: invokevirtual #2581               // Method push:(DDD)V
+       169: return
+
+  public void push(net.minecraft.world.phys.Vec3);
+    Code:
+         0: aload_1
+         1: invokevirtual #2586               // Method net/minecraft/world/phys/Vec3.isFinite:()Z
+         4: ifeq          23
+         7: aload_0
+         8: aload_1
+         9: getfield      #932                // Field net/minecraft/world/phys/Vec3.x:D
+        12: aload_1
+        13: getfield      #934                // Field net/minecraft/world/phys/Vec3.y:D
+        16: aload_1
+        17: getfield      #936                // Field net/minecraft/world/phys/Vec3.z:D
+        20: invokevirtual #2581               // Method push:(DDD)V
+        23: return
+
+  public void push(double, double, double);
+    Code:
+         0: dload_1
+         1: invokestatic  #2589               // Method java/lang/Double.isFinite:(D)Z
+         4: ifeq          42
+         7: dload_3
+         8: invokestatic  #2589               // Method java/lang/Double.isFinite:(D)Z
+        11: ifeq          42
+        14: dload         5
+        16: invokestatic  #2589               // Method java/lang/Double.isFinite:(D)Z
+        19: ifeq          42
+        22: aload_0
+        23: aload_0
+        24: invokevirtual #1369               // Method getDeltaMovement:()Lnet/minecraft/world/phys/Vec3;
+        27: dload_1
+        28: dload_3
+        29: dload         5
+        31: invokevirtual #2249               // Method net/minecraft/world/phys/Vec3.add:(DDD)Lnet/minecraft/world/phys/Vec3;
+        34: invokevirtual #1259               // Method setDeltaMovement:(Lnet/minecraft/world/phys/Vec3;)V
+        37: aload_0
+        38: iconst_1
+        39: putfield      #2591               // Field needsSync:Z
+        42: return
+
+  protected void markHurt();
+    Code:
+         0: aload_0
+         1: iconst_1
+         2: putfield      #2594               // Field hurtMarked:Z
+         5: return
+
+  public final void hurt(net.minecraft.world.damagesource.DamageSource, float);
+    Code:
+         0: aload_0
+         1: getfield      #567                // Field level:Lnet/minecraft/world/level/Level;
+         4: astore        4
+         6: aload         4
+         8: instanceof    #1016               // class net/minecraft/server/level/ServerLevel
+        11: ifeq          28
+        14: aload         4
+        16: checkcast     #1016               // class net/minecraft/server/level/ServerLevel
+        19: astore_3
+        20: aload_0
+        21: aload_3
+        22: aload_1
+        23: fload_2
+        24: invokevirtual #1041               // Method hurtServer:(Lnet/minecraft/server/level/ServerLevel;Lnet/minecraft/world/damagesource/DamageSource;F)Z
+        27: pop
+        28: return
+
+  public final boolean hurtOrSimulate(net.minecraft.world.damagesource.DamageSource, float);
+    Code:
+         0: aload_0
+         1: getfield      #567                // Field level:Lnet/minecraft/world/level/Level;
+         4: astore        4
+         6: aload         4
+         8: instanceof    #1016               // class net/minecraft/server/level/ServerLevel
+        11: ifeq          28
+        14: aload         4
+        16: checkcast     #1016               // class net/minecraft/server/level/ServerLevel
+        19: astore_3
+        20: aload_0
+        21: aload_3
+        22: aload_1
+        23: fload_2
+        24: invokevirtual #1041               // Method hurtServer:(Lnet/minecraft/server/level/ServerLevel;Lnet/minecraft/world/damagesource/DamageSource;F)Z
+        27: ireturn
+        28: aload_0
+        29: aload_1
+        30: invokevirtual #2603               // Method hurtClient:(Lnet/minecraft/world/damagesource/DamageSource;)Z
+        33: ireturn
+
+  public abstract boolean hurtServer(net.minecraft.server.level.ServerLevel, net.minecraft.world.damagesource.DamageSource, float);
+
+  public boolean hurtClient(net.minecraft.world.damagesource.DamageSource);
+    Code:
+         0: iconst_0
+         1: ireturn
+
+  public final net.minecraft.world.phys.Vec3 getViewVector(float);
+    Code:
+         0: aload_0
+         1: aload_0
+         2: fload_1
+         3: invokevirtual #2609               // Method getViewXRot:(F)F
+         6: aload_0
+         7: fload_1
+         8: invokevirtual #2612               // Method getViewYRot:(F)F
+        11: invokevirtual #2616               // Method calculateViewVector:(FF)Lnet/minecraft/world/phys/Vec3;
+        14: areturn
+
+  public net.minecraft.core.Direction getNearestViewDirection();
+    Code:
+         0: aload_0
+         1: fconst_1
+         2: invokevirtual #2619               // Method getViewVector:(F)Lnet/minecraft/world/phys/Vec3;
+         5: invokestatic  #2623               // Method net/minecraft/core/Direction.getApproximateNearest:(Lnet/minecraft/world/phys/Vec3;)Lnet/minecraft/core/Direction;
+         8: areturn
+
+  public float getViewXRot(float);
+    Code:
+         0: aload_0
+         1: fload_1
+         2: invokevirtual #2625               // Method getXRot:(F)F
+         5: freturn
+
+  public float getViewYRot(float);
+    Code:
+         0: aload_0
+         1: fload_1
+         2: invokevirtual #2627               // Method getYRot:(F)F
+         5: freturn
+
+  public float getXRot(float);
+    Code:
+         0: fload_1
+         1: fconst_1
+         2: fcmpl
+         3: ifne          11
+         6: aload_0
+         7: invokevirtual #942                // Method getXRot:()F
+        10: freturn
+        11: fload_1
+        12: aload_0
+        13: getfield      #953                // Field xRotO:F
+        16: aload_0
+        17: invokevirtual #942                // Method getXRot:()F
+        20: invokestatic  #2630               // Method net/minecraft/util/Mth.lerp:(FFF)F
+        23: freturn
+
+  public float getYRot(float);
+    Code:
+         0: fload_1
+         1: fconst_1
+         2: fcmpl
+         3: ifne          11
+         6: aload_0
+         7: invokevirtual #945                // Method getYRot:()F
+        10: freturn
+        11: fload_1
+        12: aload_0
+        13: getfield      #955                // Field yRotO:F
+        16: aload_0
+        17: invokevirtual #945                // Method getYRot:()F
+        20: invokestatic  #2633               // Method net/minecraft/util/Mth.rotLerp:(FFF)F
+        23: freturn
+
+  public final net.minecraft.world.phys.Vec3 calculateViewVector(float, float);
+    Code:
+         0: fload_1
+         1: ldc_w         #2472               // float 0.017453292f
+         4: fmul
+         5: fstore_3
+         6: fload_2
+         7: fneg
+         8: ldc_w         #2472               // float 0.017453292f
+        11: fmul
+        12: fstore        4
+        14: fload         4
+        16: f2d
+        17: invokestatic  #2479               // Method net/minecraft/util/Mth.cos:(D)F
+        20: fstore        5
+        22: fload         4
+        24: f2d
+        25: invokestatic  #2476               // Method net/minecraft/util/Mth.sin:(D)F
+        28: fstore        6
+        30: fload_3
+        31: f2d
+        32: invokestatic  #2479               // Method net/minecraft/util/Mth.cos:(D)F
+        35: fstore        7
+        37: fload_3
+        38: f2d
+        39: invokestatic  #2476               // Method net/minecraft/util/Mth.sin:(D)F
+        42: fstore        8
+        44: new           #440                // class net/minecraft/world/phys/Vec3
+        47: dup
+        48: fload         6
+        50: fload         7
+        52: fmul
+        53: f2d
+        54: fload         8
+        56: fneg
+        57: f2d
+        58: fload         5
+        60: fload         7
+        62: fmul
+        63: f2d
+        64: invokespecial #765                // Method net/minecraft/world/phys/Vec3."<init>":(DDD)V
+        67: areturn
+
+  public final net.minecraft.world.phys.Vec3 getUpVector(float);
+    Code:
+         0: aload_0
+         1: aload_0
+         2: fload_1
+         3: invokevirtual #2609               // Method getViewXRot:(F)F
+         6: aload_0
+         7: fload_1
+         8: invokevirtual #2612               // Method getViewYRot:(F)F
+        11: invokevirtual #2643               // Method calculateUpVector:(FF)Lnet/minecraft/world/phys/Vec3;
+        14: areturn
+
+  protected final net.minecraft.world.phys.Vec3 calculateUpVector(float, float);
+    Code:
+         0: aload_0
+         1: fload_1
+         2: ldc_w         #947                // float 90.0f
+         5: fsub
+         6: fload_2
+         7: invokevirtual #2616               // Method calculateViewVector:(FF)Lnet/minecraft/world/phys/Vec3;
+        10: areturn
+
+  public final net.minecraft.world.phys.Vec3 getEyePosition();
+    Code:
+         0: new           #440                // class net/minecraft/world/phys/Vec3
+         3: dup
+         4: aload_0
+         5: invokevirtual #880                // Method getX:()D
+         8: aload_0
+         9: invokevirtual #2493               // Method getEyeY:()D
+        12: aload_0
+        13: invokevirtual #886                // Method getZ:()D
+        16: invokespecial #765                // Method net/minecraft/world/phys/Vec3."<init>":(DDD)V
+        19: areturn
+
+  public final net.minecraft.world.phys.Vec3 getEyePosition(float);
+    Code:
+         0: fload_1
+         1: f2d
+         2: aload_0
+         3: getfield      #2509               // Field xo:D
+         6: aload_0
+         7: invokevirtual #880                // Method getX:()D
+        10: invokestatic  #1431               // Method net/minecraft/util/Mth.lerp:(DDD)D
+        13: dstore_2
+        14: fload_1
+        15: f2d
+        16: aload_0
+        17: getfield      #2511               // Field yo:D
+        20: aload_0
+        21: invokevirtual #883                // Method getY:()D
+        24: invokestatic  #1431               // Method net/minecraft/util/Mth.lerp:(DDD)D
+        27: aload_0
+        28: invokevirtual #2648               // Method getEyeHeight:()F
+        31: f2d
+        32: dadd
+        33: dstore        4
+        35: fload_1
+        36: f2d
+        37: aload_0
+        38: getfield      #2513               // Field zo:D
+        41: aload_0
+        42: invokevirtual #886                // Method getZ:()D
+        45: invokestatic  #1431               // Method net/minecraft/util/Mth.lerp:(DDD)D
+        48: dstore        6
+        50: new           #440                // class net/minecraft/world/phys/Vec3
+        53: dup
+        54: dload_2
+        55: dload         4
+        57: dload         6
+        59: invokespecial #765                // Method net/minecraft/world/phys/Vec3."<init>":(DDD)V
+        62: areturn
+
+  public net.minecraft.world.phys.Vec3 getLightProbePosition(float);
+    Code:
+         0: aload_0
+         1: fload_1
+         2: invokevirtual #2651               // Method getEyePosition:(F)Lnet/minecraft/world/phys/Vec3;
+         5: areturn
+
+  public final net.minecraft.world.phys.Vec3 getPosition(float);
+    Code:
+         0: fload_1
+         1: f2d
+         2: aload_0
+         3: getfield      #2509               // Field xo:D
+         6: aload_0
+         7: invokevirtual #880                // Method getX:()D
+        10: invokestatic  #1431               // Method net/minecraft/util/Mth.lerp:(DDD)D
+        13: dstore_2
+        14: fload_1
+        15: f2d
+        16: aload_0
+        17: getfield      #2511               // Field yo:D
+        20: aload_0
+        21: invokevirtual #883                // Method getY:()D
+        24: invokestatic  #1431               // Method net/minecraft/util/Mth.lerp:(DDD)D
+        27: dstore        4
+        29: fload_1
+        30: f2d
+        31: aload_0
+        32: getfield      #2513               // Field zo:D
+        35: aload_0
+        36: invokevirtual #886                // Method getZ:()D
+        39: invokestatic  #1431               // Method net/minecraft/util/Mth.lerp:(DDD)D
+        42: dstore        6
+        44: new           #440                // class net/minecraft/world/phys/Vec3
+        47: dup
+        48: dload_2
+        49: dload         4
+        51: dload         6
+        53: invokespecial #765                // Method net/minecraft/world/phys/Vec3."<init>":(DDD)V
+        56: areturn
+
+  public net.minecraft.world.phys.HitResult pick(double, float, boolean);
+    Code:
+         0: aload_0
+         1: fload_3
+         2: invokevirtual #2651               // Method getEyePosition:(F)Lnet/minecraft/world/phys/Vec3;
+         5: astore        5
+         7: aload_0
+         8: fload_3
+         9: invokevirtual #2619               // Method getViewVector:(F)Lnet/minecraft/world/phys/Vec3;
+        12: astore        6
+        14: aload         5
+        16: aload         6
+        18: getfield      #932                // Field net/minecraft/world/phys/Vec3.x:D
+        21: dload_1
+        22: dmul
+        23: aload         6
+        25: getfield      #934                // Field net/minecraft/world/phys/Vec3.y:D
+        28: dload_1
+        29: dmul
+        30: aload         6
+        32: getfield      #936                // Field net/minecraft/world/phys/Vec3.z:D
+        35: dload_1
+        36: dmul
+        37: invokevirtual #2249               // Method net/minecraft/world/phys/Vec3.add:(DDD)Lnet/minecraft/world/phys/Vec3;
+        40: astore        7
+        42: aload_0
+        43: invokevirtual #672                // Method level:()Lnet/minecraft/world/level/Level;
+        46: new           #64                 // class net/minecraft/world/level/ClipContext
+        49: dup
+        50: aload         5
+        52: aload         7
+        54: getstatic     #2662               // Field net/minecraft/world/level/ClipContext$Block.OUTLINE:Lnet/minecraft/world/level/ClipContext$Block;
+        57: iload         4
+        59: ifeq          68
+        62: getstatic     #2665               // Field net/minecraft/world/level/ClipContext$Fluid.ANY:Lnet/minecraft/world/level/ClipContext$Fluid;
+        65: goto          71
+        68: getstatic     #2668               // Field net/minecraft/world/level/ClipContext$Fluid.NONE:Lnet/minecraft/world/level/ClipContext$Fluid;
+        71: aload_0
+        72: invokespecial #1290               // Method net/minecraft/world/level/ClipContext."<init>":(Lnet/minecraft/world/phys/Vec3;Lnet/minecraft/world/phys/Vec3;Lnet/minecraft/world/level/ClipContext$Block;Lnet/minecraft/world/level/ClipContext$Fluid;Lnet/minecraft/world/entity/Entity;)V
+        75: invokevirtual #1294               // Method net/minecraft/world/level/Level.clip:(Lnet/minecraft/world/level/ClipContext;)Lnet/minecraft/world/phys/BlockHitResult;
+        78: areturn
+
+  public boolean canBeHitByProjectile();
+    Code:
+         0: aload_0
+         1: invokevirtual #741                // Method isAlive:()Z
+         4: ifeq          18
+         7: aload_0
+         8: invokevirtual #2673               // Method isPickable:()Z
+        11: ifeq          18
+        14: iconst_1
+        15: goto          19
+        18: iconst_0
+        19: ireturn
+
+  public boolean isPickable();
+    Code:
+         0: iconst_0
+         1: ireturn
+
+  public boolean canBePickedFromInside();
+    Code:
+         0: iconst_1
+         1: ireturn
+
+  public boolean isPushable();
+    Code:
+         0: iconst_0
+         1: ireturn
+
+  public void awardKillScore(net.minecraft.world.entity.Entity, net.minecraft.world.damagesource.DamageSource);
+    Code:
+         0: aload_1
+         1: instanceof    #2680               // class net/minecraft/server/level/ServerPlayer
+         4: ifeq          21
+         7: aload_1
+         8: checkcast     #2680               // class net/minecraft/server/level/ServerPlayer
+        11: astore_3
+        12: getstatic     #2686               // Field net/minecraft/advancements/triggers/CriteriaTriggers.ENTITY_KILLED_PLAYER:Lnet/minecraft/advancements/triggers/KilledTrigger;
+        15: aload_3
+        16: aload_0
+        17: aload_2
+        18: invokevirtual #2692               // Method net/minecraft/advancements/triggers/KilledTrigger.trigger:(Lnet/minecraft/server/level/ServerPlayer;Lnet/minecraft/world/entity/Entity;Lnet/minecraft/world/damagesource/DamageSource;)V
+        21: return
+
+  public boolean shouldRender(double, double, double);
+    Code:
+         0: aload_0
+         1: invokevirtual #880                // Method getX:()D
+         4: dload_1
+         5: dsub
+         6: dstore        7
+         8: aload_0
+         9: invokevirtual #883                // Method getY:()D
+        12: dload_3
+        13: dsub
+        14: dstore        9
+        16: aload_0
+        17: invokevirtual #886                // Method getZ:()D
+        20: dload         5
+        22: dsub
+        23: dstore        11
+        25: dload         7
+        27: dload         7
+        29: dmul
+        30: dload         9
+        32: dload         9
+        34: dmul
+        35: dadd
+        36: dload         11
+        38: dload         11
+        40: dmul
+        41: dadd
+        42: dstore        13
+        44: aload_0
+        45: dload         13
+        47: invokevirtual #2701               // Method shouldRenderAtSqrDistance:(D)Z
+        50: ireturn
+
+  public boolean shouldRenderAtSqrDistance(double);
+    Code:
+         0: aload_0
+         1: invokevirtual #693                // Method getBoundingBox:()Lnet/minecraft/world/phys/AABB;
+         4: invokevirtual #2704               // Method net/minecraft/world/phys/AABB.getSize:()D
+         7: dstore_3
+         8: dload_3
+         9: invokestatic  #2707               // Method java/lang/Double.isNaN:(D)Z
+        12: ifeq          17
+        15: dconst_1
+        16: dstore_3
+        17: dload_3
+        18: ldc2_w        #245                // double 64.0d
+        21: getstatic     #2709               // Field viewScale:D
+        24: dmul
+        25: dmul
+        26: dstore_3
+        27: dload_1
+        28: dload_3
+        29: dload_3
+        30: dmul
+        31: dcmpg
+        32: ifge          39
+        35: iconst_1
+        36: goto          40
+        39: iconst_0
+        40: ireturn
+
+  public boolean saveAsPassenger(net.minecraft.world.level.storage.ValueOutput);
+    Code:
+         0: aload_0
+         1: getfield      #2714               // Field removalReason:Lnet/minecraft/world/entity/Entity$RemovalReason;
+         4: ifnull        19
+         7: aload_0
+         8: getfield      #2714               // Field removalReason:Lnet/minecraft/world/entity/Entity$RemovalReason;
+        11: invokevirtual #2717               // Method net/minecraft/world/entity/Entity$RemovalReason.shouldSave:()Z
+        14: ifne          19
+        17: iconst_0
+        18: ireturn
+        19: aload_0
+        20: invokevirtual #2720               // Method getEncodeId:()Ljava/lang/String;
+        23: astore_2
+        24: aload_2
+        25: ifnonnull     30
+        28: iconst_0
+        29: ireturn
+        30: aload_1
+        31: ldc           #181                // String id
+        33: aload_2
+        34: invokeinterface #2726,  3         // InterfaceMethod net/minecraft/world/level/storage/ValueOutput.putString:(Ljava/lang/String;Ljava/lang/String;)V
+        39: aload_0
+        40: aload_1
+        41: invokevirtual #2730               // Method saveWithoutId:(Lnet/minecraft/world/level/storage/ValueOutput;)V
+        44: iconst_1
+        45: ireturn
+
+  public boolean save(net.minecraft.world.level.storage.ValueOutput);
+    Code:
+         0: aload_0
+         1: invokevirtual #756                // Method isPassenger:()Z
+         4: ifeq          9
+         7: iconst_0
+         8: ireturn
+         9: aload_0
+        10: aload_1
+        11: invokevirtual #2734               // Method saveAsPassenger:(Lnet/minecraft/world/level/storage/ValueOutput;)Z
+        14: ireturn
+
+  public void saveWithoutId(net.minecraft.world.level.storage.ValueOutput);
+    Code:
+         0: aload_0
+         1: getfield      #957                // Field vehicle:Lnet/minecraft/world/entity/Entity;
+         4: ifnull        46
+         7: aload_1
+         8: ldc           #193                // String Pos
+        10: getstatic     #2739               // Field net/minecraft/world/phys/Vec3.CODEC:Lcom/mojang/serialization/Codec;
+        13: new           #440                // class net/minecraft/world/phys/Vec3
+        16: dup
+        17: aload_0
+        18: getfield      #957                // Field vehicle:Lnet/minecraft/world/entity/Entity;
+        21: invokevirtual #880                // Method getX:()D
+        24: aload_0
+        25: invokevirtual #883                // Method getY:()D
+        28: aload_0
+        29: getfield      #957                // Field vehicle:Lnet/minecraft/world/entity/Entity;
+        32: invokevirtual #886                // Method getZ:()D
+        35: invokespecial #765                // Method net/minecraft/world/phys/Vec3."<init>":(DDD)V
+        38: invokeinterface #2743,  4         // InterfaceMethod net/minecraft/world/level/storage/ValueOutput.store:(Ljava/lang/String;Lcom/mojang/serialization/Codec;Ljava/lang/Object;)V
+        43: goto          61
+        46: aload_1
+        47: ldc           #193                // String Pos
+        49: getstatic     #2739               // Field net/minecraft/world/phys/Vec3.CODEC:Lcom/mojang/serialization/Codec;
+        52: aload_0
+        53: invokevirtual #870                // Method position:()Lnet/minecraft/world/phys/Vec3;
+        56: invokeinterface #2743,  4         // InterfaceMethod net/minecraft/world/level/storage/ValueOutput.store:(Ljava/lang/String;Lcom/mojang/serialization/Codec;Ljava/lang/Object;)V
+        61: aload_1
+        62: ldc           #196                // String Motion
+        64: getstatic     #2739               // Field net/minecraft/world/phys/Vec3.CODEC:Lcom/mojang/serialization/Codec;
+        67: aload_0
+        68: invokevirtual #1369               // Method getDeltaMovement:()Lnet/minecraft/world/phys/Vec3;
+        71: invokeinterface #2743,  4         // InterfaceMethod net/minecraft/world/level/storage/ValueOutput.store:(Ljava/lang/String;Lcom/mojang/serialization/Codec;Ljava/lang/Object;)V
+        76: aload_1
+        77: ldc           #199                // String Rotation
+        79: getstatic     #2746               // Field net/minecraft/world/phys/Vec2.CODEC:Lcom/mojang/serialization/Codec;
+        82: new           #2745               // class net/minecraft/world/phys/Vec2
+        85: dup
+        86: aload_0
+        87: invokevirtual #945                // Method getYRot:()F
+        90: aload_0
+        91: invokevirtual #942                // Method getXRot:()F
+        94: invokespecial #2748               // Method net/minecraft/world/phys/Vec2."<init>":(FF)V
+        97: invokeinterface #2743,  4         // InterfaceMethod net/minecraft/world/level/storage/ValueOutput.store:(Ljava/lang/String;Lcom/mojang/serialization/Codec;Ljava/lang/Object;)V
+       102: aload_1
+       103: ldc           #214                // String fall_distance
+       105: aload_0
+       106: getfield      #1046               // Field fallDistance:D
+       109: invokeinterface #2752,  4         // InterfaceMethod net/minecraft/world/level/storage/ValueOutput.putDouble:(Ljava/lang/String;D)V
+       114: aload_1
+       115: ldc           #217                // String Fire
+       117: aload_0
+       118: getfield      #1018               // Field remainingFireTicks:I
+       121: i2s
+       122: invokeinterface #2756,  3         // InterfaceMethod net/minecraft/world/level/storage/ValueOutput.putShort:(Ljava/lang/String;S)V
+       127: aload_1
+       128: ldc           #208                // String Air
+       130: aload_0
+       131: invokevirtual #2759               // Method getAirSupply:()I
+       134: i2s
+       135: invokeinterface #2756,  3         // InterfaceMethod net/minecraft/world/level/storage/ValueOutput.putShort:(Ljava/lang/String;S)V
+       140: aload_1
+       141: ldc           #211                // String OnGround
+       143: aload_0
+       144: invokevirtual #1341               // Method onGround:()Z
+       147: invokeinterface #2763,  3         // InterfaceMethod net/minecraft/world/level/storage/ValueOutput.putBoolean:(Ljava/lang/String;Z)V
+       152: aload_1
+       153: ldc           #226                // String Invulnerable
+       155: aload_0
+       156: getfield      #2765               // Field invulnerable:Z
+       159: invokeinterface #2763,  3         // InterfaceMethod net/minecraft/world/level/storage/ValueOutput.putBoolean:(Ljava/lang/String;Z)V
+       164: aload_1
+       165: ldc           #202                // String PortalCooldown
+       167: aload_0
+       168: getfield      #1092               // Field portalCooldown:I
+       171: invokeinterface #2769,  3         // InterfaceMethod net/minecraft/world/level/storage/ValueOutput.putInt:(Ljava/lang/String;I)V
+       176: aload_1
+       177: ldc           #184                // String UUID
+       179: getstatic     #2772               // Field net/minecraft/core/UUIDUtil.CODEC:Lcom/mojang/serialization/Codec;
+       182: aload_0
+       183: invokevirtual #2776               // Method getUUID:()Ljava/util/UUID;
+       186: invokeinterface #2743,  4         // InterfaceMethod net/minecraft/world/level/storage/ValueOutput.store:(Ljava/lang/String;Lcom/mojang/serialization/Codec;Ljava/lang/Object;)V
+       191: aload_1
+       192: ldc           #229                // String CustomName
+       194: getstatic     #2779               // Field net/minecraft/network/chat/ComponentSerialization.CODEC:Lcom/mojang/serialization/Codec;
+       197: aload_0
+       198: invokevirtual #2783               // Method getCustomName:()Lnet/minecraft/network/chat/Component;
+       201: invokeinterface #2786,  4         // InterfaceMethod net/minecraft/world/level/storage/ValueOutput.storeNullable:(Ljava/lang/String;Lcom/mojang/serialization/Codec;Ljava/lang/Object;)V
+       206: aload_0
+       207: invokevirtual #2789               // Method isCustomNameVisible:()Z
+       210: ifeq          226
+       213: aload_1
+       214: ldc_w         #2791               // String CustomNameVisible
+       217: aload_0
+       218: invokevirtual #2789               // Method isCustomNameVisible:()Z
+       221: invokeinterface #2763,  3         // InterfaceMethod net/minecraft/world/level/storage/ValueOutput.putBoolean:(Ljava/lang/String;Z)V
+       226: aload_0
+       227: invokevirtual #1113               // Method isSilent:()Z
+       230: ifeq          245
+       233: aload_1
+       234: ldc           #220                // String Silent
+       236: aload_0
+       237: invokevirtual #1113               // Method isSilent:()Z
+       240: invokeinterface #2763,  3         // InterfaceMethod net/minecraft/world/level/storage/ValueOutput.putBoolean:(Ljava/lang/String;Z)V
+       245: aload_0
+       246: invokevirtual #2244               // Method isNoGravity:()Z
+       249: ifeq          264
+       252: aload_1
+       253: ldc           #205                // String NoGravity
+       255: aload_0
+       256: invokevirtual #2244               // Method isNoGravity:()Z
+       259: invokeinterface #2763,  3         // InterfaceMethod net/minecraft/world/level/storage/ValueOutput.putBoolean:(Ljava/lang/String;Z)V
+       264: aload_0
+       265: getfield      #2793               // Field hasGlowingTag:Z
+       268: ifeq          280
+       271: aload_1
+       272: ldc           #223                // String Glowing
+       274: iconst_1
+       275: invokeinterface #2763,  3         // InterfaceMethod net/minecraft/world/level/storage/ValueOutput.putBoolean:(Ljava/lang/String;Z)V
+       280: aload_0
+       281: invokevirtual #2796               // Method getTicksFrozen:()I
+       284: istore_2
+       285: iload_2
+       286: ifle          302
+       289: aload_1
+       290: ldc_w         #2798               // String TicksFrozen
+       293: aload_0
+       294: invokevirtual #2796               // Method getTicksFrozen:()I
+       297: invokeinterface #2769,  3         // InterfaceMethod net/minecraft/world/level/storage/ValueOutput.putInt:(Ljava/lang/String;I)V
+       302: aload_0
+       303: getfield      #1076               // Field hasVisualFire:Z
+       306: ifeq          322
+       309: aload_1
+       310: ldc_w         #2800               // String HasVisualFire
+       313: aload_0
+       314: getfield      #1076               // Field hasVisualFire:Z
+       317: invokeinterface #2763,  3         // InterfaceMethod net/minecraft/world/level/storage/ValueOutput.putBoolean:(Ljava/lang/String;Z)V
+       322: aload_0
+       323: getfield      #520                // Field tags:Ljava/util/Set;
+       326: invokeinterface #2801,  1         // InterfaceMethod java/util/Set.isEmpty:()Z
+       331: ifne          353
+       334: aload_1
+       335: ldc_w         #2803               // String Tags
+       338: getstatic     #2805               // Field TAG_LIST_CODEC:Lcom/mojang/serialization/Codec;
+       341: aload_0
+       342: getfield      #520                // Field tags:Ljava/util/Set;
+       345: invokestatic  #2809               // InterfaceMethod java/util/List.copyOf:(Ljava/util/Collection;)Ljava/util/List;
+       348: invokeinterface #2743,  4         // InterfaceMethod net/minecraft/world/level/storage/ValueOutput.store:(Ljava/lang/String;Lcom/mojang/serialization/Codec;Ljava/lang/Object;)V
+       353: aload_0
+       354: getfield      #563                // Field customData:Lnet/minecraft/world/item/component/CustomData;
+       357: invokevirtual #2810               // Method net/minecraft/world/item/component/CustomData.isEmpty:()Z
+       360: ifne          378
+       363: aload_1
+       364: ldc           #190                // String data
+       366: getstatic     #2811               // Field net/minecraft/world/item/component/CustomData.CODEC:Lcom/mojang/serialization/Codec;
+       369: aload_0
+       370: getfield      #563                // Field customData:Lnet/minecraft/world/item/component/CustomData;
+       373: invokeinterface #2743,  4         // InterfaceMethod net/minecraft/world/level/storage/ValueOutput.store:(Ljava/lang/String;Lcom/mojang/serialization/Codec;Ljava/lang/Object;)V
+       378: aload_0
+       379: aload_1
+       380: invokevirtual #2814               // Method addAdditionalSaveData:(Lnet/minecraft/world/level/storage/ValueOutput;)V
+       383: aload_0
+       384: invokevirtual #750                // Method isVehicle:()Z
+       387: ifeq          476
+       390: aload_1
+       391: ldc           #187                // String Passengers
+       393: invokeinterface #2818,  2         // InterfaceMethod net/minecraft/world/level/storage/ValueOutput.childrenList:(Ljava/lang/String;)Lnet/minecraft/world/level/storage/ValueOutput$ValueOutputList;
+       398: astore_3
+       399: aload_0
+       400: invokevirtual #2307               // Method getPassengers:()Ljava/util/List;
+       403: invokeinterface #1820,  1         // InterfaceMethod java/util/List.iterator:()Ljava/util/Iterator;
+       408: astore        4
+       410: aload         4
+       412: invokeinterface #1827,  1         // InterfaceMethod java/util/Iterator.hasNext:()Z
+       417: ifeq          459
+       420: aload         4
+       422: invokeinterface #1830,  1         // InterfaceMethod java/util/Iterator.next:()Ljava/lang/Object;
+       427: checkcast     #2                  // class net/minecraft/world/entity/Entity
+       430: astore        5
+       432: aload_3
+       433: invokeinterface #2822,  1         // InterfaceMethod net/minecraft/world/level/storage/ValueOutput$ValueOutputList.addChild:()Lnet/minecraft/world/level/storage/ValueOutput;
+       438: astore        6
+       440: aload         5
+       442: aload         6
+       444: invokevirtual #2734               // Method saveAsPassenger:(Lnet/minecraft/world/level/storage/ValueOutput;)Z
+       447: ifne          456
+       450: aload_3
+       451: invokeinterface #2825,  1         // InterfaceMethod net/minecraft/world/level/storage/ValueOutput$ValueOutputList.discardLast:()V
+       456: goto          410
+       459: aload_3
+       460: invokeinterface #2826,  1         // InterfaceMethod net/minecraft/world/level/storage/ValueOutput$ValueOutputList.isEmpty:()Z
+       465: ifeq          476
+       468: aload_1
+       469: ldc           #187                // String Passengers
+       471: invokeinterface #2828,  2         // InterfaceMethod net/minecraft/world/level/storage/ValueOutput.discard:(Ljava/lang/String;)V
+       476: goto          512
+       479: astore_2
+       480: aload_2
+       481: ldc_w         #2830               // String Saving entity NBT
+       484: invokestatic  #2836               // Method net/minecraft/CrashReport.forThrowable:(Ljava/lang/Throwable;Ljava/lang/String;)Lnet/minecraft/CrashReport;
+       487: astore_3
+       488: aload_3
+       489: ldc_w         #2838               // String Entity being saved
+       492: invokevirtual #2842               // Method net/minecraft/CrashReport.addCategory:(Ljava/lang/String;)Lnet/minecraft/CrashReportCategory;
+       495: astore        4
+       497: aload_0
+       498: aload         4
+       500: invokevirtual #2846               // Method fillCrashReportCategory:(Lnet/minecraft/CrashReportCategory;)V
+       503: new           #2848               // class net/minecraft/ReportedException
+       506: dup
+       507: aload_3
+       508: invokespecial #2851               // Method net/minecraft/ReportedException."<init>":(Lnet/minecraft/CrashReport;)V
+       511: athrow
+       512: return
+      Exception table:
+         from    to  target type
+             0   476   479   Class java/lang/Throwable
+
+  public void load(net.minecraft.world.level.storage.ValueInput);
+    Code:
+         0: aload_1
+         1: ldc           #193                // String Pos
+         3: getstatic     #2739               // Field net/minecraft/world/phys/Vec3.CODEC:Lcom/mojang/serialization/Codec;
+         6: invokeinterface #2869,  3         // InterfaceMethod net/minecraft/world/level/storage/ValueInput.read:(Ljava/lang/String;Lcom/mojang/serialization/Codec;)Ljava/util/Optional;
+        11: getstatic     #443                // Field net/minecraft/world/phys/Vec3.ZERO:Lnet/minecraft/world/phys/Vec3;
+        14: invokevirtual #2285               // Method java/util/Optional.orElse:(Ljava/lang/Object;)Ljava/lang/Object;
+        17: checkcast     #440                // class net/minecraft/world/phys/Vec3
+        20: astore_2
+        21: aload_1
+        22: ldc           #196                // String Motion
+        24: getstatic     #2739               // Field net/minecraft/world/phys/Vec3.CODEC:Lcom/mojang/serialization/Codec;
+        27: invokeinterface #2869,  3         // InterfaceMethod net/minecraft/world/level/storage/ValueInput.read:(Ljava/lang/String;Lcom/mojang/serialization/Codec;)Ljava/util/Optional;
+        32: getstatic     #443                // Field net/minecraft/world/phys/Vec3.ZERO:Lnet/minecraft/world/phys/Vec3;
+        35: invokevirtual #2285               // Method java/util/Optional.orElse:(Ljava/lang/Object;)Ljava/lang/Object;
+        38: checkcast     #440                // class net/minecraft/world/phys/Vec3
+        41: astore_3
+        42: aload_1
+        43: ldc           #199                // String Rotation
+        45: getstatic     #2746               // Field net/minecraft/world/phys/Vec2.CODEC:Lcom/mojang/serialization/Codec;
+        48: invokeinterface #2869,  3         // InterfaceMethod net/minecraft/world/level/storage/ValueInput.read:(Ljava/lang/String;Lcom/mojang/serialization/Codec;)Ljava/util/Optional;
+        53: getstatic     #2872               // Field net/minecraft/world/phys/Vec2.ZERO:Lnet/minecraft/world/phys/Vec2;
+        56: invokevirtual #2285               // Method java/util/Optional.orElse:(Ljava/lang/Object;)Ljava/lang/Object;
+        59: checkcast     #2745               // class net/minecraft/world/phys/Vec2
+        62: astore        4
+        64: aload_0
+        65: aload_3
+        66: getfield      #932                // Field net/minecraft/world/phys/Vec3.x:D
+        69: invokestatic  #1324               // Method java/lang/Math.abs:(D)D
+        72: ldc2_w        #248                // double 10.0d
+        75: dcmpl
+        76: ifle          83
+        79: dconst_0
+        80: goto          87
+        83: aload_3
+        84: getfield      #932                // Field net/minecraft/world/phys/Vec3.x:D
+        87: aload_3
+        88: getfield      #934                // Field net/minecraft/world/phys/Vec3.y:D
+        91: invokestatic  #1324               // Method java/lang/Math.abs:(D)D
+        94: ldc2_w        #248                // double 10.0d
+        97: dcmpl
+        98: ifle          105
+       101: dconst_0
+       102: goto          109
+       105: aload_3
+       106: getfield      #934                // Field net/minecraft/world/phys/Vec3.y:D
+       109: aload_3
+       110: getfield      #936                // Field net/minecraft/world/phys/Vec3.z:D
+       113: invokestatic  #1324               // Method java/lang/Math.abs:(D)D
+       116: ldc2_w        #248                // double 10.0d
+       119: dcmpl
+       120: ifle          127
+       123: dconst_0
+       124: goto          131
+       127: aload_3
+       128: getfield      #936                // Field net/minecraft/world/phys/Vec3.z:D
+       131: invokevirtual #2874               // Method setDeltaMovement:(DDD)V
+       134: aload_0
+       135: iconst_1
+       136: putfield      #2591               // Field needsSync:Z
+       139: ldc2_w        #2875               // double 3.0000512E7d
+       142: dstore        5
+       144: aload_0
+       145: aload_2
+       146: getfield      #932                // Field net/minecraft/world/phys/Vec3.x:D
+       149: ldc2_w        #2877               // double -3.0000512E7d
+       152: ldc2_w        #2875               // double 3.0000512E7d
+       155: invokestatic  #1743               // Method net/minecraft/util/Mth.clamp:(DDD)D
+       158: aload_2
+       159: getfield      #934                // Field net/minecraft/world/phys/Vec3.y:D
+       162: ldc2_w        #2879               // double -2.0E7d
+       165: ldc2_w        #2881               // double 2.0E7d
+       168: invokestatic  #1743               // Method net/minecraft/util/Mth.clamp:(DDD)D
+       171: aload_2
+       172: getfield      #936                // Field net/minecraft/world/phys/Vec3.z:D
+       175: ldc2_w        #2877               // double -3.0000512E7d
+       178: ldc2_w        #2875               // double 3.0000512E7d
+       181: invokestatic  #1743               // Method net/minecraft/util/Mth.clamp:(DDD)D
+       184: invokevirtual #916                // Method setPosRaw:(DDD)V
+       187: aload_0
+       188: aload         4
+       190: getfield      #2884               // Field net/minecraft/world/phys/Vec2.x:F
+       193: invokevirtual #904                // Method setYRot:(F)V
+       196: aload_0
+       197: aload         4
+       199: getfield      #2886               // Field net/minecraft/world/phys/Vec2.y:F
+       202: invokevirtual #907                // Method setXRot:(F)V
+       205: aload_0
+       206: invokevirtual #2530               // Method setOldPosAndRot:()V
+       209: aload_0
+       210: aload_0
+       211: invokevirtual #945                // Method getYRot:()F
+       214: invokevirtual #2889               // Method setYHeadRot:(F)V
+       217: aload_0
+       218: aload_0
+       219: invokevirtual #945                // Method getYRot:()F
+       222: invokevirtual #2892               // Method setYBodyRot:(F)V
+       225: aload_0
+       226: aload_1
+       227: ldc           #214                // String fall_distance
+       229: dconst_0
+       230: invokeinterface #2896,  4         // InterfaceMethod net/minecraft/world/level/storage/ValueInput.getDoubleOr:(Ljava/lang/String;D)D
+       235: putfield      #1046               // Field fallDistance:D
+       238: aload_0
+       239: aload_1
+       240: ldc           #217                // String Fire
+       242: iconst_0
+       243: invokeinterface #2900,  3         // InterfaceMethod net/minecraft/world/level/storage/ValueInput.getShortOr:(Ljava/lang/String;S)I
+       248: putfield      #1018               // Field remainingFireTicks:I
+       251: aload_0
+       252: aload_1
+       253: ldc           #208                // String Air
+       255: aload_0
+       256: invokevirtual #613                // Method getMaxAirSupply:()I
+       259: invokeinterface #2904,  3         // InterfaceMethod net/minecraft/world/level/storage/ValueInput.getIntOr:(Ljava/lang/String;I)I
+       264: invokevirtual #2907               // Method setAirSupply:(I)V
+       267: aload_0
+       268: aload_1
+       269: ldc           #211                // String OnGround
+       271: iconst_0
+       272: invokeinterface #2911,  3         // InterfaceMethod net/minecraft/world/level/storage/ValueInput.getBooleanOr:(Ljava/lang/String;Z)Z
+       277: putfield      #1180               // Field onGround:Z
+       280: aload_0
+       281: aload_1
+       282: ldc           #226                // String Invulnerable
+       284: iconst_0
+       285: invokeinterface #2911,  3         // InterfaceMethod net/minecraft/world/level/storage/ValueInput.getBooleanOr:(Ljava/lang/String;Z)Z
+       290: putfield      #2765               // Field invulnerable:Z
+       293: aload_0
+       294: aload_1
+       295: ldc           #202                // String PortalCooldown
+       297: iconst_0
+       298: invokeinterface #2904,  3         // InterfaceMethod net/minecraft/world/level/storage/ValueInput.getIntOr:(Ljava/lang/String;I)I
+       303: putfield      #1092               // Field portalCooldown:I
+       306: aload_1
+       307: ldc           #184                // String UUID
+       309: getstatic     #2772               // Field net/minecraft/core/UUIDUtil.CODEC:Lcom/mojang/serialization/Codec;
+       312: invokeinterface #2869,  3         // InterfaceMethod net/minecraft/world/level/storage/ValueInput.read:(Ljava/lang/String;Lcom/mojang/serialization/Codec;)Ljava/util/Optional;
+       317: aload_0
+       318: invokedynamic #2922,  0           // InvokeDynamic #2:accept:(Lnet/minecraft/world/entity/Entity;)Ljava/util/function/Consumer;
+       323: invokevirtual #2926               // Method java/util/Optional.ifPresent:(Ljava/util/function/Consumer;)V
+       326: aload_0
+       327: invokevirtual #880                // Method getX:()D
+       330: invokestatic  #2589               // Method java/lang/Double.isFinite:(D)Z
+       333: ifeq          356
+       336: aload_0
+       337: invokevirtual #883                // Method getY:()D
+       340: invokestatic  #2589               // Method java/lang/Double.isFinite:(D)Z
+       343: ifeq          356
+       346: aload_0
+       347: invokevirtual #886                // Method getZ:()D
+       350: invokestatic  #2589               // Method java/lang/Double.isFinite:(D)Z
+       353: ifne          367
+       356: new           #789                // class java/lang/IllegalStateException
+       359: dup
+       360: ldc_w         #2928               // String Entity has invalid position
+       363: invokespecial #794                // Method java/lang/IllegalStateException."<init>":(Ljava/lang/String;)V
+       366: athrow
+       367: aload_0
+       368: invokevirtual #945                // Method getYRot:()F
+       371: f2d
+       372: invokestatic  #2589               // Method java/lang/Double.isFinite:(D)Z
+       375: ifeq          389
+       378: aload_0
+       379: invokevirtual #942                // Method getXRot:()F
+       382: f2d
+       383: invokestatic  #2589               // Method java/lang/Double.isFinite:(D)Z
+       386: ifne          400
+       389: new           #789                // class java/lang/IllegalStateException
+       392: dup
+       393: ldc_w         #2930               // String Entity has invalid rotation
+       396: invokespecial #794                // Method java/lang/IllegalStateException."<init>":(Ljava/lang/String;)V
+       399: athrow
+       400: aload_0
+       401: invokevirtual #2532               // Method reapplyPosition:()V
+       404: aload_0
+       405: aload_0
+       406: invokevirtual #945                // Method getYRot:()F
+       409: aload_0
+       410: invokevirtual #942                // Method getXRot:()F
+       413: invokevirtual #2932               // Method setRot:(FF)V
+       416: aload_0
+       417: aload_1
+       418: ldc           #229                // String CustomName
+       420: getstatic     #2779               // Field net/minecraft/network/chat/ComponentSerialization.CODEC:Lcom/mojang/serialization/Codec;
+       423: invokeinterface #2869,  3         // InterfaceMethod net/minecraft/world/level/storage/ValueInput.read:(Ljava/lang/String;Lcom/mojang/serialization/Codec;)Ljava/util/Optional;
+       428: aconst_null
+       429: invokevirtual #2285               // Method java/util/Optional.orElse:(Ljava/lang/Object;)Ljava/lang/Object;
+       432: checkcast     #2934               // class net/minecraft/network/chat/Component
+       435: invokevirtual #2938               // Method setCustomName:(Lnet/minecraft/network/chat/Component;)V
+       438: aload_0
+       439: aload_1
+       440: ldc_w         #2791               // String CustomNameVisible
+       443: iconst_0
+       444: invokeinterface #2911,  3         // InterfaceMethod net/minecraft/world/level/storage/ValueInput.getBooleanOr:(Ljava/lang/String;Z)Z
+       449: invokevirtual #2941               // Method setCustomNameVisible:(Z)V
+       452: aload_0
+       453: aload_1
+       454: ldc           #220                // String Silent
+       456: iconst_0
+       457: invokeinterface #2911,  3         // InterfaceMethod net/minecraft/world/level/storage/ValueInput.getBooleanOr:(Ljava/lang/String;Z)Z
+       462: invokevirtual #2943               // Method setSilent:(Z)V
+       465: aload_0
+       466: aload_1
+       467: ldc           #205                // String NoGravity
+       469: iconst_0
+       470: invokeinterface #2911,  3         // InterfaceMethod net/minecraft/world/level/storage/ValueInput.getBooleanOr:(Ljava/lang/String;Z)Z
+       475: invokevirtual #2945               // Method setNoGravity:(Z)V
+       478: aload_0
+       479: aload_1
+       480: ldc           #223                // String Glowing
+       482: iconst_0
+       483: invokeinterface #2911,  3         // InterfaceMethod net/minecraft/world/level/storage/ValueInput.getBooleanOr:(Ljava/lang/String;Z)Z
+       488: invokevirtual #2948               // Method setGlowingTag:(Z)V
+       491: aload_0
+       492: aload_1
+       493: ldc_w         #2798               // String TicksFrozen
+       496: iconst_0
+       497: invokeinterface #2904,  3         // InterfaceMethod net/minecraft/world/level/storage/ValueInput.getIntOr:(Ljava/lang/String;I)I
+       502: invokevirtual #2951               // Method setTicksFrozen:(I)V
+       505: aload_0
+       506: aload_1
+       507: ldc_w         #2800               // String HasVisualFire
+       510: iconst_0
+       511: invokeinterface #2911,  3         // InterfaceMethod net/minecraft/world/level/storage/ValueInput.getBooleanOr:(Ljava/lang/String;Z)Z
+       516: putfield      #1076               // Field hasVisualFire:Z
+       519: aload_0
+       520: aload_1
+       521: ldc           #190                // String data
+       523: getstatic     #2811               // Field net/minecraft/world/item/component/CustomData.CODEC:Lcom/mojang/serialization/Codec;
+       526: invokeinterface #2869,  3         // InterfaceMethod net/minecraft/world/level/storage/ValueInput.read:(Ljava/lang/String;Lcom/mojang/serialization/Codec;)Ljava/util/Optional;
+       531: getstatic     #561                // Field net/minecraft/world/item/component/CustomData.EMPTY:Lnet/minecraft/world/item/component/CustomData;
+       534: invokevirtual #2285               // Method java/util/Optional.orElse:(Ljava/lang/Object;)Ljava/lang/Object;
+       537: checkcast     #558                // class net/minecraft/world/item/component/CustomData
+       540: putfield      #563                // Field customData:Lnet/minecraft/world/item/component/CustomData;
+       543: aload_0
+       544: getfield      #520                // Field tags:Ljava/util/Set;
+       547: invokeinterface #2952,  1         // InterfaceMethod java/util/Set.clear:()V
+       552: aload_1
+       553: ldc_w         #2803               // String Tags
+       556: getstatic     #2805               // Field TAG_LIST_CODEC:Lcom/mojang/serialization/Codec;
+       559: invokeinterface #2869,  3         // InterfaceMethod net/minecraft/world/level/storage/ValueInput.read:(Ljava/lang/String;Lcom/mojang/serialization/Codec;)Ljava/util/Optional;
+       564: aload_0
+       565: getfield      #520                // Field tags:Ljava/util/Set;
+       568: dup
+       569: invokestatic  #2955               // Method java/util/Objects.requireNonNull:(Ljava/lang/Object;)Ljava/lang/Object;
+       572: pop
+       573: invokedynamic #2961,  0           // InvokeDynamic #3:accept:(Ljava/util/Set;)Ljava/util/function/Consumer;
+       578: invokevirtual #2926               // Method java/util/Optional.ifPresent:(Ljava/util/function/Consumer;)V
+       581: aload_0
+       582: aload_1
+       583: invokevirtual #2964               // Method readAdditionalSaveData:(Lnet/minecraft/world/level/storage/ValueInput;)V
+       586: aload_0
+       587: invokevirtual #2967               // Method repositionEntityAfterLoad:()Z
+       590: ifeq          597
+       593: aload_0
+       594: invokevirtual #2532               // Method reapplyPosition:()V
+       597: goto          633
+       600: astore_2
+       601: aload_2
+       602: ldc_w         #2969               // String Loading entity NBT
+       605: invokestatic  #2836               // Method net/minecraft/CrashReport.forThrowable:(Ljava/lang/Throwable;Ljava/lang/String;)Lnet/minecraft/CrashReport;
+       608: astore_3
+       609: aload_3
+       610: ldc_w         #2971               // String Entity being loaded
+       613: invokevirtual #2842               // Method net/minecraft/CrashReport.addCategory:(Ljava/lang/String;)Lnet/minecraft/CrashReportCategory;
+       616: astore        4
+       618: aload_0
+       619: aload         4
+       621: invokevirtual #2846               // Method fillCrashReportCategory:(Lnet/minecraft/CrashReportCategory;)V
+       624: new           #2848               // class net/minecraft/ReportedException
+       627: dup
+       628: aload_3
+       629: invokespecial #2851               // Method net/minecraft/ReportedException."<init>":(Lnet/minecraft/CrashReport;)V
+       632: athrow
+       633: return
+      Exception table:
+         from    to  target type
+             0   597   600   Class java/lang/Throwable
+
+  protected boolean repositionEntityAfterLoad();
+    Code:
+         0: iconst_1
+         1: ireturn
+
+  protected final java.lang.String getEncodeId();
+    Code:
+         0: aload_0
+         1: invokevirtual #2287               // Method getType:()Lnet/minecraft/world/entity/EntityType;
+         4: invokevirtual #2978               // Method net/minecraft/world/entity/EntityType.canSerialize:()Z
+         7: ifne          12
+        10: aconst_null
+        11: areturn
+        12: aload_0
+        13: invokevirtual #2980               // Method typeHolder:()Lnet/minecraft/core/Holder;
+        16: invokeinterface #2983,  1         // InterfaceMethod net/minecraft/core/Holder.unwrapKey:()Ljava/util/Optional;
+        21: invokedynamic #2993,  0           // InvokeDynamic #4:get:()Ljava/util/function/Supplier;
+        26: invokevirtual #2997               // Method java/util/Optional.orElseThrow:(Ljava/util/function/Supplier;)Ljava/lang/Object;
+        29: checkcast     #2999               // class net/minecraft/resources/ResourceKey
+        32: astore_1
+        33: aload_1
+        34: invokevirtual #3003               // Method net/minecraft/resources/ResourceKey.identifier:()Lnet/minecraft/resources/Identifier;
+        37: invokevirtual #3006               // Method net/minecraft/resources/Identifier.toString:()Ljava/lang/String;
+        40: areturn
+
+  protected abstract void readAdditionalSaveData(net.minecraft.world.level.storage.ValueInput);
+
+  protected abstract void addAdditionalSaveData(net.minecraft.world.level.storage.ValueOutput);
+
+  public net.minecraft.world.entity.item.ItemEntity spawnAtLocation(net.minecraft.server.level.ServerLevel, net.minecraft.world.level.ItemLike);
+    Code:
+         0: aload_0
+         1: aload_1
+         2: new           #3014               // class net/minecraft/world/item/ItemStack
+         5: dup
+         6: aload_2
+         7: invokespecial #3017               // Method net/minecraft/world/item/ItemStack."<init>":(Lnet/minecraft/world/level/ItemLike;)V
+        10: fconst_0
+        11: invokevirtual #3020               // Method spawnAtLocation:(Lnet/minecraft/server/level/ServerLevel;Lnet/minecraft/world/item/ItemStack;F)Lnet/minecraft/world/entity/item/ItemEntity;
+        14: areturn
+
+  public net.minecraft.world.entity.item.ItemEntity spawnAtLocation(net.minecraft.server.level.ServerLevel, net.minecraft.world.item.ItemStack);
+    Code:
+         0: aload_0
+         1: aload_1
+         2: aload_2
+         3: fconst_0
+         4: invokevirtual #3020               // Method spawnAtLocation:(Lnet/minecraft/server/level/ServerLevel;Lnet/minecraft/world/item/ItemStack;F)Lnet/minecraft/world/entity/item/ItemEntity;
+         7: areturn
+
+  public net.minecraft.world.entity.item.ItemEntity spawnAtLocation(net.minecraft.server.level.ServerLevel, net.minecraft.world.item.ItemStack, net.minecraft.world.phys.Vec3);
+    Code:
+         0: aload_2
+         1: invokevirtual #3026               // Method net/minecraft/world/item/ItemStack.isEmpty:()Z
+         4: ifeq          9
+         7: aconst_null
+         8: areturn
+         9: new           #3028               // class net/minecraft/world/entity/item/ItemEntity
+        12: dup
+        13: aload_1
+        14: aload_0
+        15: invokevirtual #880                // Method getX:()D
+        18: aload_3
+        19: getfield      #932                // Field net/minecraft/world/phys/Vec3.x:D
+        22: dadd
+        23: aload_0
+        24: invokevirtual #883                // Method getY:()D
+        27: aload_3
+        28: getfield      #934                // Field net/minecraft/world/phys/Vec3.y:D
+        31: dadd
+        32: aload_0
+        33: invokevirtual #886                // Method getZ:()D
+        36: aload_3
+        37: getfield      #936                // Field net/minecraft/world/phys/Vec3.z:D
+        40: dadd
+        41: aload_2
+        42: invokespecial #3031               // Method net/minecraft/world/entity/item/ItemEntity."<init>":(Lnet/minecraft/world/level/Level;DDDLnet/minecraft/world/item/ItemStack;)V
+        45: astore        4
+        47: aload         4
+        49: invokevirtual #3034               // Method net/minecraft/world/entity/item/ItemEntity.setDefaultPickUpDelay:()V
+        52: aload_1
+        53: aload         4
+        55: invokevirtual #3037               // Method net/minecraft/server/level/ServerLevel.addFreshEntity:(Lnet/minecraft/world/entity/Entity;)Z
+        58: pop
+        59: aload         4
+        61: areturn
+
+  public net.minecraft.world.entity.item.ItemEntity spawnAtLocation(net.minecraft.server.level.ServerLevel, net.minecraft.world.item.ItemStack, float);
+    Code:
+         0: aload_0
+         1: aload_1
+         2: aload_2
+         3: new           #440                // class net/minecraft/world/phys/Vec3
+         6: dup
+         7: dconst_0
+         8: fload_3
+         9: f2d
+        10: dconst_0
+        11: invokespecial #765                // Method net/minecraft/world/phys/Vec3."<init>":(DDD)V
+        14: invokevirtual #3040               // Method spawnAtLocation:(Lnet/minecraft/server/level/ServerLevel;Lnet/minecraft/world/item/ItemStack;Lnet/minecraft/world/phys/Vec3;)Lnet/minecraft/world/entity/item/ItemEntity;
+        17: areturn
+
+  public boolean isAlive();
+    Code:
+         0: aload_0
+         1: invokevirtual #744                // Method isRemoved:()Z
+         4: ifne          11
+         7: iconst_1
+         8: goto          12
+        11: iconst_0
+        12: ireturn
+
+  public boolean isInWall();
+    Code:
+         0: aload_0
+         1: getfield      #1231               // Field noPhysics:Z
+         4: ifeq          9
+         7: iconst_0
+         8: ireturn
+         9: aload_0
+        10: getfield      #581                // Field dimensions:Lnet/minecraft/world/entity/EntityDimensions;
+        13: invokevirtual #2410               // Method net/minecraft/world/entity/EntityDimensions.width:()F
+        16: ldc_w         #1455               // float 0.8f
+        19: fmul
+        20: fstore_1
+        21: aload_0
+        22: invokevirtual #3043               // Method getEyePosition:()Lnet/minecraft/world/phys/Vec3;
+        25: fload_1
+        26: f2d
+        27: ldc2_w        #1202               // double 1.0E-6d
+        30: fload_1
+        31: f2d
+        32: invokestatic  #3047               // Method net/minecraft/world/phys/AABB.ofSize:(Lnet/minecraft/world/phys/Vec3;DDD)Lnet/minecraft/world/phys/AABB;
+        35: astore_2
+        36: aload_2
+        37: invokestatic  #3051               // Method net/minecraft/core/BlockPos.betweenClosedStream:(Lnet/minecraft/world/phys/AABB;)Ljava/util/stream/Stream;
+        40: aload_0
+        41: aload_2
+        42: invokedynamic #3062,  0           // InvokeDynamic #5:test:(Lnet/minecraft/world/entity/Entity;Lnet/minecraft/world/phys/AABB;)Ljava/util/function/Predicate;
+        47: invokeinterface #3068,  2         // InterfaceMethod java/util/stream/Stream.anyMatch:(Ljava/util/function/Predicate;)Z
+        52: ireturn
+
+  public net.minecraft.world.InteractionResult interact(net.minecraft.world.entity.player.Player, net.minecraft.world.InteractionHand, net.minecraft.world.phys.Vec3);
+    Code:
+         0: aload_0
+         1: invokevirtual #672                // Method level:()Lnet/minecraft/world/level/Level;
+         4: invokevirtual #1054               // Method net/minecraft/world/level/Level.isClientSide:()Z
+         7: ifne          197
+        10: aload_1
+        11: invokevirtual #3079               // Method net/minecraft/world/entity/player/Player.isSecondaryUseActive:()Z
+        14: ifeq          197
+        17: aload_0
+        18: astore        5
+        20: aload         5
+        22: instanceof    #1059               // class net/minecraft/world/entity/Leashable
+        25: ifeq          197
+        28: aload         5
+        30: checkcast     #1059               // class net/minecraft/world/entity/Leashable
+        33: astore        4
+        35: aload         4
+        37: invokeinterface #3082,  1         // InterfaceMethod net/minecraft/world/entity/Leashable.canBeLeashed:()Z
+        42: ifeq          197
+        45: aload_0
+        46: invokevirtual #741                // Method isAlive:()Z
+        49: ifeq          197
+        52: aload_0
+        53: astore        6
+        55: aload         6
+        57: instanceof    #1454               // class net/minecraft/world/entity/LivingEntity
+        60: ifeq          78
+        63: aload         6
+        65: checkcast     #1454               // class net/minecraft/world/entity/LivingEntity
+        68: astore        5
+        70: aload         5
+        72: invokevirtual #3085               // Method net/minecraft/world/entity/LivingEntity.isBaby:()Z
+        75: ifne          197
+        78: aload_0
+        79: aload_1
+        80: invokedynamic #3095,  0           // InvokeDynamic #6:test:(Lnet/minecraft/world/entity/player/Player;)Ljava/util/function/Predicate;
+        85: invokestatic  #3099               // InterfaceMethod net/minecraft/world/entity/Leashable.leashableInArea:(Lnet/minecraft/world/entity/Entity;Ljava/util/function/Predicate;)Ljava/util/List;
+        88: astore        6
+        90: aload         6
+        92: invokeinterface #1525,  1         // InterfaceMethod java/util/List.isEmpty:()Z
+        97: ifne          197
+       100: iconst_0
+       101: istore        7
+       103: aload         6
+       105: invokeinterface #1820,  1         // InterfaceMethod java/util/List.iterator:()Ljava/util/Iterator;
+       110: astore        8
+       112: aload         8
+       114: invokeinterface #1827,  1         // InterfaceMethod java/util/Iterator.hasNext:()Z
+       119: ifeq          160
+       122: aload         8
+       124: invokeinterface #1830,  1         // InterfaceMethod java/util/Iterator.next:()Ljava/lang/Object;
+       129: checkcast     #1059               // class net/minecraft/world/entity/Leashable
+       132: astore        9
+       134: aload         9
+       136: aload_0
+       137: invokeinterface #3104,  2         // InterfaceMethod net/minecraft/world/entity/Leashable.canHaveALeashAttachedTo:(Lnet/minecraft/world/entity/Entity;)Z
+       142: ifeq          157
+       145: aload         9
+       147: aload_0
+       148: iconst_1
+       149: invokeinterface #3107,  3         // InterfaceMethod net/minecraft/world/entity/Leashable.setLeashedTo:(Lnet/minecraft/world/entity/Entity;Z)V
+       154: iconst_1
+       155: istore        7
+       157: goto          112
+       160: iload         7
+       162: ifeq          197
+       165: aload_0
+       166: invokevirtual #672                // Method level:()Lnet/minecraft/world/level/Level;
+       169: getstatic     #3110               // Field net/minecraft/world/level/gameevent/GameEvent.ENTITY_ACTION:Lnet/minecraft/core/Holder$Reference;
+       172: aload_0
+       173: invokevirtual #1698               // Method blockPosition:()Lnet/minecraft/core/BlockPos;
+       176: aload_1
+       177: invokestatic  #3113               // Method net/minecraft/world/level/gameevent/GameEvent$Context.of:(Lnet/minecraft/world/entity/Entity;)Lnet/minecraft/world/level/gameevent/GameEvent$Context;
+       180: invokevirtual #3116               // Method net/minecraft/world/level/Level.gameEvent:(Lnet/minecraft/core/Holder;Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/level/gameevent/GameEvent$Context;)V
+       183: aload_0
+       184: getstatic     #3119               // Field net/minecraft/sounds/SoundEvents.LEAD_TIED:Lnet/minecraft/sounds/SoundEvent;
+       187: invokevirtual #3121               // Method playSound:(Lnet/minecraft/sounds/SoundEvent;)V
+       190: getstatic     #3125               // Field net/minecraft/world/InteractionResult.SUCCESS_SERVER:Lnet/minecraft/world/InteractionResult$Success;
+       193: invokevirtual #3129               // Method net/minecraft/world/InteractionResult$Success.withoutItem:()Lnet/minecraft/world/InteractionResult$Success;
+       196: areturn
+       197: aload_1
+       198: aload_2
+       199: invokevirtual #3133               // Method net/minecraft/world/entity/player/Player.getItemInHand:(Lnet/minecraft/world/InteractionHand;)Lnet/minecraft/world/item/ItemStack;
+       202: astore        4
+       204: aload         4
+       206: getstatic     #3139               // Field net/minecraft/world/item/Items.SHEARS:Lnet/minecraft/world/item/Item;
+       209: invokevirtual #3140               // Method net/minecraft/world/item/ItemStack.is:(Ljava/lang/Object;)Z
+       212: ifeq          235
+       215: aload_0
+       216: aload_1
+       217: invokevirtual #3144               // Method shearOffAllLeashConnections:(Lnet/minecraft/world/entity/player/Player;)Z
+       220: ifeq          235
+       223: aload         4
+       225: iconst_1
+       226: aload_1
+       227: aload_2
+       228: invokevirtual #3148               // Method net/minecraft/world/item/ItemStack.hurtAndBreak:(ILnet/minecraft/world/entity/LivingEntity;Lnet/minecraft/world/InteractionHand;)V
+       231: getstatic     #3151               // Field net/minecraft/world/InteractionResult.SUCCESS:Lnet/minecraft/world/InteractionResult$Success;
+       234: areturn
+       235: aload_0
+       236: astore        6
+       238: aload         6
+       240: instanceof    #3153               // class net/minecraft/world/entity/Mob
+       243: ifeq          296
+       246: aload         6
+       248: checkcast     #3153               // class net/minecraft/world/entity/Mob
+       251: astore        5
+       253: aload         4
+       255: getstatic     #3139               // Field net/minecraft/world/item/Items.SHEARS:Lnet/minecraft/world/item/Item;
+       258: invokevirtual #3140               // Method net/minecraft/world/item/ItemStack.is:(Ljava/lang/Object;)Z
+       261: ifeq          296
+       264: aload         5
+       266: aload_1
+       267: invokevirtual #3156               // Method net/minecraft/world/entity/Mob.canShearEquipment:(Lnet/minecraft/world/entity/player/Player;)Z
+       270: ifeq          296
+       273: aload_1
+       274: invokevirtual #3079               // Method net/minecraft/world/entity/player/Player.isSecondaryUseActive:()Z
+       277: ifne          296
+       280: aload         5
+       282: aload_1
+       283: aload_2
+       284: aload         4
+       286: invokevirtual #3160               // Method net/minecraft/world/entity/Mob.attemptToShearEquipment:(Lnet/minecraft/world/entity/player/Player;Lnet/minecraft/world/InteractionHand;Lnet/minecraft/world/item/ItemStack;)Z
+       289: ifeq          296
+       292: getstatic     #3151               // Field net/minecraft/world/InteractionResult.SUCCESS:Lnet/minecraft/world/InteractionResult$Success;
+       295: areturn
+       296: aload_0
+       297: invokevirtual #741                // Method isAlive:()Z
+       300: ifeq          487
+       303: aload_0
+       304: astore        6
+       306: aload         6
+       308: instanceof    #1059               // class net/minecraft/world/entity/Leashable
+       311: ifeq          487
+       314: aload         6
+       316: checkcast     #1059               // class net/minecraft/world/entity/Leashable
+       319: astore        5
+       321: aload         5
+       323: invokeinterface #3163,  1         // InterfaceMethod net/minecraft/world/entity/Leashable.getLeashHolder:()Lnet/minecraft/world/entity/Entity;
+       328: aload_1
+       329: if_acmpne     388
+       332: aload_0
+       333: invokevirtual #672                // Method level:()Lnet/minecraft/world/level/Level;
+       336: invokevirtual #1054               // Method net/minecraft/world/level/Level.isClientSide:()Z
+       339: ifne          381
+       342: aload_1
+       343: invokevirtual #3166               // Method net/minecraft/world/entity/player/Player.hasInfiniteMaterials:()Z
+       346: ifeq          359
+       349: aload         5
+       351: invokeinterface #3169,  1         // InterfaceMethod net/minecraft/world/entity/Leashable.removeLeash:()V
+       356: goto          366
+       359: aload         5
+       361: invokeinterface #3172,  1         // InterfaceMethod net/minecraft/world/entity/Leashable.dropLeash:()V
+       366: aload_0
+       367: getstatic     #3175               // Field net/minecraft/world/level/gameevent/GameEvent.ENTITY_INTERACT:Lnet/minecraft/core/Holder$Reference;
+       370: aload_1
+       371: invokevirtual #2126               // Method gameEvent:(Lnet/minecraft/core/Holder;Lnet/minecraft/world/entity/Entity;)V
+       374: aload_0
+       375: getstatic     #3178               // Field net/minecraft/sounds/SoundEvents.LEAD_UNTIED:Lnet/minecraft/sounds/SoundEvent;
+       378: invokevirtual #3121               // Method playSound:(Lnet/minecraft/sounds/SoundEvent;)V
+       381: getstatic     #3151               // Field net/minecraft/world/InteractionResult.SUCCESS:Lnet/minecraft/world/InteractionResult$Success;
+       384: invokevirtual #3129               // Method net/minecraft/world/InteractionResult$Success.withoutItem:()Lnet/minecraft/world/InteractionResult$Success;
+       387: areturn
+       388: aload_1
+       389: aload_2
+       390: invokevirtual #3133               // Method net/minecraft/world/entity/player/Player.getItemInHand:(Lnet/minecraft/world/InteractionHand;)Lnet/minecraft/world/item/ItemStack;
+       393: astore        6
+       395: aload         6
+       397: getstatic     #3181               // Field net/minecraft/world/item/Items.LEAD:Lnet/minecraft/world/item/Item;
+       400: invokevirtual #3140               // Method net/minecraft/world/item/ItemStack.is:(Ljava/lang/Object;)Z
+       403: ifeq          487
+       406: aload         5
+       408: invokeinterface #3163,  1         // InterfaceMethod net/minecraft/world/entity/Leashable.getLeashHolder:()Lnet/minecraft/world/entity/Entity;
+       413: instanceof    #3076               // class net/minecraft/world/entity/player/Player
+       416: ifne          487
+       419: aload_0
+       420: invokevirtual #672                // Method level:()Lnet/minecraft/world/level/Level;
+       423: invokevirtual #1054               // Method net/minecraft/world/level/Level.isClientSide:()Z
+       426: ifeq          433
+       429: getstatic     #3184               // Field net/minecraft/world/InteractionResult.CONSUME:Lnet/minecraft/world/InteractionResult$Success;
+       432: areturn
+       433: aload         5
+       435: aload_1
+       436: invokeinterface #3104,  2         // InterfaceMethod net/minecraft/world/entity/Leashable.canHaveALeashAttachedTo:(Lnet/minecraft/world/entity/Entity;)Z
+       441: ifeq          487
+       444: aload         5
+       446: invokeinterface #3187,  1         // InterfaceMethod net/minecraft/world/entity/Leashable.isLeashed:()Z
+       451: ifeq          461
+       454: aload         5
+       456: invokeinterface #3172,  1         // InterfaceMethod net/minecraft/world/entity/Leashable.dropLeash:()V
+       461: aload         5
+       463: aload_1
+       464: iconst_1
+       465: invokeinterface #3107,  3         // InterfaceMethod net/minecraft/world/entity/Leashable.setLeashedTo:(Lnet/minecraft/world/entity/Entity;Z)V
+       470: aload_0
+       471: getstatic     #3119               // Field net/minecraft/sounds/SoundEvents.LEAD_TIED:Lnet/minecraft/sounds/SoundEvent;
+       474: invokevirtual #3121               // Method playSound:(Lnet/minecraft/sounds/SoundEvent;)V
+       477: aload         6
+       479: iconst_1
+       480: invokevirtual #3190               // Method net/minecraft/world/item/ItemStack.shrink:(I)V
+       483: getstatic     #3125               // Field net/minecraft/world/InteractionResult.SUCCESS_SERVER:Lnet/minecraft/world/InteractionResult$Success;
+       486: areturn
+       487: getstatic     #3194               // Field net/minecraft/world/InteractionResult.PASS:Lnet/minecraft/world/InteractionResult$Pass;
+       490: areturn
+
+  public boolean shearOffAllLeashConnections(net.minecraft.world.entity.player.Player);
+    Code:
+         0: aload_0
+         1: aload_1
+         2: invokevirtual #3209               // Method dropAllLeashConnections:(Lnet/minecraft/world/entity/player/Player;)Z
+         5: istore_2
+         6: iload_2
+         7: ifeq          57
+        10: aload_0
+        11: invokevirtual #672                // Method level:()Lnet/minecraft/world/level/Level;
+        14: astore        4
+        16: aload         4
+        18: instanceof    #1016               // class net/minecraft/server/level/ServerLevel
+        21: ifeq          57
+        24: aload         4
+        26: checkcast     #1016               // class net/minecraft/server/level/ServerLevel
+        29: astore_3
+        30: aload_3
+        31: aconst_null
+        32: aload_0
+        33: invokevirtual #1698               // Method blockPosition:()Lnet/minecraft/core/BlockPos;
+        36: getstatic     #3212               // Field net/minecraft/sounds/SoundEvents.SHEARS_SNIP:Lnet/minecraft/sounds/SoundEvent;
+        39: aload_1
+        40: ifnull        50
+        43: aload_1
+        44: invokevirtual #3213               // Method net/minecraft/world/entity/player/Player.getSoundSource:()Lnet/minecraft/sounds/SoundSource;
+        47: goto          54
+        50: aload_0
+        51: invokevirtual #1123               // Method getSoundSource:()Lnet/minecraft/sounds/SoundSource;
+        54: invokevirtual #3220               // Method net/minecraft/server/level/ServerLevel.playSound:(Lnet/minecraft/world/entity/Entity;Lnet/minecraft/core/BlockPos;Lnet/minecraft/sounds/SoundEvent;Lnet/minecraft/sounds/SoundSource;)V
+        57: iload_2
+        58: ireturn
+
+  public boolean dropAllLeashConnections(net.minecraft.world.entity.player.Player);
+    Code:
+         0: aload_0
+         1: invokestatic  #3225               // InterfaceMethod net/minecraft/world/entity/Leashable.leashableLeashedTo:(Lnet/minecraft/world/entity/Entity;)Ljava/util/List;
+         4: astore_2
+         5: aload_2
+         6: invokeinterface #1525,  1         // InterfaceMethod java/util/List.isEmpty:()Z
+        11: ifne          18
+        14: iconst_1
+        15: goto          19
+        18: iconst_0
+        19: istore_3
+        20: aload_0
+        21: astore        5
+        23: aload         5
+        25: instanceof    #1059               // class net/minecraft/world/entity/Leashable
+        28: ifeq          57
+        31: aload         5
+        33: checkcast     #1059               // class net/minecraft/world/entity/Leashable
+        36: astore        4
+        38: aload         4
+        40: invokeinterface #3187,  1         // InterfaceMethod net/minecraft/world/entity/Leashable.isLeashed:()Z
+        45: ifeq          57
+        48: aload         4
+        50: invokeinterface #3172,  1         // InterfaceMethod net/minecraft/world/entity/Leashable.dropLeash:()V
+        55: iconst_1
+        56: istore_3
+        57: aload_2
+        58: invokeinterface #1820,  1         // InterfaceMethod java/util/List.iterator:()Ljava/util/Iterator;
+        63: astore        4
+        65: aload         4
+        67: invokeinterface #1827,  1         // InterfaceMethod java/util/Iterator.hasNext:()Z
+        72: ifeq          97
+        75: aload         4
+        77: invokeinterface #1830,  1         // InterfaceMethod java/util/Iterator.next:()Ljava/lang/Object;
+        82: checkcast     #1059               // class net/minecraft/world/entity/Leashable
+        85: astore        5
+        87: aload         5
+        89: invokeinterface #3172,  1         // InterfaceMethod net/minecraft/world/entity/Leashable.dropLeash:()V
+        94: goto          65
+        97: iload_3
+        98: ifeq          111
+       101: aload_0
+       102: getstatic     #3228               // Field net/minecraft/world/level/gameevent/GameEvent.SHEAR:Lnet/minecraft/core/Holder$Reference;
+       105: aload_1
+       106: invokevirtual #2126               // Method gameEvent:(Lnet/minecraft/core/Holder;Lnet/minecraft/world/entity/Entity;)V
+       109: iconst_1
+       110: ireturn
+       111: iconst_0
+       112: ireturn
+
+  public boolean canCollideWith(net.minecraft.world.entity.Entity);
+    Code:
+         0: aload_1
+         1: aload_0
+         2: invokevirtual #3234               // Method canBeCollidedWith:(Lnet/minecraft/world/entity/Entity;)Z
+         5: ifeq          20
+         8: aload_0
+         9: aload_1
+        10: invokevirtual #2569               // Method isPassengerOfSameVehicle:(Lnet/minecraft/world/entity/Entity;)Z
+        13: ifne          20
+        16: iconst_1
+        17: goto          21
+        20: iconst_0
+        21: ireturn
+
+  public boolean canBeCollidedWith(net.minecraft.world.entity.Entity);
+    Code:
+         0: iconst_0
+         1: ireturn
+
+  public void rideTick();
+    Code:
+         0: aload_0
+         1: getstatic     #443                // Field net/minecraft/world/phys/Vec3.ZERO:Lnet/minecraft/world/phys/Vec3;
+         4: invokevirtual #1259               // Method setDeltaMovement:(Lnet/minecraft/world/phys/Vec3;)V
+         7: aload_0
+         8: invokevirtual #3237               // Method tick:()V
+        11: aload_0
+        12: invokevirtual #756                // Method isPassenger:()Z
+        15: ifne          19
+        18: return
+        19: aload_0
+        20: invokevirtual #987                // Method getVehicle:()Lnet/minecraft/world/entity/Entity;
+        23: aload_0
+        24: invokevirtual #3240               // Method positionRider:(Lnet/minecraft/world/entity/Entity;)V
+        27: return
+
+  public final void positionRider(net.minecraft.world.entity.Entity);
+    Code:
+         0: aload_0
+         1: aload_1
+         2: invokevirtual #3243               // Method hasPassenger:(Lnet/minecraft/world/entity/Entity;)Z
+         5: ifne          9
+         8: return
+         9: aload_0
+        10: aload_1
+        11: invokedynamic #3249,  0           // InvokeDynamic #7:accept:()Lnet/minecraft/world/entity/Entity$MoveFunction;
+        16: invokevirtual #3252               // Method positionRider:(Lnet/minecraft/world/entity/Entity;Lnet/minecraft/world/entity/Entity$MoveFunction;)V
+        19: return
+
+  protected void positionRider(net.minecraft.world.entity.Entity, net.minecraft.world.entity.Entity$MoveFunction);
+    Code:
+         0: aload_0
+         1: aload_1
+         2: invokevirtual #3257               // Method getPassengerRidingPosition:(Lnet/minecraft/world/entity/Entity;)Lnet/minecraft/world/phys/Vec3;
+         5: astore_3
+         6: aload_1
+         7: aload_0
+         8: invokevirtual #3260               // Method getVehicleAttachmentPoint:(Lnet/minecraft/world/entity/Entity;)Lnet/minecraft/world/phys/Vec3;
+        11: astore        4
+        13: aload_2
+        14: aload_1
+        15: aload_3
+        16: getfield      #932                // Field net/minecraft/world/phys/Vec3.x:D
+        19: aload         4
+        21: getfield      #932                // Field net/minecraft/world/phys/Vec3.x:D
+        24: dsub
+        25: aload_3
+        26: getfield      #934                // Field net/minecraft/world/phys/Vec3.y:D
+        29: aload         4
+        31: getfield      #934                // Field net/minecraft/world/phys/Vec3.y:D
+        34: dsub
+        35: aload_3
+        36: getfield      #936                // Field net/minecraft/world/phys/Vec3.z:D
+        39: aload         4
+        41: getfield      #936                // Field net/minecraft/world/phys/Vec3.z:D
+        44: dsub
+        45: invokeinterface #3262,  8         // InterfaceMethod net/minecraft/world/entity/Entity$MoveFunction.accept:(Lnet/minecraft/world/entity/Entity;DDD)V
+        50: return
+
+  public void onPassengerTurned(net.minecraft.world.entity.Entity);
+    Code:
+         0: return
+
+  public net.minecraft.world.phys.Vec3 getVehicleAttachmentPoint(net.minecraft.world.entity.Entity);
+    Code:
+         0: aload_0
+         1: invokevirtual #3267               // Method getAttachments:()Lnet/minecraft/world/entity/EntityAttachments;
+         4: getstatic     #3273               // Field net/minecraft/world/entity/EntityAttachment.VEHICLE:Lnet/minecraft/world/entity/EntityAttachment;
+         7: iconst_0
+         8: aload_0
+         9: getfield      #3275               // Field yRot:F
+        12: invokevirtual #3280               // Method net/minecraft/world/entity/EntityAttachments.get:(Lnet/minecraft/world/entity/EntityAttachment;IF)Lnet/minecraft/world/phys/Vec3;
+        15: areturn
+
+  public net.minecraft.world.phys.Vec3 getPassengerRidingPosition(net.minecraft.world.entity.Entity);
+    Code:
+         0: aload_0
+         1: invokevirtual #870                // Method position:()Lnet/minecraft/world/phys/Vec3;
+         4: aload_0
+         5: aload_1
+         6: aload_0
+         7: getfield      #581                // Field dimensions:Lnet/minecraft/world/entity/EntityDimensions;
+        10: fconst_1
+        11: invokevirtual #3284               // Method getPassengerAttachmentPoint:(Lnet/minecraft/world/entity/Entity;Lnet/minecraft/world/entity/EntityDimensions;F)Lnet/minecraft/world/phys/Vec3;
+        14: invokevirtual #1280               // Method net/minecraft/world/phys/Vec3.add:(Lnet/minecraft/world/phys/Vec3;)Lnet/minecraft/world/phys/Vec3;
+        17: areturn
+
+  protected net.minecraft.world.phys.Vec3 getPassengerAttachmentPoint(net.minecraft.world.entity.Entity, net.minecraft.world.entity.EntityDimensions, float);
+    Code:
+         0: aload_0
+         1: aload_1
+         2: aload_2
+         3: invokevirtual #3287               // Method net/minecraft/world/entity/EntityDimensions.attachments:()Lnet/minecraft/world/entity/EntityAttachments;
+         6: invokestatic  #3291               // Method getDefaultPassengerAttachmentPoint:(Lnet/minecraft/world/entity/Entity;Lnet/minecraft/world/entity/Entity;Lnet/minecraft/world/entity/EntityAttachments;)Lnet/minecraft/world/phys/Vec3;
+         9: areturn
+
+  protected static net.minecraft.world.phys.Vec3 getDefaultPassengerAttachmentPoint(net.minecraft.world.entity.Entity, net.minecraft.world.entity.Entity, net.minecraft.world.entity.EntityAttachments);
+    Code:
+         0: aload_0
+         1: invokevirtual #2307               // Method getPassengers:()Ljava/util/List;
+         4: aload_1
+         5: invokeinterface #3295,  2         // InterfaceMethod java/util/List.indexOf:(Ljava/lang/Object;)I
+        10: istore_3
+        11: aload_2
+        12: getstatic     #3298               // Field net/minecraft/world/entity/EntityAttachment.PASSENGER:Lnet/minecraft/world/entity/EntityAttachment;
+        15: iload_3
+        16: aload_0
+        17: getfield      #3275               // Field yRot:F
+        20: invokevirtual #3301               // Method net/minecraft/world/entity/EntityAttachments.getClamped:(Lnet/minecraft/world/entity/EntityAttachment;IF)Lnet/minecraft/world/phys/Vec3;
+        23: areturn
+
+  public final boolean startRiding(net.minecraft.world.entity.Entity);
+    Code:
+         0: aload_0
+         1: aload_1
+         2: iconst_0
+         3: iconst_1
+         4: invokevirtual #3307               // Method startRiding:(Lnet/minecraft/world/entity/Entity;ZZ)Z
+         7: ireturn
+
+  public boolean showVehicleHealth();
+    Code:
+         0: aload_0
+         1: instanceof    #1454               // class net/minecraft/world/entity/LivingEntity
+         4: ireturn
+
+  public boolean startRiding(net.minecraft.world.entity.Entity, boolean, boolean);
+    Code:
+         0: aload_1
+         1: aload_0
+         2: getfield      #957                // Field vehicle:Lnet/minecraft/world/entity/Entity;
+         5: if_acmpne     10
+         8: iconst_0
+         9: ireturn
+        10: aload_1
+        11: invokevirtual #3314               // Method couldAcceptPassenger:()Z
+        14: ifne          19
+        17: iconst_0
+        18: ireturn
+        19: aload_0
+        20: invokevirtual #672                // Method level:()Lnet/minecraft/world/level/Level;
+        23: invokevirtual #1054               // Method net/minecraft/world/level/Level.isClientSide:()Z
+        26: ifne          41
+        29: aload_1
+        30: getfield      #565                // Field type:Lnet/minecraft/world/entity/EntityType;
+        33: invokevirtual #2978               // Method net/minecraft/world/entity/EntityType.canSerialize:()Z
+        36: ifne          41
+        39: iconst_0
+        40: ireturn
+        41: aload_1
+        42: astore        4
+        44: aload         4
+        46: getfield      #957                // Field vehicle:Lnet/minecraft/world/entity/Entity;
+        49: ifnull        73
+        52: aload         4
+        54: getfield      #957                // Field vehicle:Lnet/minecraft/world/entity/Entity;
+        57: aload_0
+        58: if_acmpne     63
+        61: iconst_0
+        62: ireturn
+        63: aload         4
+        65: getfield      #957                // Field vehicle:Lnet/minecraft/world/entity/Entity;
+        68: astore        4
+        70: goto          44
+        73: iload_2
+        74: ifne          95
+        77: aload_0
+        78: aload_1
+        79: invokevirtual #3317               // Method canRide:(Lnet/minecraft/world/entity/Entity;)Z
+        82: ifeq          93
+        85: aload_1
+        86: aload_0
+        87: invokevirtual #3320               // Method canAddPassenger:(Lnet/minecraft/world/entity/Entity;)Z
+        90: ifne          95
+        93: iconst_0
+        94: ireturn
+        95: aload_0
+        96: invokevirtual #756                // Method isPassenger:()Z
+        99: ifeq          106
+       102: aload_0
+       103: invokevirtual #759                // Method stopRiding:()V
+       106: aload_0
+       107: getstatic     #639                // Field net/minecraft/world/entity/Pose.STANDING:Lnet/minecraft/world/entity/Pose;
+       110: invokevirtual #3322               // Method setPose:(Lnet/minecraft/world/entity/Pose;)V
+       113: aload_0
+       114: aload_1
+       115: putfield      #957                // Field vehicle:Lnet/minecraft/world/entity/Entity;
+       118: aload_0
+       119: getfield      #957                // Field vehicle:Lnet/minecraft/world/entity/Entity;
+       122: aload_0
+       123: invokevirtual #3325               // Method addPassenger:(Lnet/minecraft/world/entity/Entity;)V
+       126: iload_3
+       127: ifeq          172
+       130: aload_0
+       131: invokevirtual #672                // Method level:()Lnet/minecraft/world/level/Level;
+       134: aload_0
+       135: getstatic     #3328               // Field net/minecraft/world/level/gameevent/GameEvent.ENTITY_MOUNT:Lnet/minecraft/core/Holder$Reference;
+       138: aload_0
+       139: getfield      #957                // Field vehicle:Lnet/minecraft/world/entity/Entity;
+       142: getfield      #583                // Field position:Lnet/minecraft/world/phys/Vec3;
+       145: invokevirtual #2121               // Method net/minecraft/world/level/Level.gameEvent:(Lnet/minecraft/world/entity/Entity;Lnet/minecraft/core/Holder;Lnet/minecraft/world/phys/Vec3;)V
+       148: aload_1
+       149: invokevirtual #3332               // Method getIndirectPassengersStream:()Ljava/util/stream/Stream;
+       152: invokedynamic #3340,  0           // InvokeDynamic #8:test:()Ljava/util/function/Predicate;
+       157: invokeinterface #3344,  2         // InterfaceMethod java/util/stream/Stream.filter:(Ljava/util/function/Predicate;)Ljava/util/stream/Stream;
+       162: invokedynamic #3352,  0           // InvokeDynamic #9:accept:()Ljava/util/function/Consumer;
+       167: invokeinterface #3355,  2         // InterfaceMethod java/util/stream/Stream.forEach:(Ljava/util/function/Consumer;)V
+       172: iconst_1
+       173: ireturn
+
+  protected boolean canRide(net.minecraft.world.entity.Entity);
+    Code:
+         0: aload_0
+         1: invokevirtual #3359               // Method isShiftKeyDown:()Z
+         4: ifne          18
+         7: aload_0
+         8: getfield      #989                // Field boardingCooldown:I
+        11: ifgt          18
+        14: iconst_1
+        15: goto          19
+        18: iconst_0
+        19: ireturn
+
+  public void ejectPassengers();
+    Code:
+         0: aload_0
+         1: getfield      #438                // Field passengers:Lcom/google/common/collect/ImmutableList;
+         4: invokevirtual #3360               // Method com/google/common/collect/ImmutableList.size:()I
+         7: iconst_1
+         8: isub
+         9: istore_1
+        10: iload_1
+        11: iflt          34
+        14: aload_0
+        15: getfield      #438                // Field passengers:Lcom/google/common/collect/ImmutableList;
+        18: iload_1
+        19: invokevirtual #3363               // Method com/google/common/collect/ImmutableList.get:(I)Ljava/lang/Object;
+        22: checkcast     #2                  // class net/minecraft/world/entity/Entity
+        25: invokevirtual #759                // Method stopRiding:()V
+        28: iinc          1, -1
+        31: goto          10
+        34: return
+
+  public void removeVehicle();
+    Code:
+         0: aload_0
+         1: getfield      #957                // Field vehicle:Lnet/minecraft/world/entity/Entity;
+         4: ifnull        53
+         7: aload_0
+         8: getfield      #957                // Field vehicle:Lnet/minecraft/world/entity/Entity;
+        11: astore_1
+        12: aload_0
+        13: aconst_null
+        14: putfield      #957                // Field vehicle:Lnet/minecraft/world/entity/Entity;
+        17: aload_1
+        18: aload_0
+        19: invokevirtual #3367               // Method removePassenger:(Lnet/minecraft/world/entity/Entity;)V
+        22: aload_0
+        23: invokevirtual #3371               // Method getRemovalReason:()Lnet/minecraft/world/entity/Entity$RemovalReason;
+        26: astore_2
+        27: aload_2
+        28: ifnull        38
+        31: aload_2
+        32: invokevirtual #3374               // Method net/minecraft/world/entity/Entity$RemovalReason.shouldDestroy:()Z
+        35: ifeq          53
+        38: aload_0
+        39: invokevirtual #672                // Method level:()Lnet/minecraft/world/level/Level;
+        42: aload_0
+        43: getstatic     #3377               // Field net/minecraft/world/level/gameevent/GameEvent.ENTITY_DISMOUNT:Lnet/minecraft/core/Holder$Reference;
+        46: aload_1
+        47: getfield      #583                // Field position:Lnet/minecraft/world/phys/Vec3;
+        50: invokevirtual #2121               // Method net/minecraft/world/level/Level.gameEvent:(Lnet/minecraft/world/entity/Entity;Lnet/minecraft/core/Holder;Lnet/minecraft/world/phys/Vec3;)V
+        53: return
+
+  public void stopRiding();
+    Code:
+         0: aload_0
+         1: invokevirtual #3380               // Method removeVehicle:()V
+         4: return
+
+  protected void addPassenger(net.minecraft.world.entity.Entity);
+    Code:
+         0: aload_1
+         1: invokevirtual #987                // Method getVehicle:()Lnet/minecraft/world/entity/Entity;
+         4: aload_0
+         5: if_acmpeq     19
+         8: new           #789                // class java/lang/IllegalStateException
+        11: dup
+        12: ldc_w         #3382               // String Use x.startRiding(y), not y.addPassenger(x)
+        15: invokespecial #794                // Method java/lang/IllegalStateException."<init>":(Ljava/lang/String;)V
+        18: athrow
+        19: aload_0
+        20: getfield      #438                // Field passengers:Lcom/google/common/collect/ImmutableList;
+        23: invokevirtual #3383               // Method com/google/common/collect/ImmutableList.isEmpty:()Z
+        26: ifeq          40
+        29: aload_0
+        30: aload_1
+        31: invokestatic  #3386               // Method com/google/common/collect/ImmutableList.of:(Ljava/lang/Object;)Lcom/google/common/collect/ImmutableList;
+        34: putfield      #438                // Field passengers:Lcom/google/common/collect/ImmutableList;
+        37: goto          102
+        40: aload_0
+        41: getfield      #438                // Field passengers:Lcom/google/common/collect/ImmutableList;
+        44: invokestatic  #3392               // Method com/google/common/collect/Lists.newArrayList:(Ljava/lang/Iterable;)Ljava/util/ArrayList;
+        47: astore_2
+        48: aload_0
+        49: invokevirtual #672                // Method level:()Lnet/minecraft/world/level/Level;
+        52: invokevirtual #1054               // Method net/minecraft/world/level/Level.isClientSide:()Z
+        55: ifne          86
+        58: aload_1
+        59: instanceof    #3076               // class net/minecraft/world/entity/player/Player
+        62: ifeq          86
+        65: aload_0
+        66: invokevirtual #3395               // Method getFirstPassenger:()Lnet/minecraft/world/entity/Entity;
+        69: instanceof    #3076               // class net/minecraft/world/entity/player/Player
+        72: ifne          86
+        75: aload_2
+        76: iconst_0
+        77: aload_1
+        78: invokeinterface #3398,  3         // InterfaceMethod java/util/List.add:(ILjava/lang/Object;)V
+        83: goto          94
+        86: aload_2
+        87: aload_1
+        88: invokeinterface #1532,  2         // InterfaceMethod java/util/List.add:(Ljava/lang/Object;)Z
+        93: pop
+        94: aload_0
+        95: aload_2
+        96: invokestatic  #3401               // Method com/google/common/collect/ImmutableList.copyOf:(Ljava/util/Collection;)Lcom/google/common/collect/ImmutableList;
+        99: putfield      #438                // Field passengers:Lcom/google/common/collect/ImmutableList;
+       102: return
+
+  protected void removePassenger(net.minecraft.world.entity.Entity);
+    Code:
+         0: aload_1
+         1: invokevirtual #987                // Method getVehicle:()Lnet/minecraft/world/entity/Entity;
+         4: aload_0
+         5: if_acmpne     19
+         8: new           #789                // class java/lang/IllegalStateException
+        11: dup
+        12: ldc_w         #3405               // String Use x.stopRiding(y), not y.removePassenger(x)
+        15: invokespecial #794                // Method java/lang/IllegalStateException."<init>":(Ljava/lang/String;)V
+        18: athrow
+        19: aload_0
+        20: getfield      #438                // Field passengers:Lcom/google/common/collect/ImmutableList;
+        23: invokevirtual #3360               // Method com/google/common/collect/ImmutableList.size:()I
+        26: iconst_1
+        27: if_icmpne     52
+        30: aload_0
+        31: getfield      #438                // Field passengers:Lcom/google/common/collect/ImmutableList;
+        34: iconst_0
+        35: invokevirtual #3363               // Method com/google/common/collect/ImmutableList.get:(I)Ljava/lang/Object;
+        38: aload_1
+        39: if_acmpne     52
+        42: aload_0
+        43: invokestatic  #436                // Method com/google/common/collect/ImmutableList.of:()Lcom/google/common/collect/ImmutableList;
+        46: putfield      #438                // Field passengers:Lcom/google/common/collect/ImmutableList;
+        49: goto          85
+        52: aload_0
+        53: aload_0
+        54: getfield      #438                // Field passengers:Lcom/google/common/collect/ImmutableList;
+        57: invokevirtual #3408               // Method com/google/common/collect/ImmutableList.stream:()Ljava/util/stream/Stream;
+        60: aload_1
+        61: invokedynamic #3416,  0           // InvokeDynamic #10:test:(Lnet/minecraft/world/entity/Entity;)Ljava/util/function/Predicate;
+        66: invokeinterface #3344,  2         // InterfaceMethod java/util/stream/Stream.filter:(Ljava/util/function/Predicate;)Ljava/util/stream/Stream;
+        71: invokestatic  #3420               // Method com/google/common/collect/ImmutableList.toImmutableList:()Ljava/util/stream/Collector;
+        74: invokeinterface #3424,  2         // InterfaceMethod java/util/stream/Stream.collect:(Ljava/util/stream/Collector;)Ljava/lang/Object;
+        79: checkcast     #89                 // class com/google/common/collect/ImmutableList
+        82: putfield      #438                // Field passengers:Lcom/google/common/collect/ImmutableList;
+        85: aload_1
+        86: bipush        60
+        88: putfield      #989                // Field boardingCooldown:I
+        91: return
+
+  protected boolean canAddPassenger(net.minecraft.world.entity.Entity);
+    Code:
+         0: aload_0
+         1: getfield      #438                // Field passengers:Lcom/google/common/collect/ImmutableList;
+         4: invokevirtual #3383               // Method com/google/common/collect/ImmutableList.isEmpty:()Z
+         7: ireturn
+
+  protected boolean couldAcceptPassenger();
+    Code:
+         0: iconst_1
+         1: ireturn
+
+  public final boolean isInterpolating();
+    Code:
+         0: aload_0
+         1: invokevirtual #3429               // Method getInterpolation:()Lnet/minecraft/world/entity/InterpolationHandler;
+         4: ifnull        21
+         7: aload_0
+         8: invokevirtual #3429               // Method getInterpolation:()Lnet/minecraft/world/entity/InterpolationHandler;
+        11: invokevirtual #3434               // Method net/minecraft/world/entity/InterpolationHandler.hasActiveInterpolation:()Z
+        14: ifeq          21
+        17: iconst_1
+        18: goto          22
+        21: iconst_0
+        22: ireturn
+
+  public final void moveOrInterpolateTo(net.minecraft.world.phys.Vec3, float, float);
+    Code:
+         0: aload_0
+         1: aload_1
+         2: invokestatic  #3438               // Method java/util/Optional.of:(Ljava/lang/Object;)Ljava/util/Optional;
+         5: fload_2
+         6: invokestatic  #3441               // Method java/lang/Float.valueOf:(F)Ljava/lang/Float;
+         9: invokestatic  #3438               // Method java/util/Optional.of:(Ljava/lang/Object;)Ljava/util/Optional;
+        12: fload_3
+        13: invokestatic  #3441               // Method java/lang/Float.valueOf:(F)Ljava/lang/Float;
+        16: invokestatic  #3438               // Method java/util/Optional.of:(Ljava/lang/Object;)Ljava/util/Optional;
+        19: invokevirtual #3444               // Method moveOrInterpolateTo:(Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;)V
+        22: return
+
+  public final void moveOrInterpolateTo(float, float);
+    Code:
+         0: aload_0
+         1: invokestatic  #528                // Method java/util/Optional.empty:()Ljava/util/Optional;
+         4: fload_1
+         5: invokestatic  #3441               // Method java/lang/Float.valueOf:(F)Ljava/lang/Float;
+         8: invokestatic  #3438               // Method java/util/Optional.of:(Ljava/lang/Object;)Ljava/util/Optional;
+        11: fload_2
+        12: invokestatic  #3441               // Method java/lang/Float.valueOf:(F)Ljava/lang/Float;
+        15: invokestatic  #3438               // Method java/util/Optional.of:(Ljava/lang/Object;)Ljava/util/Optional;
+        18: invokevirtual #3444               // Method moveOrInterpolateTo:(Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;)V
+        21: return
+
+  public final void moveOrInterpolateTo(net.minecraft.world.phys.Vec3);
+    Code:
+         0: aload_0
+         1: aload_1
+         2: invokestatic  #3438               // Method java/util/Optional.of:(Ljava/lang/Object;)Ljava/util/Optional;
+         5: invokestatic  #528                // Method java/util/Optional.empty:()Ljava/util/Optional;
+         8: invokestatic  #528                // Method java/util/Optional.empty:()Ljava/util/Optional;
+        11: invokevirtual #3444               // Method moveOrInterpolateTo:(Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;)V
+        14: return
+
+  public final void moveOrInterpolateTo(java.util.Optional<net.minecraft.world.phys.Vec3>, java.util.Optional<java.lang.Float>, java.util.Optional<java.lang.Float>);
+    Code:
+         0: aload_0
+         1: invokevirtual #3429               // Method getInterpolation:()Lnet/minecraft/world/entity/InterpolationHandler;
+         4: astore        4
+         6: aload         4
+         8: ifnull        67
+        11: aload         4
+        13: aload_1
+        14: aload         4
+        16: invokevirtual #3446               // Method net/minecraft/world/entity/InterpolationHandler.position:()Lnet/minecraft/world/phys/Vec3;
+        19: invokevirtual #2285               // Method java/util/Optional.orElse:(Ljava/lang/Object;)Ljava/lang/Object;
+        22: checkcast     #440                // class net/minecraft/world/phys/Vec3
+        25: aload_2
+        26: aload         4
+        28: invokevirtual #3448               // Method net/minecraft/world/entity/InterpolationHandler.yRot:()F
+        31: invokestatic  #3441               // Method java/lang/Float.valueOf:(F)Ljava/lang/Float;
+        34: invokevirtual #2285               // Method java/util/Optional.orElse:(Ljava/lang/Object;)Ljava/lang/Object;
+        37: checkcast     #2355               // class java/lang/Float
+        40: invokevirtual #2358               // Method java/lang/Float.floatValue:()F
+        43: aload_3
+        44: aload         4
+        46: invokevirtual #3450               // Method net/minecraft/world/entity/InterpolationHandler.xRot:()F
+        49: invokestatic  #3441               // Method java/lang/Float.valueOf:(F)Ljava/lang/Float;
+        52: invokevirtual #2285               // Method java/util/Optional.orElse:(Ljava/lang/Object;)Ljava/lang/Object;
+        55: checkcast     #2355               // class java/lang/Float
+        58: invokevirtual #2358               // Method java/lang/Float.floatValue:()F
+        61: invokevirtual #3453               // Method net/minecraft/world/entity/InterpolationHandler.interpolateTo:(Lnet/minecraft/world/phys/Vec3;FF)V
+        64: goto          97
+        67: aload_1
+        68: aload_0
+        69: invokedynamic #3456,  0           // InvokeDynamic #11:accept:(Lnet/minecraft/world/entity/Entity;)Ljava/util/function/Consumer;
+        74: invokevirtual #2926               // Method java/util/Optional.ifPresent:(Ljava/util/function/Consumer;)V
+        77: aload_2
+        78: aload_0
+        79: invokedynamic #3463,  0           // InvokeDynamic #12:accept:(Lnet/minecraft/world/entity/Entity;)Ljava/util/function/Consumer;
+        84: invokevirtual #2926               // Method java/util/Optional.ifPresent:(Ljava/util/function/Consumer;)V
+        87: aload_3
+        88: aload_0
+        89: invokedynamic #3468,  0           // InvokeDynamic #13:accept:(Lnet/minecraft/world/entity/Entity;)Ljava/util/function/Consumer;
+        94: invokevirtual #2926               // Method java/util/Optional.ifPresent:(Ljava/util/function/Consumer;)V
+        97: return
+
+  public net.minecraft.world.entity.InterpolationHandler getInterpolation();
+    Code:
+         0: aconst_null
+         1: areturn
+
+  public void lerpHeadTo(float, int);
+    Code:
+         0: aload_0
+         1: fload_1
+         2: invokevirtual #2889               // Method setYHeadRot:(F)V
+         5: return
+
+  public float getPickRadius();
+    Code:
+         0: fconst_0
+         1: freturn
+
+  public net.minecraft.world.phys.Vec3 getLookAngle();
+    Code:
+         0: aload_0
+         1: aload_0
+         2: invokevirtual #942                // Method getXRot:()F
+         5: aload_0
+         6: invokevirtual #945                // Method getYRot:()F
+         9: invokevirtual #2616               // Method calculateViewVector:(FF)Lnet/minecraft/world/phys/Vec3;
+        12: areturn
+
+  public net.minecraft.world.phys.Vec3 getHeadLookAngle();
+    Code:
+         0: aload_0
+         1: aload_0
+         2: invokevirtual #942                // Method getXRot:()F
+         5: aload_0
+         6: invokevirtual #3481               // Method getYHeadRot:()F
+         9: invokevirtual #2616               // Method calculateViewVector:(FF)Lnet/minecraft/world/phys/Vec3;
+        12: areturn
+
+  public net.minecraft.world.phys.Vec3 getHandHoldingItemAngle(net.minecraft.world.item.Item);
+    Code:
+         0: aload_0
+         1: astore_3
+         2: aload_3
+         3: instanceof    #3076               // class net/minecraft/world/entity/player/Player
+         6: ifeq          95
+         9: aload_3
+        10: checkcast     #3076               // class net/minecraft/world/entity/player/Player
+        13: astore_2
+        14: aload_2
+        15: invokevirtual #3488               // Method net/minecraft/world/entity/player/Player.getOffhandItem:()Lnet/minecraft/world/item/ItemStack;
+        18: aload_1
+        19: invokevirtual #3140               // Method net/minecraft/world/item/ItemStack.is:(Ljava/lang/Object;)Z
+        22: ifeq          40
+        25: aload_2
+        26: invokevirtual #3491               // Method net/minecraft/world/entity/player/Player.getMainHandItem:()Lnet/minecraft/world/item/ItemStack;
+        29: aload_1
+        30: invokevirtual #3140               // Method net/minecraft/world/item/ItemStack.is:(Ljava/lang/Object;)Z
+        33: ifne          40
+        36: iconst_1
+        37: goto          41
+        40: iconst_0
+        41: istore_3
+        42: iload_3
+        43: ifeq          56
+        46: aload_2
+        47: invokevirtual #3495               // Method net/minecraft/world/entity/player/Player.getMainArm:()Lnet/minecraft/world/entity/HumanoidArm;
+        50: invokevirtual #3500               // Method net/minecraft/world/entity/HumanoidArm.getOpposite:()Lnet/minecraft/world/entity/HumanoidArm;
+        53: goto          60
+        56: aload_2
+        57: invokevirtual #3495               // Method net/minecraft/world/entity/player/Player.getMainArm:()Lnet/minecraft/world/entity/HumanoidArm;
+        60: astore        4
+        62: aload_0
+        63: fconst_0
+        64: aload_0
+        65: invokevirtual #945                // Method getYRot:()F
+        68: aload         4
+        70: getstatic     #3504               // Field net/minecraft/world/entity/HumanoidArm.RIGHT:Lnet/minecraft/world/entity/HumanoidArm;
+        73: if_acmpne     81
+        76: bipush        80
+        78: goto          83
+        81: bipush        -80
+        83: i2f
+        84: fadd
+        85: invokevirtual #2616               // Method calculateViewVector:(FF)Lnet/minecraft/world/phys/Vec3;
+        88: ldc2_w        #1047               // double 0.5d
+        91: invokevirtual #1278               // Method net/minecraft/world/phys/Vec3.scale:(D)Lnet/minecraft/world/phys/Vec3;
+        94: areturn
+        95: getstatic     #443                // Field net/minecraft/world/phys/Vec3.ZERO:Lnet/minecraft/world/phys/Vec3;
+        98: areturn
+
+  public net.minecraft.world.phys.Vec2 getRotationVector();
+    Code:
+         0: new           #2745               // class net/minecraft/world/phys/Vec2
+         3: dup
+         4: aload_0
+         5: invokevirtual #942                // Method getXRot:()F
+         8: aload_0
+         9: invokevirtual #945                // Method getYRot:()F
+        12: invokespecial #2748               // Method net/minecraft/world/phys/Vec2."<init>":(FF)V
+        15: areturn
+
+  public net.minecraft.world.phys.Vec3 getForward();
+    Code:
+         0: aload_0
+         1: invokevirtual #3513               // Method getRotationVector:()Lnet/minecraft/world/phys/Vec2;
+         4: invokestatic  #3517               // Method net/minecraft/world/phys/Vec3.directionFromRotation:(Lnet/minecraft/world/phys/Vec2;)Lnet/minecraft/world/phys/Vec3;
+         7: areturn
+
+  public void setAsInsidePortal(net.minecraft.world.level.block.Portal, net.minecraft.core.BlockPos);
+    Code:
+         0: aload_0
+         1: invokevirtual #1097               // Method isOnPortalCooldown:()Z
+         4: ifeq          12
+         7: aload_0
+         8: invokevirtual #3522               // Method setPortalCooldown:()V
+        11: return
+        12: aload_0
+        13: getfield      #3524               // Field portalProcess:Lnet/minecraft/world/entity/PortalProcessor;
+        16: ifnull        30
+        19: aload_0
+        20: getfield      #3524               // Field portalProcess:Lnet/minecraft/world/entity/PortalProcessor;
+        23: aload_1
+        24: invokevirtual #3530               // Method net/minecraft/world/entity/PortalProcessor.isSamePortal:(Lnet/minecraft/world/level/block/Portal;)Z
+        27: ifne          49
+        30: aload_0
+        31: new           #3526               // class net/minecraft/world/entity/PortalProcessor
+        34: dup
+        35: aload_1
+        36: aload_2
+        37: invokevirtual #3533               // Method net/minecraft/core/BlockPos.immutable:()Lnet/minecraft/core/BlockPos;
+        40: invokespecial #3535               // Method net/minecraft/world/entity/PortalProcessor."<init>":(Lnet/minecraft/world/level/block/Portal;Lnet/minecraft/core/BlockPos;)V
+        43: putfield      #3524               // Field portalProcess:Lnet/minecraft/world/entity/PortalProcessor;
+        46: goto          78
+        49: aload_0
+        50: getfield      #3524               // Field portalProcess:Lnet/minecraft/world/entity/PortalProcessor;
+        53: invokevirtual #3538               // Method net/minecraft/world/entity/PortalProcessor.isInsidePortalThisTick:()Z
+        56: ifne          78
+        59: aload_0
+        60: getfield      #3524               // Field portalProcess:Lnet/minecraft/world/entity/PortalProcessor;
+        63: aload_2
+        64: invokevirtual #3533               // Method net/minecraft/core/BlockPos.immutable:()Lnet/minecraft/core/BlockPos;
+        67: invokevirtual #3542               // Method net/minecraft/world/entity/PortalProcessor.updateEntryPosition:(Lnet/minecraft/core/BlockPos;)V
+        70: aload_0
+        71: getfield      #3524               // Field portalProcess:Lnet/minecraft/world/entity/PortalProcessor;
+        74: iconst_1
+        75: invokevirtual #3545               // Method net/minecraft/world/entity/PortalProcessor.setAsInsidePortalThisTick:(Z)V
+        78: return
+
+  protected void handlePortal();
+    Code:
+         0: aload_0
+         1: invokevirtual #672                // Method level:()Lnet/minecraft/world/level/Level;
+         4: astore_2
+         5: aload_2
+         6: instanceof    #1016               // class net/minecraft/server/level/ServerLevel
+         9: ifeq          20
+        12: aload_2
+        13: checkcast     #1016               // class net/minecraft/server/level/ServerLevel
+        16: astore_1
+        17: goto          21
+        20: return
+        21: aload_0
+        22: invokevirtual #3548               // Method processPortalCooldown:()V
+        25: aload_0
+        26: getfield      #3524               // Field portalProcess:Lnet/minecraft/world/entity/PortalProcessor;
+        29: ifnonnull     33
+        32: return
+        33: aload_0
+        34: getfield      #3524               // Field portalProcess:Lnet/minecraft/world/entity/PortalProcessor;
+        37: aload_1
+        38: aload_0
+        39: aload_0
+        40: iconst_0
+        41: invokevirtual #3552               // Method canUsePortal:(Z)Z
+        44: invokevirtual #3556               // Method net/minecraft/world/entity/PortalProcessor.processPortalTeleportation:(Lnet/minecraft/server/level/ServerLevel;Lnet/minecraft/world/entity/Entity;Z)Z
+        47: ifeq          133
+        50: invokestatic  #973                // Method net/minecraft/util/profiling/Profiler.get:()Lnet/minecraft/util/profiling/ProfilerFiller;
+        53: astore_2
+        54: aload_2
+        55: ldc_w         #3557               // String portal
+        58: invokeinterface #980,  2          // InterfaceMethod net/minecraft/util/profiling/ProfilerFiller.push:(Ljava/lang/String;)V
+        63: aload_0
+        64: invokevirtual #3522               // Method setPortalCooldown:()V
+        67: aload_0
+        68: getfield      #3524               // Field portalProcess:Lnet/minecraft/world/entity/PortalProcessor;
+        71: aload_1
+        72: aload_0
+        73: invokevirtual #3561               // Method net/minecraft/world/entity/PortalProcessor.getPortalDestination:(Lnet/minecraft/server/level/ServerLevel;Lnet/minecraft/world/entity/Entity;)Lnet/minecraft/world/level/portal/TeleportTransition;
+        76: astore_3
+        77: aload_3
+        78: ifnull        124
+        81: aload_3
+        82: invokevirtual #3565               // Method net/minecraft/world/level/portal/TeleportTransition.newLevel:()Lnet/minecraft/server/level/ServerLevel;
+        85: astore        4
+        87: aload_1
+        88: aload         4
+        90: invokevirtual #3569               // Method net/minecraft/server/level/ServerLevel.isAllowedToEnterPortal:(Lnet/minecraft/world/level/Level;)Z
+        93: ifeq          124
+        96: aload         4
+        98: invokevirtual #3573               // Method net/minecraft/server/level/ServerLevel.dimension:()Lnet/minecraft/resources/ResourceKey;
+       101: aload_1
+       102: invokevirtual #3573               // Method net/minecraft/server/level/ServerLevel.dimension:()Lnet/minecraft/resources/ResourceKey;
+       105: if_acmpeq     118
+       108: aload_0
+       109: aload_1
+       110: aload         4
+       112: invokevirtual #3577               // Method canTeleport:(Lnet/minecraft/world/level/Level;Lnet/minecraft/world/level/Level;)Z
+       115: ifeq          124
+       118: aload_0
+       119: aload_3
+       120: invokevirtual #3581               // Method teleport:(Lnet/minecraft/world/level/portal/TeleportTransition;)Lnet/minecraft/world/entity/Entity;
+       123: pop
+       124: aload_2
+       125: invokeinterface #1066,  1         // InterfaceMethod net/minecraft/util/profiling/ProfilerFiller.pop:()V
+       130: goto          148
+       133: aload_0
+       134: getfield      #3524               // Field portalProcess:Lnet/minecraft/world/entity/PortalProcessor;
+       137: invokevirtual #3584               // Method net/minecraft/world/entity/PortalProcessor.hasExpired:()Z
+       140: ifeq          148
+       143: aload_0
+       144: aconst_null
+       145: putfield      #3524               // Field portalProcess:Lnet/minecraft/world/entity/PortalProcessor;
+       148: return
+
+  public int getDimensionChangingDelay();
+    Code:
+         0: aload_0
+         1: invokevirtual #3395               // Method getFirstPassenger:()Lnet/minecraft/world/entity/Entity;
+         4: astore_1
+         5: aload_1
+         6: instanceof    #2680               // class net/minecraft/server/level/ServerPlayer
+         9: ifeq          19
+        12: aload_1
+        13: invokevirtual #1090               // Method getDimensionChangingDelay:()I
+        16: goto          22
+        19: sipush        300
+        22: ireturn
+
+  public void lerpMotion(net.minecraft.world.phys.Vec3);
+    Code:
+         0: aload_0
+         1: aload_1
+         2: invokevirtual #1259               // Method setDeltaMovement:(Lnet/minecraft/world/phys/Vec3;)V
+         5: return
+
+  public void handleDamageEvent(net.minecraft.world.damagesource.DamageSource);
+    Code:
+         0: return
+
+  public void handleEntityEvent(byte);
+    Code:
+         0: iload_1
+         1: lookupswitch  { // 1
+                      53: 20
+                 default: 24
+            }
+        20: aload_0
+        21: invokestatic  #3597               // Method net/minecraft/world/level/block/HoneyBlock.showSlideParticles:(Lnet/minecraft/world/entity/Entity;)V
+        24: return
+
+  public void animateHurt(float);
+    Code:
+         0: return
+
+  public boolean isOnFire();
+    Code:
+         0: aload_0
+         1: invokevirtual #672                // Method level:()Lnet/minecraft/world/level/Level;
+         4: ifnull        21
+         7: aload_0
+         8: invokevirtual #672                // Method level:()Lnet/minecraft/world/level/Level;
+        11: invokevirtual #1054               // Method net/minecraft/world/level/Level.isClientSide:()Z
+        14: ifeq          21
+        17: iconst_1
+        18: goto          22
+        21: iconst_0
+        22: istore_1
+        23: aload_0
+        24: invokevirtual #1021               // Method fireImmune:()Z
+        27: ifne          53
+        30: aload_0
+        31: getfield      #1018               // Field remainingFireTicks:I
+        34: ifgt          49
+        37: iload_1
+        38: ifeq          53
+        41: aload_0
+        42: iconst_0
+        43: invokevirtual #3604               // Method getSharedFlag:(I)Z
+        46: ifeq          53
+        49: iconst_1
+        50: goto          54
+        53: iconst_0
+        54: ireturn
+
+  public boolean isPassenger();
+    Code:
+         0: aload_0
+         1: invokevirtual #987                // Method getVehicle:()Lnet/minecraft/world/entity/Entity;
+         4: ifnull        11
+         7: iconst_1
+         8: goto          12
+        11: iconst_0
+        12: ireturn
+
+  public boolean isVehicle();
+    Code:
+         0: aload_0
+         1: getfield      #438                // Field passengers:Lcom/google/common/collect/ImmutableList;
+         4: invokevirtual #3383               // Method com/google/common/collect/ImmutableList.isEmpty:()Z
+         7: ifne          14
+        10: iconst_1
+        11: goto          15
+        14: iconst_0
+        15: ireturn
+
+  public boolean dismountsUnderwater();
+    Code:
+         0: aload_0
+         1: getstatic     #3608               // Field net/minecraft/tags/EntityTypeTags.DISMOUNTS_UNDERWATER:Lnet/minecraft/tags/TagKey;
+         4: invokevirtual #2298               // Method is:(Lnet/minecraft/tags/TagKey;)Z
+         7: ireturn
+
+  public boolean canControlVehicle();
+    Code:
+         0: aload_0
+         1: getstatic     #3612               // Field net/minecraft/tags/EntityTypeTags.NON_CONTROLLING_RIDER:Lnet/minecraft/tags/TagKey;
+         4: invokevirtual #2298               // Method is:(Lnet/minecraft/tags/TagKey;)Z
+         7: ifne          14
+        10: iconst_1
+        11: goto          15
+        14: iconst_0
+        15: ireturn
+
+  public void setShiftKeyDown(boolean);
+    Code:
+         0: aload_0
+         1: iconst_1
+         2: iload_1
+         3: invokevirtual #1080               // Method setSharedFlag:(IZ)V
+         6: return
+
+  public boolean isShiftKeyDown();
+    Code:
+         0: aload_0
+         1: iconst_1
+         2: invokevirtual #3604               // Method getSharedFlag:(I)Z
+         5: ireturn
+
+  public boolean isSteppingCarefully();
+    Code:
+         0: aload_0
+         1: invokevirtual #3359               // Method isShiftKeyDown:()Z
+         4: ireturn
+
+  public boolean isSuppressingBounce();
+    Code:
+         0: aload_0
+         1: invokevirtual #3359               // Method isShiftKeyDown:()Z
+         4: ireturn
+
+  public boolean isDiscrete();
+    Code:
+         0: aload_0
+         1: invokevirtual #3359               // Method isShiftKeyDown:()Z
+         4: ireturn
+
+  public boolean isDescending();
+    Code:
+         0: aload_0
+         1: invokevirtual #3359               // Method isShiftKeyDown:()Z
+         4: ireturn
+
+  public boolean isCrouching();
+    Code:
+         0: aload_0
+         1: getstatic     #3620               // Field net/minecraft/world/entity/Pose.CROUCHING:Lnet/minecraft/world/entity/Pose;
+         4: invokevirtual #3622               // Method hasPose:(Lnet/minecraft/world/entity/Pose;)Z
+         7: ireturn
+
+  public boolean isSprinting();
+    Code:
+         0: aload_0
+         1: iconst_3
+         2: invokevirtual #3604               // Method getSharedFlag:(I)Z
+         5: ireturn
+
+  public void setSprinting(boolean);
+    Code:
+         0: aload_0
+         1: iconst_3
+         2: iload_1
+         3: invokevirtual #1080               // Method setSharedFlag:(IZ)V
+         6: return
+
+  public boolean isSwimming();
+    Code:
+         0: aload_0
+         1: iconst_4
+         2: invokevirtual #3604               // Method getSharedFlag:(I)Z
+         5: ireturn
+
+  public boolean isVisuallySwimming();
+    Code:
+         0: aload_0
+         1: getstatic     #3627               // Field net/minecraft/world/entity/Pose.SWIMMING:Lnet/minecraft/world/entity/Pose;
+         4: invokevirtual #3622               // Method hasPose:(Lnet/minecraft/world/entity/Pose;)Z
+         7: ireturn
+
+  public boolean isVisuallyCrawling();
+    Code:
+         0: aload_0
+         1: invokevirtual #3630               // Method isVisuallySwimming:()Z
+         4: ifeq          18
+         7: aload_0
+         8: invokevirtual #1496               // Method isInWater:()Z
+        11: ifne          18
+        14: iconst_1
+        15: goto          19
+        18: iconst_0
+        19: ireturn
+
+  public void setSwimming(boolean);
+    Code:
+         0: aload_0
+         1: iconst_4
+         2: iload_1
+         3: invokevirtual #1080               // Method setSharedFlag:(IZ)V
+         6: return
+
+  public final boolean hasGlowingTag();
+    Code:
+         0: aload_0
+         1: getfield      #2793               // Field hasGlowingTag:Z
+         4: ireturn
+
+  public final void setGlowingTag(boolean);
+    Code:
+         0: aload_0
+         1: iload_1
+         2: putfield      #2793               // Field hasGlowingTag:Z
+         5: aload_0
+         6: bipush        6
+         8: aload_0
+         9: invokevirtual #3634               // Method isCurrentlyGlowing:()Z
+        12: invokevirtual #1080               // Method setSharedFlag:(IZ)V
+        15: return
+
+  public boolean isCurrentlyGlowing();
+    Code:
+         0: aload_0
+         1: invokevirtual #672                // Method level:()Lnet/minecraft/world/level/Level;
+         4: invokevirtual #1054               // Method net/minecraft/world/level/Level.isClientSide:()Z
+         7: ifeq          17
+        10: aload_0
+        11: bipush        6
+        13: invokevirtual #3604               // Method getSharedFlag:(I)Z
+        16: ireturn
+        17: aload_0
+        18: getfield      #2793               // Field hasGlowingTag:Z
+        21: ireturn
+
+  public boolean isInvisible();
+    Code:
+         0: aload_0
+         1: iconst_5
+         2: invokevirtual #3604               // Method getSharedFlag:(I)Z
+         5: ireturn
+
+  public boolean isInvisibleTo(net.minecraft.world.entity.player.Player);
+    Code:
+         0: aload_1
+         1: invokevirtual #3637               // Method net/minecraft/world/entity/player/Player.isSpectator:()Z
+         4: ifeq          9
+         7: iconst_0
+         8: ireturn
+         9: aload_0
+        10: invokevirtual #715                // Method getTeam:()Lnet/minecraft/world/scores/PlayerTeam;
+        13: astore_2
+        14: aload_2
+        15: ifnull        39
+        18: aload_1
+        19: ifnull        39
+        22: aload_1
+        23: invokevirtual #3638               // Method net/minecraft/world/entity/player/Player.getTeam:()Lnet/minecraft/world/scores/PlayerTeam;
+        26: aload_2
+        27: if_acmpne     39
+        30: aload_2
+        31: invokevirtual #3641               // Method net/minecraft/world/scores/Team.canSeeFriendlyInvisibles:()Z
+        34: ifeq          39
+        37: iconst_0
+        38: ireturn
+        39: aload_0
+        40: invokevirtual #3643               // Method isInvisible:()Z
+        43: ireturn
+
+  public boolean isOnRails();
+    Code:
+         0: iconst_0
+         1: ireturn
+
+  public void updateDynamicGameEventListener(java.util.function.BiConsumer<net.minecraft.world.level.gameevent.DynamicGameEventListener<?>, net.minecraft.server.level.ServerLevel>);
+    Code:
+         0: return
+
+  public net.minecraft.world.scores.PlayerTeam getTeam();
+    Code:
+         0: aload_0
+         1: invokevirtual #672                // Method level:()Lnet/minecraft/world/level/Level;
+         4: invokevirtual #3653               // Method net/minecraft/world/level/Level.getScoreboard:()Lnet/minecraft/world/scores/Scoreboard;
+         7: aload_0
+         8: invokevirtual #3656               // Method getScoreboardName:()Ljava/lang/String;
+        11: invokevirtual #3662               // Method net/minecraft/world/scores/Scoreboard.getPlayersTeam:(Ljava/lang/String;)Lnet/minecraft/world/scores/PlayerTeam;
+        14: areturn
+
+  public final boolean isAlliedTo(net.minecraft.world.entity.Entity);
+    Code:
+         0: aload_1
+         1: ifnonnull     6
+         4: iconst_0
+         5: ireturn
+         6: aload_0
+         7: aload_1
+         8: if_acmpeq     27
+        11: aload_0
+        12: aload_1
+        13: invokevirtual #3666               // Method considersEntityAsAlly:(Lnet/minecraft/world/entity/Entity;)Z
+        16: ifne          27
+        19: aload_1
+        20: aload_0
+        21: invokevirtual #3666               // Method considersEntityAsAlly:(Lnet/minecraft/world/entity/Entity;)Z
+        24: ifeq          31
+        27: iconst_1
+        28: goto          32
+        31: iconst_0
+        32: ireturn
+
+  protected boolean considersEntityAsAlly(net.minecraft.world.entity.Entity);
+    Code:
+         0: aload_0
+         1: aload_1
+         2: invokevirtual #715                // Method getTeam:()Lnet/minecraft/world/scores/PlayerTeam;
+         5: invokevirtual #3669               // Method isAlliedTo:(Lnet/minecraft/world/scores/Team;)Z
+         8: ireturn
+
+  public boolean isAlliedTo(net.minecraft.world.scores.Team);
+    Code:
+         0: aload_0
+         1: invokevirtual #715                // Method getTeam:()Lnet/minecraft/world/scores/PlayerTeam;
+         4: ifnull        16
+         7: aload_0
+         8: invokevirtual #715                // Method getTeam:()Lnet/minecraft/world/scores/PlayerTeam;
+        11: aload_1
+        12: invokevirtual #3672               // Method net/minecraft/world/scores/PlayerTeam.isAlliedTo:(Lnet/minecraft/world/scores/Team;)Z
+        15: ireturn
+        16: iconst_0
+        17: ireturn
+
+  public void setInvisible(boolean);
+    Code:
+         0: aload_0
+         1: iconst_5
+         2: iload_1
+         3: invokevirtual #1080               // Method setSharedFlag:(IZ)V
+         6: return
+
+  protected boolean getSharedFlag(int);
+    Code:
+         0: aload_0
+         1: getfield      #651                // Field entityData:Lnet/minecraft/network/syncher/SynchedEntityData;
+         4: getstatic     #598                // Field DATA_SHARED_FLAGS_ID:Lnet/minecraft/network/syncher/EntityDataAccessor;
+         7: invokevirtual #859                // Method net/minecraft/network/syncher/SynchedEntityData.get:(Lnet/minecraft/network/syncher/EntityDataAccessor;)Ljava/lang/Object;
+        10: checkcast     #600                // class java/lang/Byte
+        13: invokevirtual #3680               // Method java/lang/Byte.byteValue:()B
+        16: iconst_1
+        17: iload_1
+        18: ishl
+        19: iand
+        20: ifeq          27
+        23: iconst_1
+        24: goto          28
+        27: iconst_0
+        28: ireturn
+
+  protected void setSharedFlag(int, boolean);
+    Code:
+         0: aload_0
+         1: getfield      #651                // Field entityData:Lnet/minecraft/network/syncher/SynchedEntityData;
+         4: getstatic     #598                // Field DATA_SHARED_FLAGS_ID:Lnet/minecraft/network/syncher/EntityDataAccessor;
+         7: invokevirtual #859                // Method net/minecraft/network/syncher/SynchedEntityData.get:(Lnet/minecraft/network/syncher/EntityDataAccessor;)Ljava/lang/Object;
+        10: checkcast     #600                // class java/lang/Byte
+        13: invokevirtual #3680               // Method java/lang/Byte.byteValue:()B
+        16: istore_3
+        17: iload_2
+        18: ifeq          43
+        21: aload_0
+        22: getfield      #651                // Field entityData:Lnet/minecraft/network/syncher/SynchedEntityData;
+        25: getstatic     #598                // Field DATA_SHARED_FLAGS_ID:Lnet/minecraft/network/syncher/EntityDataAccessor;
+        28: iload_3
+        29: iconst_1
+        30: iload_1
+        31: ishl
+        32: ior
+        33: i2b
+        34: invokestatic  #604                // Method java/lang/Byte.valueOf:(B)Ljava/lang/Byte;
+        37: invokevirtual #854                // Method net/minecraft/network/syncher/SynchedEntityData.set:(Lnet/minecraft/network/syncher/EntityDataAccessor;Ljava/lang/Object;)V
+        40: goto          64
+        43: aload_0
+        44: getfield      #651                // Field entityData:Lnet/minecraft/network/syncher/SynchedEntityData;
+        47: getstatic     #598                // Field DATA_SHARED_FLAGS_ID:Lnet/minecraft/network/syncher/EntityDataAccessor;
+        50: iload_3
+        51: iconst_1
+        52: iload_1
+        53: ishl
+        54: iconst_m1
+        55: ixor
+        56: iand
+        57: i2b
+        58: invokestatic  #604                // Method java/lang/Byte.valueOf:(B)Ljava/lang/Byte;
+        61: invokevirtual #854                // Method net/minecraft/network/syncher/SynchedEntityData.set:(Lnet/minecraft/network/syncher/EntityDataAccessor;Ljava/lang/Object;)V
+        64: return
+
+  public int getMaxAirSupply();
+    Code:
+         0: sipush        300
+         3: ireturn
+
+  public int getAirSupply();
+    Code:
+         0: aload_0
+         1: getfield      #651                // Field entityData:Lnet/minecraft/network/syncher/SynchedEntityData;
+         4: getstatic     #610                // Field DATA_AIR_SUPPLY_ID:Lnet/minecraft/network/syncher/EntityDataAccessor;
+         7: invokevirtual #859                // Method net/minecraft/network/syncher/SynchedEntityData.get:(Lnet/minecraft/network/syncher/EntityDataAccessor;)Ljava/lang/Object;
+        10: checkcast     #615                // class java/lang/Integer
+        13: invokevirtual #2344               // Method java/lang/Integer.intValue:()I
+        16: ireturn
+
+  public void setAirSupply(int);
+    Code:
+         0: aload_0
+         1: getfield      #651                // Field entityData:Lnet/minecraft/network/syncher/SynchedEntityData;
+         4: getstatic     #610                // Field DATA_AIR_SUPPLY_ID:Lnet/minecraft/network/syncher/EntityDataAccessor;
+         7: iload_1
+         8: invokestatic  #618                // Method java/lang/Integer.valueOf:(I)Ljava/lang/Integer;
+        11: invokevirtual #854                // Method net/minecraft/network/syncher/SynchedEntityData.set:(Lnet/minecraft/network/syncher/EntityDataAccessor;Ljava/lang/Object;)V
+        14: return
+
+  public void clearFreeze();
+    Code:
+         0: aload_0
+         1: iconst_0
+         2: invokevirtual #2951               // Method setTicksFrozen:(I)V
+         5: return
+
+  public int getTicksFrozen();
+    Code:
+         0: aload_0
+         1: getfield      #651                // Field entityData:Lnet/minecraft/network/syncher/SynchedEntityData;
+         4: getstatic     #641                // Field DATA_TICKS_FROZEN:Lnet/minecraft/network/syncher/EntityDataAccessor;
+         7: invokevirtual #859                // Method net/minecraft/network/syncher/SynchedEntityData.get:(Lnet/minecraft/network/syncher/EntityDataAccessor;)Ljava/lang/Object;
+        10: checkcast     #615                // class java/lang/Integer
+        13: invokevirtual #2344               // Method java/lang/Integer.intValue:()I
+        16: ireturn
+
+  public void setTicksFrozen(int);
+    Code:
+         0: aload_0
+         1: getfield      #651                // Field entityData:Lnet/minecraft/network/syncher/SynchedEntityData;
+         4: getstatic     #641                // Field DATA_TICKS_FROZEN:Lnet/minecraft/network/syncher/EntityDataAccessor;
+         7: iload_1
+         8: invokestatic  #618                // Method java/lang/Integer.valueOf:(I)Ljava/lang/Integer;
+        11: invokevirtual #854                // Method net/minecraft/network/syncher/SynchedEntityData.set:(Lnet/minecraft/network/syncher/EntityDataAccessor;Ljava/lang/Object;)V
+        14: return
+
+  public float getPercentFrozen();
+    Code:
+         0: aload_0
+         1: invokevirtual #3687               // Method getTicksRequiredToFreeze:()I
+         4: istore_1
+         5: aload_0
+         6: invokevirtual #2796               // Method getTicksFrozen:()I
+         9: iload_1
+        10: invokestatic  #1154               // Method java/lang/Math.min:(II)I
+        13: i2f
+        14: iload_1
+        15: i2f
+        16: fdiv
+        17: freturn
+
+  public boolean isFullyFrozen();
+    Code:
+         0: aload_0
+         1: invokevirtual #2796               // Method getTicksFrozen:()I
+         4: aload_0
+         5: invokevirtual #3687               // Method getTicksRequiredToFreeze:()I
+         8: if_icmplt     15
+        11: iconst_1
+        12: goto          16
+        15: iconst_0
+        16: ireturn
+
+  public int getTicksRequiredToFreeze();
+    Code:
+         0: sipush        140
+         3: ireturn
+
+  public void thunderHit(net.minecraft.server.level.ServerLevel, net.minecraft.world.entity.LightningBolt);
+    Code:
+         0: aload_0
+         1: aload_0
+         2: getfield      #1018               // Field remainingFireTicks:I
+         5: iconst_1
+         6: iadd
+         7: invokevirtual #1044               // Method setRemainingFireTicks:(I)V
+        10: aload_0
+        11: getfield      #1018               // Field remainingFireTicks:I
+        14: ifne          24
+        17: aload_0
+        18: ldc_w         #3693               // float 8.0f
+        21: invokevirtual #1102               // Method igniteForSeconds:(F)V
+        24: aload_0
+        25: aload_1
+        26: aload_0
+        27: invokevirtual #1031               // Method damageSources:()Lnet/minecraft/world/damagesource/DamageSources;
+        30: invokevirtual #3695               // Method net/minecraft/world/damagesource/DamageSources.lightningBolt:()Lnet/minecraft/world/damagesource/DamageSource;
+        33: ldc_w         #3696               // float 5.0f
+        36: invokevirtual #1041               // Method hurtServer:(Lnet/minecraft/server/level/ServerLevel;Lnet/minecraft/world/damagesource/DamageSource;F)Z
+        39: pop
+        40: return
+
+  public void onAboveBubbleColumn(boolean, net.minecraft.core.BlockPos);
+    Code:
+         0: aload_0
+         1: iload_1
+         2: aload_2
+         3: invokestatic  #3704               // Method handleOnAboveBubbleColumn:(Lnet/minecraft/world/entity/Entity;ZLnet/minecraft/core/BlockPos;)V
+         6: return
+
+  protected static void handleOnAboveBubbleColumn(net.minecraft.world.entity.Entity, boolean, net.minecraft.core.BlockPos);
+    Code:
+         0: aload_0
+         1: invokevirtual #1369               // Method getDeltaMovement:()Lnet/minecraft/world/phys/Vec3;
+         4: astore_3
+         5: iload_1
+         6: ifeq          28
+         9: ldc2_w        #3705               // double -0.9d
+        12: aload_3
+        13: getfield      #934                // Field net/minecraft/world/phys/Vec3.y:D
+        16: ldc2_w        #3707               // double 0.03d
+        19: dsub
+        20: invokestatic  #1424               // Method java/lang/Math.max:(DD)D
+        23: dstore        4
+        25: goto          44
+        28: ldc2_w        #3709               // double 1.8d
+        31: aload_3
+        32: getfield      #934                // Field net/minecraft/world/phys/Vec3.y:D
+        35: ldc2_w        #2455               // double 0.1d
+        38: dadd
+        39: invokestatic  #1271               // Method java/lang/Math.min:(DD)D
+        42: dstore        4
+        44: aload_0
+        45: aload_3
+        46: getfield      #932                // Field net/minecraft/world/phys/Vec3.x:D
+        49: dload         4
+        51: aload_3
+        52: getfield      #936                // Field net/minecraft/world/phys/Vec3.z:D
+        55: invokevirtual #2874               // Method setDeltaMovement:(DDD)V
+        58: aload_0
+        59: getfield      #567                // Field level:Lnet/minecraft/world/level/Level;
+        62: aload_2
+        63: invokestatic  #3714               // Method sendBubbleColumnParticles:(Lnet/minecraft/world/level/Level;Lnet/minecraft/core/BlockPos;)V
+        66: return
+
+  protected static void sendBubbleColumnParticles(net.minecraft.world.level.Level, net.minecraft.core.BlockPos);
+    Code:
+         0: aload_0
+         1: instanceof    #1016               // class net/minecraft/server/level/ServerLevel
+         4: ifeq          124
+         7: aload_0
+         8: checkcast     #1016               // class net/minecraft/server/level/ServerLevel
+        11: astore_2
+        12: aload_0
+        13: invokevirtual #3717               // Method net/minecraft/world/level/Level.getRandom:()Lnet/minecraft/util/RandomSource;
+        16: astore_3
+        17: iconst_0
+        18: istore        4
+        20: iload         4
+        22: iconst_2
+        23: if_icmpge     124
+        26: aload_2
+        27: getstatic     #2428               // Field net/minecraft/core/particles/ParticleTypes.SPLASH:Lnet/minecraft/core/particles/SimpleParticleType;
+        30: aload_1
+        31: invokevirtual #2099               // Method net/minecraft/core/BlockPos.getX:()I
+        34: i2d
+        35: aload_3
+        36: invokeinterface #2413,  1         // InterfaceMethod net/minecraft/util/RandomSource.nextDouble:()D
+        41: dadd
+        42: aload_1
+        43: invokevirtual #3719               // Method net/minecraft/core/BlockPos.getY:()I
+        46: iconst_1
+        47: iadd
+        48: i2d
+        49: aload_1
+        50: invokevirtual #2101               // Method net/minecraft/core/BlockPos.getZ:()I
+        53: i2d
+        54: aload_3
+        55: invokeinterface #2413,  1         // InterfaceMethod net/minecraft/util/RandomSource.nextDouble:()D
+        60: dadd
+        61: iconst_1
+        62: dconst_0
+        63: dconst_0
+        64: dconst_0
+        65: dconst_1
+        66: invokevirtual #3723               // Method net/minecraft/server/level/ServerLevel.sendParticles:(Lnet/minecraft/core/particles/ParticleOptions;DDDIDDDD)I
+        69: pop
+        70: aload_2
+        71: getstatic     #2421               // Field net/minecraft/core/particles/ParticleTypes.BUBBLE:Lnet/minecraft/core/particles/SimpleParticleType;
+        74: aload_1
+        75: invokevirtual #2099               // Method net/minecraft/core/BlockPos.getX:()I
+        78: i2d
+        79: aload_3
+        80: invokeinterface #2413,  1         // InterfaceMethod net/minecraft/util/RandomSource.nextDouble:()D
+        85: dadd
+        86: aload_1
+        87: invokevirtual #3719               // Method net/minecraft/core/BlockPos.getY:()I
+        90: iconst_1
+        91: iadd
+        92: i2d
+        93: aload_1
+        94: invokevirtual #2101               // Method net/minecraft/core/BlockPos.getZ:()I
+        97: i2d
+        98: aload_3
+        99: invokeinterface #2413,  1         // InterfaceMethod net/minecraft/util/RandomSource.nextDouble:()D
+       104: dadd
+       105: iconst_1
+       106: dconst_0
+       107: ldc2_w        #3724               // double 0.01d
+       110: dconst_0
+       111: ldc2_w        #3726               // double 0.2d
+       114: invokevirtual #3723               // Method net/minecraft/server/level/ServerLevel.sendParticles:(Lnet/minecraft/core/particles/ParticleOptions;DDDIDDDD)I
+       117: pop
+       118: iinc          4, 1
+       121: goto          20
+       124: return
+
+  public void onInsideBubbleColumn(boolean);
+    Code:
+         0: aload_0
+         1: iload_1
+         2: invokestatic  #3731               // Method handleOnInsideBubbleColumn:(Lnet/minecraft/world/entity/Entity;Z)V
+         5: return
+
+  protected static void handleOnInsideBubbleColumn(net.minecraft.world.entity.Entity, boolean);
+    Code:
+         0: aload_0
+         1: invokevirtual #1369               // Method getDeltaMovement:()Lnet/minecraft/world/phys/Vec3;
+         4: astore_2
+         5: iload_1
+         6: ifeq          27
+         9: ldc2_w        #3732               // double -0.3d
+        12: aload_2
+        13: getfield      #934                // Field net/minecraft/world/phys/Vec3.y:D
+        16: ldc2_w        #3707               // double 0.03d
+        19: dsub
+        20: invokestatic  #1424               // Method java/lang/Math.max:(DD)D
+        23: dstore_3
+        24: goto          42
+        27: ldc2_w        #3734               // double 0.7d
+        30: aload_2
+        31: getfield      #934                // Field net/minecraft/world/phys/Vec3.y:D
+        34: ldc2_w        #3736               // double 0.06d
+        37: dadd
+        38: invokestatic  #1271               // Method java/lang/Math.min:(DD)D
+        41: dstore_3
+        42: aload_0
+        43: aload_2
+        44: getfield      #932                // Field net/minecraft/world/phys/Vec3.x:D
+        47: dload_3
+        48: aload_2
+        49: getfield      #936                // Field net/minecraft/world/phys/Vec3.z:D
+        52: invokevirtual #2874               // Method setDeltaMovement:(DDD)V
+        55: aload_0
+        56: invokevirtual #1306               // Method resetFallDistance:()V
+        59: return
+
+  public boolean killedEntity(net.minecraft.server.level.ServerLevel, net.minecraft.world.entity.LivingEntity, net.minecraft.world.damagesource.DamageSource);
+    Code:
+         0: iconst_1
+         1: ireturn
+
+  public void checkFallDistanceAccumulation();
+    Code:
+         0: aload_0
+         1: invokevirtual #1369               // Method getDeltaMovement:()Lnet/minecraft/world/phys/Vec3;
+         4: invokevirtual #911                // Method net/minecraft/world/phys/Vec3.y:()D
+         7: ldc2_w        #3741               // double -0.5d
+        10: dcmpl
+        11: ifle          28
+        14: aload_0
+        15: getfield      #1046               // Field fallDistance:D
+        18: dconst_1
+        19: dcmpl
+        20: ifle          28
+        23: aload_0
+        24: dconst_1
+        25: putfield      #1046               // Field fallDistance:D
+        28: return
+
+  public void resetFallDistance();
+    Code:
+         0: aload_0
+         1: dconst_0
+         2: putfield      #1046               // Field fallDistance:D
+         5: return
+
+  protected void moveTowardsClosestSpace(double, double, double);
+    Code:
+         0: dload_1
+         1: dload_3
+         2: dload         5
+         4: invokestatic  #2111               // Method net/minecraft/core/BlockPos.containing:(DDD)Lnet/minecraft/core/BlockPos;
+         7: astore        7
+         9: new           #440                // class net/minecraft/world/phys/Vec3
+        12: dup
+        13: dload_1
+        14: aload         7
+        16: invokevirtual #2099               // Method net/minecraft/core/BlockPos.getX:()I
+        19: i2d
+        20: dsub
+        21: dload_3
+        22: aload         7
+        24: invokevirtual #3719               // Method net/minecraft/core/BlockPos.getY:()I
+        27: i2d
+        28: dsub
+        29: dload         5
+        31: aload         7
+        33: invokevirtual #2101               // Method net/minecraft/core/BlockPos.getZ:()I
+        36: i2d
+        37: dsub
+        38: invokespecial #765                // Method net/minecraft/world/phys/Vec3."<init>":(DDD)V
+        41: astore        8
+        43: new           #120                // class net/minecraft/core/BlockPos$MutableBlockPos
+        46: dup
+        47: invokespecial #3744               // Method net/minecraft/core/BlockPos$MutableBlockPos."<init>":()V
+        50: astore        9
+        52: getstatic     #3748               // Field net/minecraft/core/Direction.UP:Lnet/minecraft/core/Direction;
+        55: astore        10
+        57: ldc2_w        #3749               // double 1.7976931348623157E308d
+        60: dstore        11
+        62: iconst_5
+        63: anewarray     #79                 // class net/minecraft/core/Direction
+        66: dup
+        67: iconst_0
+        68: getstatic     #3753               // Field net/minecraft/core/Direction.NORTH:Lnet/minecraft/core/Direction;
+        71: aastore
+        72: dup
+        73: iconst_1
+        74: getstatic     #3756               // Field net/minecraft/core/Direction.SOUTH:Lnet/minecraft/core/Direction;
+        77: aastore
+        78: dup
+        79: iconst_2
+        80: getstatic     #3759               // Field net/minecraft/core/Direction.WEST:Lnet/minecraft/core/Direction;
+        83: aastore
+        84: dup
+        85: iconst_3
+        86: getstatic     #3762               // Field net/minecraft/core/Direction.EAST:Lnet/minecraft/core/Direction;
+        89: aastore
+        90: dup
+        91: iconst_4
+        92: getstatic     #3748               // Field net/minecraft/core/Direction.UP:Lnet/minecraft/core/Direction;
+        95: aastore
+        96: astore        13
+        98: aload         13
+       100: arraylength
+       101: istore        14
+       103: iconst_0
+       104: istore        15
+       106: iload         15
+       108: iload         14
+       110: if_icmpge     207
+       113: aload         13
+       115: iload         15
+       117: aaload
+       118: astore        16
+       120: aload         9
+       122: aload         7
+       124: aload         16
+       126: invokevirtual #3768               // Method net/minecraft/core/BlockPos$MutableBlockPos.setWithOffset:(Lnet/minecraft/core/Vec3i;Lnet/minecraft/core/Direction;)Lnet/minecraft/core/BlockPos$MutableBlockPos;
+       129: pop
+       130: aload_0
+       131: invokevirtual #672                // Method level:()Lnet/minecraft/world/level/Level;
+       134: aload         9
+       136: invokevirtual #1339               // Method net/minecraft/world/level/Level.getBlockState:(Lnet/minecraft/core/BlockPos;)Lnet/minecraft/world/level/block/state/BlockState;
+       139: aload_0
+       140: invokevirtual #672                // Method level:()Lnet/minecraft/world/level/Level;
+       143: aload         9
+       145: invokevirtual #3772               // Method net/minecraft/world/level/block/state/BlockState.isCollisionShapeFullBlock:(Lnet/minecraft/world/level/BlockGetter;Lnet/minecraft/core/BlockPos;)Z
+       148: ifne          201
+       151: aload         8
+       153: aload         16
+       155: invokevirtual #3776               // Method net/minecraft/core/Direction.getAxis:()Lnet/minecraft/core/Direction$Axis;
+       158: invokevirtual #1926               // Method net/minecraft/world/phys/Vec3.get:(Lnet/minecraft/core/Direction$Axis;)D
+       161: dstore        17
+       163: aload         16
+       165: invokevirtual #3780               // Method net/minecraft/core/Direction.getAxisDirection:()Lnet/minecraft/core/Direction$AxisDirection;
+       168: getstatic     #3784               // Field net/minecraft/core/Direction$AxisDirection.POSITIVE:Lnet/minecraft/core/Direction$AxisDirection;
+       171: if_acmpne     181
+       174: dconst_1
+       175: dload         17
+       177: dsub
+       178: goto          183
+       181: dload         17
+       183: dstore        19
+       185: dload         19
+       187: dload         11
+       189: dcmpg
+       190: ifge          201
+       193: dload         19
+       195: dstore        11
+       197: aload         16
+       199: astore        10
+       201: iinc          15, 1
+       204: goto          106
+       207: aload_0
+       208: getfield      #461                // Field random:Lnet/minecraft/util/RandomSource;
+       211: invokeinterface #1127,  1         // InterfaceMethod net/minecraft/util/RandomSource.nextFloat:()F
+       216: ldc           #255                // float 0.2f
+       218: fmul
+       219: ldc_w         #2224               // float 0.1f
+       222: fadd
+       223: fstore        13
+       225: aload         10
+       227: invokevirtual #3780               // Method net/minecraft/core/Direction.getAxisDirection:()Lnet/minecraft/core/Direction$AxisDirection;
+       230: invokevirtual #3787               // Method net/minecraft/core/Direction$AxisDirection.getStep:()I
+       233: i2f
+       234: fstore        14
+       236: aload_0
+       237: invokevirtual #1369               // Method getDeltaMovement:()Lnet/minecraft/world/phys/Vec3;
+       240: ldc2_w        #3788               // double 0.75d
+       243: invokevirtual #1278               // Method net/minecraft/world/phys/Vec3.scale:(D)Lnet/minecraft/world/phys/Vec3;
+       246: astore        15
+       248: aload         10
+       250: invokevirtual #3776               // Method net/minecraft/core/Direction.getAxis:()Lnet/minecraft/core/Direction$Axis;
+       253: getstatic     #1396               // Field net/minecraft/core/Direction$Axis.X:Lnet/minecraft/core/Direction$Axis;
+       256: if_acmpne     282
+       259: aload_0
+       260: fload         14
+       262: fload         13
+       264: fmul
+       265: f2d
+       266: aload         15
+       268: getfield      #934                // Field net/minecraft/world/phys/Vec3.y:D
+       271: aload         15
+       273: getfield      #936                // Field net/minecraft/world/phys/Vec3.z:D
+       276: invokevirtual #2874               // Method setDeltaMovement:(DDD)V
+       279: goto          347
+       282: aload         10
+       284: invokevirtual #3776               // Method net/minecraft/core/Direction.getAxis:()Lnet/minecraft/core/Direction$Axis;
+       287: getstatic     #1434               // Field net/minecraft/core/Direction$Axis.Y:Lnet/minecraft/core/Direction$Axis;
+       290: if_acmpne     316
+       293: aload_0
+       294: aload         15
+       296: getfield      #932                // Field net/minecraft/world/phys/Vec3.x:D
+       299: fload         14
+       301: fload         13
+       303: fmul
+       304: f2d
+       305: aload         15
+       307: getfield      #936                // Field net/minecraft/world/phys/Vec3.z:D
+       310: invokevirtual #2874               // Method setDeltaMovement:(DDD)V
+       313: goto          347
+       316: aload         10
+       318: invokevirtual #3776               // Method net/minecraft/core/Direction.getAxis:()Lnet/minecraft/core/Direction$Axis;
+       321: getstatic     #1402               // Field net/minecraft/core/Direction$Axis.Z:Lnet/minecraft/core/Direction$Axis;
+       324: if_acmpne     347
+       327: aload_0
+       328: aload         15
+       330: getfield      #932                // Field net/minecraft/world/phys/Vec3.x:D
+       333: aload         15
+       335: getfield      #934                // Field net/minecraft/world/phys/Vec3.y:D
+       338: fload         14
+       340: fload         13
+       342: fmul
+       343: f2d
+       344: invokevirtual #2874               // Method setDeltaMovement:(DDD)V
+       347: return
+
+  public void makeStuckInBlock(net.minecraft.world.level.block.state.BlockState, net.minecraft.world.phys.Vec3);
+    Code:
+         0: aload_0
+         1: invokevirtual #1306               // Method resetFallDistance:()V
+         4: aload_0
+         5: aload_2
+         6: putfield      #451                // Field stuckSpeedMultiplier:Lnet/minecraft/world/phys/Vec3;
+         9: return
+
+  private static net.minecraft.network.chat.Component removeAction(net.minecraft.network.chat.Component);
+    Code:
+         0: aload_0
+         1: invokeinterface #3807,  1         // InterfaceMethod net/minecraft/network/chat/Component.plainCopy:()Lnet/minecraft/network/chat/MutableComponent;
+         6: aload_0
+         7: invokeinterface #3811,  1         // InterfaceMethod net/minecraft/network/chat/Component.getStyle:()Lnet/minecraft/network/chat/Style;
+        12: aconst_null
+        13: invokevirtual #3817               // Method net/minecraft/network/chat/Style.withClickEvent:(Lnet/minecraft/network/chat/ClickEvent;)Lnet/minecraft/network/chat/Style;
+        16: invokevirtual #3823               // Method net/minecraft/network/chat/MutableComponent.setStyle:(Lnet/minecraft/network/chat/Style;)Lnet/minecraft/network/chat/MutableComponent;
+        19: astore_1
+        20: aload_0
+        21: invokeinterface #3826,  1         // InterfaceMethod net/minecraft/network/chat/Component.getSiblings:()Ljava/util/List;
+        26: invokeinterface #1820,  1         // InterfaceMethod java/util/List.iterator:()Ljava/util/Iterator;
+        31: astore_2
+        32: aload_2
+        33: invokeinterface #1827,  1         // InterfaceMethod java/util/Iterator.hasNext:()Z
+        38: ifeq          63
+        41: aload_2
+        42: invokeinterface #1830,  1         // InterfaceMethod java/util/Iterator.next:()Ljava/lang/Object;
+        47: checkcast     #2934               // class net/minecraft/network/chat/Component
+        50: astore_3
+        51: aload_1
+        52: aload_3
+        53: invokestatic  #3828               // Method removeAction:(Lnet/minecraft/network/chat/Component;)Lnet/minecraft/network/chat/Component;
+        56: invokevirtual #3832               // Method net/minecraft/network/chat/MutableComponent.append:(Lnet/minecraft/network/chat/Component;)Lnet/minecraft/network/chat/MutableComponent;
+        59: pop
+        60: goto          32
+        63: aload_1
+        64: areturn
+
+  public net.minecraft.network.chat.Component getName();
+    Code:
+         0: aload_0
+         1: invokevirtual #2783               // Method getCustomName:()Lnet/minecraft/network/chat/Component;
+         4: astore_1
+         5: aload_1
+         6: ifnull        14
+         9: aload_1
+        10: invokestatic  #3828               // Method removeAction:(Lnet/minecraft/network/chat/Component;)Lnet/minecraft/network/chat/Component;
+        13: areturn
+        14: aload_0
+        15: invokevirtual #3840               // Method getTypeName:()Lnet/minecraft/network/chat/Component;
+        18: areturn
+
+  protected net.minecraft.network.chat.Component getTypeName();
+    Code:
+         0: aload_0
+         1: getfield      #565                // Field type:Lnet/minecraft/world/entity/EntityType;
+         4: invokevirtual #3844               // Method net/minecraft/world/entity/EntityType.getDescription:()Lnet/minecraft/network/chat/Component;
+         7: areturn
+
+  public boolean is(net.minecraft.world.entity.Entity);
+    Code:
+         0: aload_0
+         1: aload_1
+         2: if_acmpne     9
+         5: iconst_1
+         6: goto          10
+         9: iconst_0
+        10: ireturn
+
+  public float getYHeadRot();
+    Code:
+         0: fconst_0
+         1: freturn
+
+  public void setYHeadRot(float);
+    Code:
+         0: return
+
+  public void setYBodyRot(float);
+    Code:
+         0: return
+
+  public boolean isAttackable();
+    Code:
+         0: iconst_1
+         1: ireturn
+
+  public boolean skipAttackInteraction(net.minecraft.world.entity.Entity);
+    Code:
+         0: iconst_0
+         1: ireturn
+
+  public java.lang.String toString();
+    Code:
+         0: aload_0
+         1: invokevirtual #672                // Method level:()Lnet/minecraft/world/level/Level;
+         4: ifnonnull     13
+         7: ldc_w         #3850               // String ~NULL~
+        10: goto          20
+        13: aload_0
+        14: invokevirtual #672                // Method level:()Lnet/minecraft/world/level/Level;
+        17: invokevirtual #3851               // Method java/lang/Object.toString:()Ljava/lang/String;
+        20: astore_1
+        21: aload_0
+        22: getfield      #2714               // Field removalReason:Lnet/minecraft/world/entity/Entity$RemovalReason;
+        25: ifnull        113
+        28: getstatic     #3857               // Field java/util/Locale.ROOT:Ljava/util/Locale;
+        31: ldc_w         #3859               // String %s[\'%s\'/%d, l=\'%s\', x=%.2f, y=%.2f, z=%.2f, removed=%s]
+        34: bipush        8
+        36: anewarray     #5                  // class java/lang/Object
+        39: dup
+        40: iconst_0
+        41: aload_0
+        42: invokevirtual #3863               // Method java/lang/Object.getClass:()Ljava/lang/Class;
+        45: invokevirtual #3868               // Method java/lang/Class.getSimpleName:()Ljava/lang/String;
+        48: aastore
+        49: dup
+        50: iconst_1
+        51: aload_0
+        52: invokevirtual #3871               // Method getPlainTextName:()Ljava/lang/String;
+        55: aastore
+        56: dup
+        57: iconst_2
+        58: aload_0
+        59: getfield      #432                // Field id:I
+        62: invokestatic  #618                // Method java/lang/Integer.valueOf:(I)Ljava/lang/Integer;
+        65: aastore
+        66: dup
+        67: iconst_3
+        68: aload_1
+        69: aastore
+        70: dup
+        71: iconst_4
+        72: aload_0
+        73: invokevirtual #880                // Method getX:()D
+        76: invokestatic  #3874               // Method java/lang/Double.valueOf:(D)Ljava/lang/Double;
+        79: aastore
+        80: dup
+        81: iconst_5
+        82: aload_0
+        83: invokevirtual #883                // Method getY:()D
+        86: invokestatic  #3874               // Method java/lang/Double.valueOf:(D)Ljava/lang/Double;
+        89: aastore
+        90: dup
+        91: bipush        6
+        93: aload_0
+        94: invokevirtual #886                // Method getZ:()D
+        97: invokestatic  #3874               // Method java/lang/Double.valueOf:(D)Ljava/lang/Double;
+       100: aastore
+       101: dup
+       102: bipush        7
+       104: aload_0
+       105: getfield      #2714               // Field removalReason:Lnet/minecraft/world/entity/Entity$RemovalReason;
+       108: aastore
+       109: invokestatic  #3878               // Method java/lang/String.format:(Ljava/util/Locale;Ljava/lang/String;[Ljava/lang/Object;)Ljava/lang/String;
+       112: areturn
+       113: getstatic     #3857               // Field java/util/Locale.ROOT:Ljava/util/Locale;
+       116: ldc_w         #3880               // String %s[\'%s\'/%d, l=\'%s\', x=%.2f, y=%.2f, z=%.2f]
+       119: bipush        7
+       121: anewarray     #5                  // class java/lang/Object
+       124: dup
+       125: iconst_0
+       126: aload_0
+       127: invokevirtual #3863               // Method java/lang/Object.getClass:()Ljava/lang/Class;
+       130: invokevirtual #3868               // Method java/lang/Class.getSimpleName:()Ljava/lang/String;
+       133: aastore
+       134: dup
+       135: iconst_1
+       136: aload_0
+       137: invokevirtual #3871               // Method getPlainTextName:()Ljava/lang/String;
+       140: aastore
+       141: dup
+       142: iconst_2
+       143: aload_0
+       144: getfield      #432                // Field id:I
+       147: invokestatic  #618                // Method java/lang/Integer.valueOf:(I)Ljava/lang/Integer;
+       150: aastore
+       151: dup
+       152: iconst_3
+       153: aload_1
+       154: aastore
+       155: dup
+       156: iconst_4
+       157: aload_0
+       158: invokevirtual #880                // Method getX:()D
+       161: invokestatic  #3874               // Method java/lang/Double.valueOf:(D)Ljava/lang/Double;
+       164: aastore
+       165: dup
+       166: iconst_5
+       167: aload_0
+       168: invokevirtual #883                // Method getY:()D
+       171: invokestatic  #3874               // Method java/lang/Double.valueOf:(D)Ljava/lang/Double;
+       174: aastore
+       175: dup
+       176: bipush        6
+       178: aload_0
+       179: invokevirtual #886                // Method getZ:()D
+       182: invokestatic  #3874               // Method java/lang/Double.valueOf:(D)Ljava/lang/Double;
+       185: aastore
+       186: invokestatic  #3878               // Method java/lang/String.format:(Ljava/util/Locale;Ljava/lang/String;[Ljava/lang/Object;)Ljava/lang/String;
+       189: areturn
+
+  protected final boolean isInvulnerableToBase(net.minecraft.world.damagesource.DamageSource);
+    Code:
+         0: aload_0
+         1: invokevirtual #744                // Method isRemoved:()Z
+         4: ifne          68
+         7: aload_0
+         8: getfield      #2765               // Field invulnerable:Z
+        11: ifeq          31
+        14: aload_1
+        15: getstatic     #3887               // Field net/minecraft/tags/DamageTypeTags.BYPASSES_INVULNERABILITY:Lnet/minecraft/tags/TagKey;
+        18: invokevirtual #3890               // Method net/minecraft/world/damagesource/DamageSource.is:(Lnet/minecraft/tags/TagKey;)Z
+        21: ifne          31
+        24: aload_1
+        25: invokevirtual #3893               // Method net/minecraft/world/damagesource/DamageSource.isCreativePlayer:()Z
+        28: ifeq          68
+        31: aload_1
+        32: getstatic     #3896               // Field net/minecraft/tags/DamageTypeTags.IS_FIRE:Lnet/minecraft/tags/TagKey;
+        35: invokevirtual #3890               // Method net/minecraft/world/damagesource/DamageSource.is:(Lnet/minecraft/tags/TagKey;)Z
+        38: ifeq          48
+        41: aload_0
+        42: invokevirtual #1021               // Method fireImmune:()Z
+        45: ifne          68
+        48: aload_1
+        49: getstatic     #3899               // Field net/minecraft/tags/DamageTypeTags.IS_FALL:Lnet/minecraft/tags/TagKey;
+        52: invokevirtual #3890               // Method net/minecraft/world/damagesource/DamageSource.is:(Lnet/minecraft/tags/TagKey;)Z
+        55: ifeq          72
+        58: aload_0
+        59: getstatic     #2297               // Field net/minecraft/tags/EntityTypeTags.FALL_DAMAGE_IMMUNE:Lnet/minecraft/tags/TagKey;
+        62: invokevirtual #2298               // Method is:(Lnet/minecraft/tags/TagKey;)Z
+        65: ifeq          72
+        68: iconst_1
+        69: goto          73
+        72: iconst_0
+        73: ireturn
+
+  public boolean isInvulnerable();
+    Code:
+         0: aload_0
+         1: getfield      #2765               // Field invulnerable:Z
+         4: ireturn
+
+  public boolean isInvulnerableToPiercingWeapon();
+    Code:
+         0: aload_0
+         1: invokevirtual #3903               // Method isInvulnerable:()Z
+         4: ireturn
+
+  public void setInvulnerable(boolean);
+    Code:
+         0: aload_0
+         1: iload_1
+         2: putfield      #2765               // Field invulnerable:Z
+         5: return
+
+  public void copyPosition(net.minecraft.world.entity.Entity);
+    Code:
+         0: aload_0
+         1: aload_1
+         2: invokevirtual #880                // Method getX:()D
+         5: aload_1
+         6: invokevirtual #883                // Method getY:()D
+         9: aload_1
+        10: invokevirtual #886                // Method getZ:()D
+        13: aload_1
+        14: invokevirtual #945                // Method getYRot:()F
+        17: aload_1
+        18: invokevirtual #942                // Method getXRot:()F
+        21: invokevirtual #2520               // Method snapTo:(DDDFF)V
+        24: return
+
+  public void restoreFrom(net.minecraft.world.entity.Entity);
+    Code:
+         0: new           #128                // class net/minecraft/util/ProblemReporter$ScopedCollector
+         3: dup
+         4: aload_0
+         5: invokevirtual #3911               // Method problemPath:()Lnet/minecraft/util/ProblemReporter$PathElement;
+         8: getstatic     #3913               // Field LOGGER:Lorg/slf4j/Logger;
+        11: invokespecial #3916               // Method net/minecraft/util/ProblemReporter$ScopedCollector."<init>":(Lnet/minecraft/util/ProblemReporter$PathElement;Lorg/slf4j/Logger;)V
+        14: astore_2
+        15: aload_2
+        16: aload_1
+        17: invokevirtual #3920               // Method registryAccess:()Lnet/minecraft/core/RegistryAccess;
+        20: invokestatic  #3926               // Method net/minecraft/world/level/storage/TagValueOutput.createWithContext:(Lnet/minecraft/util/ProblemReporter;Lnet/minecraft/core/HolderLookup$Provider;)Lnet/minecraft/world/level/storage/TagValueOutput;
+        23: astore_3
+        24: aload_1
+        25: aload_3
+        26: invokevirtual #2730               // Method saveWithoutId:(Lnet/minecraft/world/level/storage/ValueOutput;)V
+        29: aload_0
+        30: aload_2
+        31: aload_0
+        32: invokevirtual #3920               // Method registryAccess:()Lnet/minecraft/core/RegistryAccess;
+        35: aload_3
+        36: invokevirtual #3930               // Method net/minecraft/world/level/storage/TagValueOutput.buildResult:()Lnet/minecraft/nbt/CompoundTag;
+        39: invokestatic  #3935               // Method net/minecraft/world/level/storage/TagValueInput.create:(Lnet/minecraft/util/ProblemReporter;Lnet/minecraft/core/HolderLookup$Provider;Lnet/minecraft/nbt/CompoundTag;)Lnet/minecraft/world/level/storage/ValueInput;
+        42: invokevirtual #3937               // Method load:(Lnet/minecraft/world/level/storage/ValueInput;)V
+        45: aload_2
+        46: invokevirtual #3940               // Method net/minecraft/util/ProblemReporter$ScopedCollector.close:()V
+        49: goto          70
+        52: astore_3
+        53: aload_2
+        54: invokevirtual #3940               // Method net/minecraft/util/ProblemReporter$ScopedCollector.close:()V
+        57: goto          68
+        60: astore        4
+        62: aload_3
+        63: aload         4
+        65: invokevirtual #3944               // Method java/lang/Throwable.addSuppressed:(Ljava/lang/Throwable;)V
+        68: aload_3
+        69: athrow
+        70: aload_0
+        71: aload_1
+        72: getfield      #1092               // Field portalCooldown:I
+        75: putfield      #1092               // Field portalCooldown:I
+        78: aload_0
+        79: aload_1
+        80: getfield      #3524               // Field portalProcess:Lnet/minecraft/world/entity/PortalProcessor;
+        83: putfield      #3524               // Field portalProcess:Lnet/minecraft/world/entity/PortalProcessor;
+        86: return
+      Exception table:
+         from    to  target type
+            15    45    52   Class java/lang/Throwable
+            53    57    60   Class java/lang/Throwable
+
+  public net.minecraft.world.entity.Entity teleport(net.minecraft.world.level.portal.TeleportTransition);
+    Code:
+         0: aload_0
+         1: invokevirtual #672                // Method level:()Lnet/minecraft/world/level/Level;
+         4: astore_3
+         5: aload_3
+         6: instanceof    #1016               // class net/minecraft/server/level/ServerLevel
+         9: ifeq          24
+        12: aload_3
+        13: checkcast     #1016               // class net/minecraft/server/level/ServerLevel
+        16: astore_2
+        17: aload_0
+        18: invokevirtual #744                // Method isRemoved:()Z
+        21: ifeq          26
+        24: aconst_null
+        25: areturn
+        26: aload_1
+        27: invokevirtual #3565               // Method net/minecraft/world/level/portal/TeleportTransition.newLevel:()Lnet/minecraft/server/level/ServerLevel;
+        30: astore_3
+        31: aload_3
+        32: invokevirtual #3573               // Method net/minecraft/server/level/ServerLevel.dimension:()Lnet/minecraft/resources/ResourceKey;
+        35: aload_2
+        36: invokevirtual #3573               // Method net/minecraft/server/level/ServerLevel.dimension:()Lnet/minecraft/resources/ResourceKey;
+        39: if_acmpeq     46
+        42: iconst_1
+        43: goto          47
+        46: iconst_0
+        47: istore        4
+        49: aload_1
+        50: invokevirtual #3951               // Method net/minecraft/world/level/portal/TeleportTransition.asPassenger:()Z
+        53: ifne          60
+        56: aload_0
+        57: invokevirtual #759                // Method stopRiding:()V
+        60: iload         4
+        62: ifeq          73
+        65: aload_0
+        66: aload_2
+        67: aload_3
+        68: aload_1
+        69: invokevirtual #3955               // Method teleportCrossDimension:(Lnet/minecraft/server/level/ServerLevel;Lnet/minecraft/server/level/ServerLevel;Lnet/minecraft/world/level/portal/TeleportTransition;)Lnet/minecraft/world/entity/Entity;
+        72: areturn
+        73: aload_0
+        74: aload_2
+        75: aload_1
+        76: invokevirtual #3959               // Method teleportSameDimension:(Lnet/minecraft/server/level/ServerLevel;Lnet/minecraft/world/level/portal/TeleportTransition;)Lnet/minecraft/world/entity/Entity;
+        79: areturn
+
+  private net.minecraft.world.entity.Entity teleportSameDimension(net.minecraft.server.level.ServerLevel, net.minecraft.world.level.portal.TeleportTransition);
+    Code:
+         0: aload_0
+         1: invokevirtual #2307               // Method getPassengers:()Ljava/util/List;
+         4: invokeinterface #1820,  1         // InterfaceMethod java/util/List.iterator:()Ljava/util/Iterator;
+         9: astore_3
+        10: aload_3
+        11: invokeinterface #1827,  1         // InterfaceMethod java/util/Iterator.hasNext:()Z
+        16: ifeq          46
+        19: aload_3
+        20: invokeinterface #1830,  1         // InterfaceMethod java/util/Iterator.next:()Ljava/lang/Object;
+        25: checkcast     #2                  // class net/minecraft/world/entity/Entity
+        28: astore        4
+        30: aload         4
+        32: aload_0
+        33: aload_2
+        34: aload         4
+        36: invokevirtual #3964               // Method calculatePassengerTransition:(Lnet/minecraft/world/level/portal/TeleportTransition;Lnet/minecraft/world/entity/Entity;)Lnet/minecraft/world/level/portal/TeleportTransition;
+        39: invokevirtual #3581               // Method teleport:(Lnet/minecraft/world/level/portal/TeleportTransition;)Lnet/minecraft/world/entity/Entity;
+        42: pop
+        43: goto          10
+        46: invokestatic  #973                // Method net/minecraft/util/profiling/Profiler.get:()Lnet/minecraft/util/profiling/ProfilerFiller;
+        49: astore_3
+        50: aload_3
+        51: ldc_w         #3965               // String teleportSameDimension
+        54: invokeinterface #980,  2          // InterfaceMethod net/minecraft/util/profiling/ProfilerFiller.push:(Ljava/lang/String;)V
+        59: aload_0
+        60: aload_2
+        61: invokestatic  #3970               // Method net/minecraft/world/entity/PositionMoveRotation.of:(Lnet/minecraft/world/level/portal/TeleportTransition;)Lnet/minecraft/world/entity/PositionMoveRotation;
+        64: aload_2
+        65: invokevirtual #3973               // Method net/minecraft/world/level/portal/TeleportTransition.relatives:()Ljava/util/Set;
+        68: invokevirtual #3977               // Method teleportSetPosition:(Lnet/minecraft/world/entity/PositionMoveRotation;Ljava/util/Set;)V
+        71: aload_2
+        72: invokevirtual #3951               // Method net/minecraft/world/level/portal/TeleportTransition.asPassenger:()Z
+        75: ifne          83
+        78: aload_0
+        79: aload_2
+        80: invokevirtual #3981               // Method sendTeleportTransitionToRidingPlayers:(Lnet/minecraft/world/level/portal/TeleportTransition;)V
+        83: aload_2
+        84: invokevirtual #3985               // Method net/minecraft/world/level/portal/TeleportTransition.postTeleportTransition:()Lnet/minecraft/world/level/portal/TeleportTransition$PostTeleportTransition;
+        87: aload_0
+        88: invokeinterface #3988,  2         // InterfaceMethod net/minecraft/world/level/portal/TeleportTransition$PostTeleportTransition.onTransition:(Lnet/minecraft/world/entity/Entity;)V
+        93: aload_3
+        94: invokeinterface #1066,  1         // InterfaceMethod net/minecraft/util/profiling/ProfilerFiller.pop:()V
+        99: aload_0
+       100: areturn
+
+  private net.minecraft.world.entity.Entity teleportCrossDimension(net.minecraft.server.level.ServerLevel, net.minecraft.server.level.ServerLevel, net.minecraft.world.level.portal.TeleportTransition);
+    Code:
+         0: aload_0
+         1: invokevirtual #2307               // Method getPassengers:()Ljava/util/List;
+         4: astore        4
+         6: new           #3991               // class java/util/ArrayList
+         9: dup
+        10: aload         4
+        12: invokeinterface #1876,  1         // InterfaceMethod java/util/List.size:()I
+        17: invokespecial #3992               // Method java/util/ArrayList."<init>":(I)V
+        20: astore        5
+        22: aload_0
+        23: invokevirtual #753                // Method ejectPassengers:()V
+        26: aload         4
+        28: invokeinterface #1820,  1         // InterfaceMethod java/util/List.iterator:()Ljava/util/Iterator;
+        33: astore        6
+        35: aload         6
+        37: invokeinterface #1827,  1         // InterfaceMethod java/util/Iterator.hasNext:()Z
+        42: ifeq          89
+        45: aload         6
+        47: invokeinterface #1830,  1         // InterfaceMethod java/util/Iterator.next:()Ljava/lang/Object;
+        52: checkcast     #2                  // class net/minecraft/world/entity/Entity
+        55: astore        7
+        57: aload         7
+        59: aload_0
+        60: aload_3
+        61: aload         7
+        63: invokevirtual #3964               // Method calculatePassengerTransition:(Lnet/minecraft/world/level/portal/TeleportTransition;Lnet/minecraft/world/entity/Entity;)Lnet/minecraft/world/level/portal/TeleportTransition;
+        66: invokevirtual #3581               // Method teleport:(Lnet/minecraft/world/level/portal/TeleportTransition;)Lnet/minecraft/world/entity/Entity;
+        69: astore        8
+        71: aload         8
+        73: ifnull        86
+        76: aload         5
+        78: aload         8
+        80: invokeinterface #1532,  2         // InterfaceMethod java/util/List.add:(Ljava/lang/Object;)Z
+        85: pop
+        86: goto          35
+        89: invokestatic  #973                // Method net/minecraft/util/profiling/Profiler.get:()Lnet/minecraft/util/profiling/ProfilerFiller;
+        92: astore        6
+        94: aload         6
+        96: ldc_w         #3993               // String teleportCrossDimension
+        99: invokeinterface #980,  2          // InterfaceMethod net/minecraft/util/profiling/ProfilerFiller.push:(Ljava/lang/String;)V
+       104: aload_0
+       105: invokevirtual #2287               // Method getType:()Lnet/minecraft/world/entity/EntityType;
+       108: aload_2
+       109: getstatic     #3999               // Field net/minecraft/world/entity/EntitySpawnReason.DIMENSION_TRAVEL:Lnet/minecraft/world/entity/EntitySpawnReason;
+       112: invokevirtual #4002               // Method net/minecraft/world/entity/EntityType.create:(Lnet/minecraft/world/level/Level;Lnet/minecraft/world/entity/EntitySpawnReason;)Lnet/minecraft/world/entity/Entity;
+       115: astore        7
+       117: aload         7
+       119: ifnonnull     131
+       122: aload         6
+       124: invokeinterface #1066,  1         // InterfaceMethod net/minecraft/util/profiling/ProfilerFiller.pop:()V
+       129: aconst_null
+       130: areturn
+       131: aload         7
+       133: aload_0
+       134: invokevirtual #4004               // Method restoreFrom:(Lnet/minecraft/world/entity/Entity;)V
+       137: aload_0
+       138: invokevirtual #4007               // Method removeAfterChangingDimensions:()V
+       141: aload         7
+       143: aload_0
+       144: invokestatic  #4010               // Method net/minecraft/world/entity/PositionMoveRotation.of:(Lnet/minecraft/world/entity/Entity;)Lnet/minecraft/world/entity/PositionMoveRotation;
+       147: aload_3
+       148: invokestatic  #3970               // Method net/minecraft/world/entity/PositionMoveRotation.of:(Lnet/minecraft/world/level/portal/TeleportTransition;)Lnet/minecraft/world/entity/PositionMoveRotation;
+       151: aload_3
+       152: invokevirtual #3973               // Method net/minecraft/world/level/portal/TeleportTransition.relatives:()Ljava/util/Set;
+       155: invokevirtual #4013               // Method teleportSetPosition:(Lnet/minecraft/world/entity/PositionMoveRotation;Lnet/minecraft/world/entity/PositionMoveRotation;Ljava/util/Set;)V
+       158: aload_2
+       159: aload         7
+       161: invokevirtual #4016               // Method net/minecraft/server/level/ServerLevel.addDuringTeleport:(Lnet/minecraft/world/entity/Entity;)V
+       164: aload         5
+       166: invokeinterface #1820,  1         // InterfaceMethod java/util/List.iterator:()Ljava/util/Iterator;
+       171: astore        8
+       173: aload         8
+       175: invokeinterface #1827,  1         // InterfaceMethod java/util/Iterator.hasNext:()Z
+       180: ifeq          208
+       183: aload         8
+       185: invokeinterface #1830,  1         // InterfaceMethod java/util/Iterator.next:()Ljava/lang/Object;
+       190: checkcast     #2                  // class net/minecraft/world/entity/Entity
+       193: astore        9
+       195: aload         9
+       197: aload         7
+       199: iconst_1
+       200: iconst_0
+       201: invokevirtual #3307               // Method startRiding:(Lnet/minecraft/world/entity/Entity;ZZ)Z
+       204: pop
+       205: goto          173
+       208: aload_2
+       209: invokevirtual #4019               // Method net/minecraft/server/level/ServerLevel.resetEmptyTime:()V
+       212: aload_3
+       213: invokevirtual #3985               // Method net/minecraft/world/level/portal/TeleportTransition.postTeleportTransition:()Lnet/minecraft/world/level/portal/TeleportTransition$PostTeleportTransition;
+       216: aload         7
+       218: invokeinterface #3988,  2         // InterfaceMethod net/minecraft/world/level/portal/TeleportTransition$PostTeleportTransition.onTransition:(Lnet/minecraft/world/entity/Entity;)V
+       223: aload_0
+       224: aload_3
+       225: aload_1
+       226: invokevirtual #4023               // Method teleportSpectators:(Lnet/minecraft/world/level/portal/TeleportTransition;Lnet/minecraft/server/level/ServerLevel;)V
+       229: aload         6
+       231: invokeinterface #1066,  1         // InterfaceMethod net/minecraft/util/profiling/ProfilerFiller.pop:()V
+       236: aload         7
+       238: areturn
+
+  protected void teleportSpectators(net.minecraft.world.level.portal.TeleportTransition, net.minecraft.server.level.ServerLevel);
+    Code:
+         0: aload_2
+         1: invokevirtual #4029               // Method net/minecraft/server/level/ServerLevel.players:()Ljava/util/List;
+         4: invokestatic  #2809               // InterfaceMethod java/util/List.copyOf:(Ljava/util/Collection;)Ljava/util/List;
+         7: astore_3
+         8: aload_3
+         9: invokeinterface #1820,  1         // InterfaceMethod java/util/List.iterator:()Ljava/util/Iterator;
+        14: astore        4
+        16: aload         4
+        18: invokeinterface #1827,  1         // InterfaceMethod java/util/Iterator.hasNext:()Z
+        23: ifeq          63
+        26: aload         4
+        28: invokeinterface #1830,  1         // InterfaceMethod java/util/Iterator.next:()Ljava/lang/Object;
+        33: checkcast     #2680               // class net/minecraft/server/level/ServerPlayer
+        36: astore        5
+        38: aload         5
+        40: invokevirtual #4032               // Method net/minecraft/server/level/ServerPlayer.getCamera:()Lnet/minecraft/world/entity/Entity;
+        43: aload_0
+        44: if_acmpne     60
+        47: aload         5
+        49: aload_1
+        50: invokevirtual #4035               // Method net/minecraft/server/level/ServerPlayer.teleport:(Lnet/minecraft/world/level/portal/TeleportTransition;)Lnet/minecraft/server/level/ServerPlayer;
+        53: pop
+        54: aload         5
+        56: aconst_null
+        57: invokevirtual #4038               // Method net/minecraft/server/level/ServerPlayer.setCamera:(Lnet/minecraft/world/entity/Entity;)V
+        60: goto          16
+        63: return
+
+  private net.minecraft.world.level.portal.TeleportTransition calculatePassengerTransition(net.minecraft.world.level.portal.TeleportTransition, net.minecraft.world.entity.Entity);
+    Code:
+         0: aload_1
+         1: invokevirtual #4040               // Method net/minecraft/world/level/portal/TeleportTransition.yRot:()F
+         4: aload_1
+         5: invokevirtual #3973               // Method net/minecraft/world/level/portal/TeleportTransition.relatives:()Ljava/util/Set;
+         8: getstatic     #4046               // Field net/minecraft/world/entity/Relative.Y_ROT:Lnet/minecraft/world/entity/Relative;
+        11: invokeinterface #4049,  2         // InterfaceMethod java/util/Set.contains:(Ljava/lang/Object;)Z
+        16: ifeq          23
+        19: fconst_0
+        20: goto          32
+        23: aload_2
+        24: invokevirtual #945                // Method getYRot:()F
+        27: aload_0
+        28: invokevirtual #945                // Method getYRot:()F
+        31: fsub
+        32: fadd
+        33: fstore_3
+        34: aload_1
+        35: invokevirtual #4050               // Method net/minecraft/world/level/portal/TeleportTransition.xRot:()F
+        38: aload_1
+        39: invokevirtual #3973               // Method net/minecraft/world/level/portal/TeleportTransition.relatives:()Ljava/util/Set;
+        42: getstatic     #4053               // Field net/minecraft/world/entity/Relative.X_ROT:Lnet/minecraft/world/entity/Relative;
+        45: invokeinterface #4049,  2         // InterfaceMethod java/util/Set.contains:(Ljava/lang/Object;)Z
+        50: ifeq          57
+        53: fconst_0
+        54: goto          66
+        57: aload_2
+        58: invokevirtual #942                // Method getXRot:()F
+        61: aload_0
+        62: invokevirtual #942                // Method getXRot:()F
+        65: fsub
+        66: fadd
+        67: fstore        4
+        69: aload_2
+        70: invokevirtual #870                // Method position:()Lnet/minecraft/world/phys/Vec3;
+        73: aload_0
+        74: invokevirtual #870                // Method position:()Lnet/minecraft/world/phys/Vec3;
+        77: invokevirtual #1073               // Method net/minecraft/world/phys/Vec3.subtract:(Lnet/minecraft/world/phys/Vec3;)Lnet/minecraft/world/phys/Vec3;
+        80: astore        5
+        82: aload_1
+        83: invokevirtual #4054               // Method net/minecraft/world/level/portal/TeleportTransition.position:()Lnet/minecraft/world/phys/Vec3;
+        86: aload_1
+        87: invokevirtual #3973               // Method net/minecraft/world/level/portal/TeleportTransition.relatives:()Ljava/util/Set;
+        90: getstatic     #4056               // Field net/minecraft/world/entity/Relative.X:Lnet/minecraft/world/entity/Relative;
+        93: invokeinterface #4049,  2         // InterfaceMethod java/util/Set.contains:(Ljava/lang/Object;)Z
+        98: ifeq          105
+       101: dconst_0
+       102: goto          110
+       105: aload         5
+       107: invokevirtual #909                // Method net/minecraft/world/phys/Vec3.x:()D
+       110: aload_1
+       111: invokevirtual #3973               // Method net/minecraft/world/level/portal/TeleportTransition.relatives:()Ljava/util/Set;
+       114: getstatic     #4058               // Field net/minecraft/world/entity/Relative.Y:Lnet/minecraft/world/entity/Relative;
+       117: invokeinterface #4049,  2         // InterfaceMethod java/util/Set.contains:(Ljava/lang/Object;)Z
+       122: ifeq          129
+       125: dconst_0
+       126: goto          134
+       129: aload         5
+       131: invokevirtual #911                // Method net/minecraft/world/phys/Vec3.y:()D
+       134: aload_1
+       135: invokevirtual #3973               // Method net/minecraft/world/level/portal/TeleportTransition.relatives:()Ljava/util/Set;
+       138: getstatic     #4060               // Field net/minecraft/world/entity/Relative.Z:Lnet/minecraft/world/entity/Relative;
+       141: invokeinterface #4049,  2         // InterfaceMethod java/util/Set.contains:(Ljava/lang/Object;)Z
+       146: ifeq          153
+       149: dconst_0
+       150: goto          158
+       153: aload         5
+       155: invokevirtual #913                // Method net/minecraft/world/phys/Vec3.z:()D
+       158: invokevirtual #2249               // Method net/minecraft/world/phys/Vec3.add:(DDD)Lnet/minecraft/world/phys/Vec3;
+       161: astore        6
+       163: aload_1
+       164: aload         6
+       166: invokevirtual #4064               // Method net/minecraft/world/level/portal/TeleportTransition.withPosition:(Lnet/minecraft/world/phys/Vec3;)Lnet/minecraft/world/level/portal/TeleportTransition;
+       169: fload_3
+       170: fload         4
+       172: invokevirtual #4068               // Method net/minecraft/world/level/portal/TeleportTransition.withRotation:(FF)Lnet/minecraft/world/level/portal/TeleportTransition;
+       175: invokevirtual #4072               // Method net/minecraft/world/level/portal/TeleportTransition.transitionAsPassenger:()Lnet/minecraft/world/level/portal/TeleportTransition;
+       178: areturn
+
+  private void sendTeleportTransitionToRidingPlayers(net.minecraft.world.level.portal.TeleportTransition);
+    Code:
+         0: aload_0
+         1: invokevirtual #2141               // Method getControllingPassenger:()Lnet/minecraft/world/entity/LivingEntity;
+         4: astore_2
+         5: aload_0
+         6: invokevirtual #4080               // Method getIndirectPassengers:()Ljava/lang/Iterable;
+         9: invokeinterface #4083,  1         // InterfaceMethod java/lang/Iterable.iterator:()Ljava/util/Iterator;
+        14: astore_3
+        15: aload_3
+        16: invokeinterface #1827,  1         // InterfaceMethod java/util/Iterator.hasNext:()Z
+        21: ifeq          125
+        24: aload_3
+        25: invokeinterface #1830,  1         // InterfaceMethod java/util/Iterator.next:()Ljava/lang/Object;
+        30: checkcast     #2                  // class net/minecraft/world/entity/Entity
+        33: astore        4
+        35: aload         4
+        37: instanceof    #2680               // class net/minecraft/server/level/ServerPlayer
+        40: ifeq          122
+        43: aload         4
+        45: checkcast     #2680               // class net/minecraft/server/level/ServerPlayer
+        48: astore        5
+        50: aload_2
+        51: ifnull        96
+        54: aload         5
+        56: invokevirtual #4084               // Method net/minecraft/server/level/ServerPlayer.getId:()I
+        59: aload_2
+        60: invokevirtual #838                // Method getId:()I
+        63: if_icmpne     96
+        66: aload         5
+        68: getfield      #4088               // Field net/minecraft/server/level/ServerPlayer.connection:Lnet/minecraft/server/network/ServerGamePacketListenerImpl;
+        71: aload_0
+        72: invokevirtual #838                // Method getId:()I
+        75: aload_1
+        76: invokestatic  #3970               // Method net/minecraft/world/entity/PositionMoveRotation.of:(Lnet/minecraft/world/level/portal/TeleportTransition;)Lnet/minecraft/world/entity/PositionMoveRotation;
+        79: aload_1
+        80: invokevirtual #3973               // Method net/minecraft/world/level/portal/TeleportTransition.relatives:()Ljava/util/Set;
+        83: aload_0
+        84: getfield      #1180               // Field onGround:Z
+        87: invokestatic  #4093               // Method net/minecraft/network/protocol/game/ClientboundTeleportEntityPacket.teleport:(ILnet/minecraft/world/entity/PositionMoveRotation;Ljava/util/Set;Z)Lnet/minecraft/network/protocol/game/ClientboundTeleportEntityPacket;
+        90: invokevirtual #4099               // Method net/minecraft/server/network/ServerGamePacketListenerImpl.send:(Lnet/minecraft/network/protocol/Packet;)V
+        93: goto          122
+        96: aload         5
+        98: getfield      #4088               // Field net/minecraft/server/level/ServerPlayer.connection:Lnet/minecraft/server/network/ServerGamePacketListenerImpl;
+       101: aload_0
+       102: invokevirtual #838                // Method getId:()I
+       105: aload_0
+       106: invokestatic  #4010               // Method net/minecraft/world/entity/PositionMoveRotation.of:(Lnet/minecraft/world/entity/Entity;)Lnet/minecraft/world/entity/PositionMoveRotation;
+       109: invokestatic  #4101               // InterfaceMethod java/util/Set.of:()Ljava/util/Set;
+       112: aload_0
+       113: getfield      #1180               // Field onGround:Z
+       116: invokestatic  #4093               // Method net/minecraft/network/protocol/game/ClientboundTeleportEntityPacket.teleport:(ILnet/minecraft/world/entity/PositionMoveRotation;Ljava/util/Set;Z)Lnet/minecraft/network/protocol/game/ClientboundTeleportEntityPacket;
+       119: invokevirtual #4099               // Method net/minecraft/server/network/ServerGamePacketListenerImpl.send:(Lnet/minecraft/network/protocol/Packet;)V
+       122: goto          15
+       125: return
+
+  public void teleportSetPosition(net.minecraft.world.entity.PositionMoveRotation, java.util.Set<net.minecraft.world.entity.Relative>);
+    Code:
+         0: aload_0
+         1: aload_0
+         2: invokestatic  #4010               // Method net/minecraft/world/entity/PositionMoveRotation.of:(Lnet/minecraft/world/entity/Entity;)Lnet/minecraft/world/entity/PositionMoveRotation;
+         5: aload_1
+         6: aload_2
+         7: invokevirtual #4013               // Method teleportSetPosition:(Lnet/minecraft/world/entity/PositionMoveRotation;Lnet/minecraft/world/entity/PositionMoveRotation;Ljava/util/Set;)V
+        10: return
+
+  public void teleportSetPosition(net.minecraft.world.entity.PositionMoveRotation, net.minecraft.world.entity.PositionMoveRotation, java.util.Set<net.minecraft.world.entity.Relative>);
+    Code:
+         0: aload_1
+         1: aload_2
+         2: aload_3
+         3: invokestatic  #4112               // Method net/minecraft/world/entity/PositionMoveRotation.calculateAbsolute:(Lnet/minecraft/world/entity/PositionMoveRotation;Lnet/minecraft/world/entity/PositionMoveRotation;Ljava/util/Set;)Lnet/minecraft/world/entity/PositionMoveRotation;
+         6: astore        4
+         8: aload_0
+         9: aload         4
+        11: invokevirtual #4113               // Method net/minecraft/world/entity/PositionMoveRotation.position:()Lnet/minecraft/world/phys/Vec3;
+        14: getfield      #932                // Field net/minecraft/world/phys/Vec3.x:D
+        17: aload         4
+        19: invokevirtual #4113               // Method net/minecraft/world/entity/PositionMoveRotation.position:()Lnet/minecraft/world/phys/Vec3;
+        22: getfield      #934                // Field net/minecraft/world/phys/Vec3.y:D
+        25: aload         4
+        27: invokevirtual #4113               // Method net/minecraft/world/entity/PositionMoveRotation.position:()Lnet/minecraft/world/phys/Vec3;
+        30: getfield      #936                // Field net/minecraft/world/phys/Vec3.z:D
+        33: invokevirtual #916                // Method setPosRaw:(DDD)V
+        36: aload_0
+        37: aload         4
+        39: invokevirtual #4114               // Method net/minecraft/world/entity/PositionMoveRotation.yRot:()F
+        42: invokevirtual #904                // Method setYRot:(F)V
+        45: aload_0
+        46: aload         4
+        48: invokevirtual #4114               // Method net/minecraft/world/entity/PositionMoveRotation.yRot:()F
+        51: invokevirtual #2889               // Method setYHeadRot:(F)V
+        54: aload_0
+        55: aload         4
+        57: invokevirtual #4115               // Method net/minecraft/world/entity/PositionMoveRotation.xRot:()F
+        60: invokevirtual #907                // Method setXRot:(F)V
+        63: aload_0
+        64: invokevirtual #2532               // Method reapplyPosition:()V
+        67: aload_0
+        68: invokevirtual #2530               // Method setOldPosAndRot:()V
+        71: aload_0
+        72: aload         4
+        74: invokevirtual #4117               // Method net/minecraft/world/entity/PositionMoveRotation.deltaMovement:()Lnet/minecraft/world/phys/Vec3;
+        77: invokevirtual #1259               // Method setDeltaMovement:(Lnet/minecraft/world/phys/Vec3;)V
+        80: aload_0
+        81: invokevirtual #4119               // Method clearMovementThisTick:()V
+        84: return
+
+  public void forceSetRotation(float, boolean, float, boolean);
+    Code:
+         0: iload_2
+         1: iload         4
+         3: invokestatic  #4127               // Method net/minecraft/world/entity/Relative.rotation:(ZZ)Ljava/util/Set;
+         6: astore        5
+         8: aload_0
+         9: invokestatic  #4010               // Method net/minecraft/world/entity/PositionMoveRotation.of:(Lnet/minecraft/world/entity/Entity;)Lnet/minecraft/world/entity/PositionMoveRotation;
+        12: astore        6
+        14: aload         6
+        16: fload_1
+        17: fload_3
+        18: invokevirtual #4130               // Method net/minecraft/world/entity/PositionMoveRotation.withRotation:(FF)Lnet/minecraft/world/entity/PositionMoveRotation;
+        21: astore        7
+        23: aload         6
+        25: aload         7
+        27: aload         5
+        29: invokestatic  #4112               // Method net/minecraft/world/entity/PositionMoveRotation.calculateAbsolute:(Lnet/minecraft/world/entity/PositionMoveRotation;Lnet/minecraft/world/entity/PositionMoveRotation;Ljava/util/Set;)Lnet/minecraft/world/entity/PositionMoveRotation;
+        32: astore        8
+        34: aload_0
+        35: aload         8
+        37: invokevirtual #4114               // Method net/minecraft/world/entity/PositionMoveRotation.yRot:()F
+        40: invokevirtual #904                // Method setYRot:(F)V
+        43: aload_0
+        44: aload         8
+        46: invokevirtual #4114               // Method net/minecraft/world/entity/PositionMoveRotation.yRot:()F
+        49: invokevirtual #2889               // Method setYHeadRot:(F)V
+        52: aload_0
+        53: aload         8
+        55: invokevirtual #4115               // Method net/minecraft/world/entity/PositionMoveRotation.xRot:()F
+        58: invokevirtual #907                // Method setXRot:(F)V
+        61: aload_0
+        62: invokevirtual #2538               // Method setOldRot:()V
+        65: return
+
+  public void placePortalTicket(net.minecraft.core.BlockPos);
+    Code:
+         0: aload_0
+         1: invokevirtual #672                // Method level:()Lnet/minecraft/world/level/Level;
+         4: astore_3
+         5: aload_3
+         6: instanceof    #1016               // class net/minecraft/server/level/ServerLevel
+         9: ifeq          32
+        12: aload_3
+        13: checkcast     #1016               // class net/minecraft/server/level/ServerLevel
+        16: astore_2
+        17: aload_2
+        18: invokevirtual #4136               // Method net/minecraft/server/level/ServerLevel.getChunkSource:()Lnet/minecraft/server/level/ServerChunkCache;
+        21: getstatic     #4142               // Field net/minecraft/server/level/TicketType.PORTAL:Lnet/minecraft/server/level/TicketType;
+        24: aload_1
+        25: invokestatic  #4145               // Method net/minecraft/world/level/ChunkPos.containing:(Lnet/minecraft/core/BlockPos;)Lnet/minecraft/world/level/ChunkPos;
+        28: iconst_3
+        29: invokevirtual #4151               // Method net/minecraft/server/level/ServerChunkCache.addTicketWithRadius:(Lnet/minecraft/server/level/TicketType;Lnet/minecraft/world/level/ChunkPos;I)V
+        32: return
+
+  protected void removeAfterChangingDimensions();
+    Code:
+         0: aload_0
+         1: getstatic     #4154               // Field net/minecraft/world/entity/Entity$RemovalReason.CHANGED_DIMENSION:Lnet/minecraft/world/entity/Entity$RemovalReason;
+         4: invokevirtual #845                // Method setRemoved:(Lnet/minecraft/world/entity/Entity$RemovalReason;)V
+         7: aload_0
+         8: astore_2
+         9: aload_2
+        10: instanceof    #1059               // class net/minecraft/world/entity/Leashable
+        13: ifeq          27
+        16: aload_2
+        17: checkcast     #1059               // class net/minecraft/world/entity/Leashable
+        20: astore_1
+        21: aload_1
+        22: invokeinterface #3169,  1         // InterfaceMethod net/minecraft/world/entity/Leashable.removeLeash:()V
+        27: aload_0
+        28: astore_3
+        29: aload_3
+        30: instanceof    #4156               // class net/minecraft/world/waypoints/WaypointTransmitter
+        33: ifeq          66
+        36: aload_3
+        37: checkcast     #4156               // class net/minecraft/world/waypoints/WaypointTransmitter
+        40: astore_1
+        41: aload_0
+        42: getfield      #567                // Field level:Lnet/minecraft/world/level/Level;
+        45: astore_3
+        46: aload_3
+        47: instanceof    #1016               // class net/minecraft/server/level/ServerLevel
+        50: ifeq          66
+        53: aload_3
+        54: checkcast     #1016               // class net/minecraft/server/level/ServerLevel
+        57: astore_2
+        58: aload_2
+        59: invokevirtual #4160               // Method net/minecraft/server/level/ServerLevel.getWaypointManager:()Lnet/minecraft/server/waypoints/ServerWaypointManager;
+        62: aload_1
+        63: invokevirtual #4166               // Method net/minecraft/server/waypoints/ServerWaypointManager.untrackWaypoint:(Lnet/minecraft/world/waypoints/WaypointTransmitter;)V
+        66: return
+
+  public net.minecraft.world.phys.Vec3 getRelativePortalPosition(net.minecraft.core.Direction$Axis, net.minecraft.util.BlockUtil$FoundRectangle);
+    Code:
+         0: aload_2
+         1: aload_1
+         2: aload_0
+         3: invokevirtual #870                // Method position:()Lnet/minecraft/world/phys/Vec3;
+         6: aload_0
+         7: aload_0
+         8: invokevirtual #863                // Method getPose:()Lnet/minecraft/world/entity/Pose;
+        11: invokevirtual #4174               // Method getDimensions:(Lnet/minecraft/world/entity/Pose;)Lnet/minecraft/world/entity/EntityDimensions;
+        14: invokestatic  #4180               // Method net/minecraft/world/level/portal/PortalShape.getRelativePosition:(Lnet/minecraft/util/BlockUtil$FoundRectangle;Lnet/minecraft/core/Direction$Axis;Lnet/minecraft/world/phys/Vec3;Lnet/minecraft/world/entity/EntityDimensions;)Lnet/minecraft/world/phys/Vec3;
+        17: areturn
+
+  public boolean canUsePortal(boolean);
+    Code:
+         0: iload_1
+         1: ifne          11
+         4: aload_0
+         5: invokevirtual #756                // Method isPassenger:()Z
+         8: ifne          22
+        11: aload_0
+        12: invokevirtual #741                // Method isAlive:()Z
+        15: ifeq          22
+        18: iconst_1
+        19: goto          23
+        22: iconst_0
+        23: ireturn
+
+  public boolean canTeleport(net.minecraft.world.level.Level, net.minecraft.world.level.Level);
+    Code:
+         0: aload_1
+         1: invokevirtual #4183               // Method net/minecraft/world/level/Level.dimension:()Lnet/minecraft/resources/ResourceKey;
+         4: getstatic     #4186               // Field net/minecraft/world/level/Level.END:Lnet/minecraft/resources/ResourceKey;
+         7: if_acmpne     78
+        10: aload_2
+        11: invokevirtual #4183               // Method net/minecraft/world/level/Level.dimension:()Lnet/minecraft/resources/ResourceKey;
+        14: getstatic     #4189               // Field net/minecraft/world/level/Level.OVERWORLD:Lnet/minecraft/resources/ResourceKey;
+        17: if_acmpne     78
+        20: aload_0
+        21: invokevirtual #2307               // Method getPassengers:()Ljava/util/List;
+        24: invokeinterface #1820,  1         // InterfaceMethod java/util/List.iterator:()Ljava/util/Iterator;
+        29: astore_3
+        30: aload_3
+        31: invokeinterface #1827,  1         // InterfaceMethod java/util/Iterator.hasNext:()Z
+        36: ifeq          78
+        39: aload_3
+        40: invokeinterface #1830,  1         // InterfaceMethod java/util/Iterator.next:()Ljava/lang/Object;
+        45: checkcast     #2                  // class net/minecraft/world/entity/Entity
+        48: astore        4
+        50: aload         4
+        52: instanceof    #2680               // class net/minecraft/server/level/ServerPlayer
+        55: ifeq          75
+        58: aload         4
+        60: checkcast     #2680               // class net/minecraft/server/level/ServerPlayer
+        63: astore        5
+        65: aload         5
+        67: getfield      #4192               // Field net/minecraft/server/level/ServerPlayer.seenCredits:Z
+        70: ifne          75
+        73: iconst_0
+        74: ireturn
+        75: goto          30
+        78: iconst_1
+        79: ireturn
+
+  public float getBlockExplosionResistance(net.minecraft.world.level.Explosion, net.minecraft.world.level.BlockGetter, net.minecraft.core.BlockPos, net.minecraft.world.level.block.state.BlockState, net.minecraft.world.level.material.FluidState, float);
+    Code:
+         0: fload         6
+         2: freturn
+
+  public boolean shouldBlockExplode(net.minecraft.world.level.Explosion, net.minecraft.world.level.BlockGetter, net.minecraft.core.BlockPos, net.minecraft.world.level.block.state.BlockState, float);
+    Code:
+         0: iconst_1
+         1: ireturn
+
+  public int getMaxFallDistance();
+    Code:
+         0: iconst_3
+         1: ireturn
+
+  public boolean isIgnoringBlockTriggers();
+    Code:
+         0: iconst_0
+         1: ireturn
+
+  public void fillCrashReportCategory(net.minecraft.CrashReportCategory);
+    Code:
+         0: aload_1
+         1: ldc_w         #4207               // String Entity Type
+         4: aload_0
+         5: invokedynamic #4216,  0           // InvokeDynamic #14:call:(Lnet/minecraft/world/entity/Entity;)Lnet/minecraft/CrashReportDetail;
+        10: invokevirtual #4222               // Method net/minecraft/CrashReportCategory.setDetail:(Ljava/lang/String;Lnet/minecraft/CrashReportDetail;)Lnet/minecraft/CrashReportCategory;
+        13: pop
+        14: aload_1
+        15: ldc_w         #4224               // String Entity ID
+        18: aload_0
+        19: getfield      #432                // Field id:I
+        22: invokestatic  #618                // Method java/lang/Integer.valueOf:(I)Ljava/lang/Integer;
+        25: invokevirtual #4227               // Method net/minecraft/CrashReportCategory.setDetail:(Ljava/lang/String;Ljava/lang/Object;)Lnet/minecraft/CrashReportCategory;
+        28: pop
+        29: aload_1
+        30: ldc_w         #4229               // String Entity Name
+        33: aload_0
+        34: invokedynamic #4234,  0           // InvokeDynamic #15:call:(Lnet/minecraft/world/entity/Entity;)Lnet/minecraft/CrashReportDetail;
+        39: invokevirtual #4222               // Method net/minecraft/CrashReportCategory.setDetail:(Ljava/lang/String;Lnet/minecraft/CrashReportDetail;)Lnet/minecraft/CrashReportCategory;
+        42: pop
+        43: aload_1
+        44: ldc_w         #4236               // String Entity\'s Exact location
+        47: getstatic     #3857               // Field java/util/Locale.ROOT:Ljava/util/Locale;
+        50: ldc_w         #4238               // String %.2f, %.2f, %.2f
+        53: iconst_3
+        54: anewarray     #5                  // class java/lang/Object
+        57: dup
+        58: iconst_0
+        59: aload_0
+        60: invokevirtual #880                // Method getX:()D
+        63: invokestatic  #3874               // Method java/lang/Double.valueOf:(D)Ljava/lang/Double;
+        66: aastore
+        67: dup
+        68: iconst_1
+        69: aload_0
+        70: invokevirtual #883                // Method getY:()D
+        73: invokestatic  #3874               // Method java/lang/Double.valueOf:(D)Ljava/lang/Double;
+        76: aastore
+        77: dup
+        78: iconst_2
+        79: aload_0
+        80: invokevirtual #886                // Method getZ:()D
+        83: invokestatic  #3874               // Method java/lang/Double.valueOf:(D)Ljava/lang/Double;
+        86: aastore
+        87: invokestatic  #3878               // Method java/lang/String.format:(Ljava/util/Locale;Ljava/lang/String;[Ljava/lang/Object;)Ljava/lang/String;
+        90: invokevirtual #4227               // Method net/minecraft/CrashReportCategory.setDetail:(Ljava/lang/String;Ljava/lang/Object;)Lnet/minecraft/CrashReportCategory;
+        93: pop
+        94: aload_1
+        95: ldc_w         #4240               // String Entity\'s Block location
+        98: aload_0
+        99: invokevirtual #672                // Method level:()Lnet/minecraft/world/level/Level;
+       102: aload_0
+       103: invokevirtual #880                // Method getX:()D
+       106: invokestatic  #1684               // Method net/minecraft/util/Mth.floor:(D)I
+       109: aload_0
+       110: invokevirtual #883                // Method getY:()D
+       113: invokestatic  #1684               // Method net/minecraft/util/Mth.floor:(D)I
+       116: aload_0
+       117: invokevirtual #886                // Method getZ:()D
+       120: invokestatic  #1684               // Method net/minecraft/util/Mth.floor:(D)I
+       123: invokestatic  #4244               // Method net/minecraft/CrashReportCategory.formatLocation:(Lnet/minecraft/world/level/LevelHeightAccessor;III)Ljava/lang/String;
+       126: invokevirtual #4227               // Method net/minecraft/CrashReportCategory.setDetail:(Ljava/lang/String;Ljava/lang/Object;)Lnet/minecraft/CrashReportCategory;
+       129: pop
+       130: aload_0
+       131: invokevirtual #1369               // Method getDeltaMovement:()Lnet/minecraft/world/phys/Vec3;
+       134: astore_2
+       135: aload_1
+       136: ldc_w         #4246               // String Entity\'s Momentum
+       139: getstatic     #3857               // Field java/util/Locale.ROOT:Ljava/util/Locale;
+       142: ldc_w         #4238               // String %.2f, %.2f, %.2f
+       145: iconst_3
+       146: anewarray     #5                  // class java/lang/Object
+       149: dup
+       150: iconst_0
+       151: aload_2
+       152: getfield      #932                // Field net/minecraft/world/phys/Vec3.x:D
+       155: invokestatic  #3874               // Method java/lang/Double.valueOf:(D)Ljava/lang/Double;
+       158: aastore
+       159: dup
+       160: iconst_1
+       161: aload_2
+       162: getfield      #934                // Field net/minecraft/world/phys/Vec3.y:D
+       165: invokestatic  #3874               // Method java/lang/Double.valueOf:(D)Ljava/lang/Double;
+       168: aastore
+       169: dup
+       170: iconst_2
+       171: aload_2
+       172: getfield      #936                // Field net/minecraft/world/phys/Vec3.z:D
+       175: invokestatic  #3874               // Method java/lang/Double.valueOf:(D)Ljava/lang/Double;
+       178: aastore
+       179: invokestatic  #3878               // Method java/lang/String.format:(Ljava/util/Locale;Ljava/lang/String;[Ljava/lang/Object;)Ljava/lang/String;
+       182: invokevirtual #4227               // Method net/minecraft/CrashReportCategory.setDetail:(Ljava/lang/String;Ljava/lang/Object;)Lnet/minecraft/CrashReportCategory;
+       185: pop
+       186: aload_1
+       187: ldc_w         #4248               // String Entity\'s Passengers
+       190: aload_0
+       191: invokedynamic #4253,  0           // InvokeDynamic #16:call:(Lnet/minecraft/world/entity/Entity;)Lnet/minecraft/CrashReportDetail;
+       196: invokevirtual #4222               // Method net/minecraft/CrashReportCategory.setDetail:(Ljava/lang/String;Lnet/minecraft/CrashReportDetail;)Lnet/minecraft/CrashReportCategory;
+       199: pop
+       200: aload_1
+       201: ldc_w         #4255               // String Entity\'s Vehicle
+       204: aload_0
+       205: invokedynamic #4260,  0           // InvokeDynamic #17:call:(Lnet/minecraft/world/entity/Entity;)Lnet/minecraft/CrashReportDetail;
+       210: invokevirtual #4222               // Method net/minecraft/CrashReportCategory.setDetail:(Ljava/lang/String;Lnet/minecraft/CrashReportDetail;)Lnet/minecraft/CrashReportCategory;
+       213: pop
+       214: return
+
+  public boolean displayFireAnimation();
+    Code:
+         0: aload_0
+         1: invokevirtual #1590               // Method isOnFire:()Z
+         4: ifeq          18
+         7: aload_0
+         8: invokevirtual #746                // Method isSpectator:()Z
+        11: ifne          18
+        14: iconst_1
+        15: goto          19
+        18: iconst_0
+        19: ireturn
+
+  public void setUUID(java.util.UUID);
+    Code:
+         0: aload_0
+         1: aload_1
+         2: putfield      #504                // Field uuid:Ljava/util/UUID;
+         5: aload_0
+         6: aload_0
+         7: getfield      #504                // Field uuid:Ljava/util/UUID;
+        10: invokevirtual #510                // Method java/util/UUID.toString:()Ljava/lang/String;
+        13: putfield      #512                // Field stringUUID:Ljava/lang/String;
+        16: return
+
+  public java.util.UUID getUUID();
+    Code:
+         0: aload_0
+         1: getfield      #504                // Field uuid:Ljava/util/UUID;
+         4: areturn
+
+  public java.lang.String getStringUUID();
+    Code:
+         0: aload_0
+         1: getfield      #512                // Field stringUUID:Ljava/lang/String;
+         4: areturn
+
+  public java.lang.String getScoreboardName();
+    Code:
+         0: aload_0
+         1: getfield      #512                // Field stringUUID:Ljava/lang/String;
+         4: areturn
+
+  public boolean isPushedByFluid();
+    Code:
+         0: iconst_1
+         1: ireturn
+
+  public static double getViewScale();
+    Code:
+         0: getstatic     #2709               // Field viewScale:D
+         3: dreturn
+
+  public static void setViewScale(double);
+    Code:
+         0: dload_0
+         1: putstatic     #2709               // Field viewScale:D
+         4: return
+
+  public net.minecraft.network.chat.Component getDisplayName();
+    Code:
+         0: aload_0
+         1: invokevirtual #715                // Method getTeam:()Lnet/minecraft/world/scores/PlayerTeam;
+         4: aload_0
+         5: invokevirtual #4269               // Method getName:()Lnet/minecraft/network/chat/Component;
+         8: invokestatic  #4273               // Method net/minecraft/world/scores/PlayerTeam.formatNameForTeam:(Lnet/minecraft/world/scores/Team;Lnet/minecraft/network/chat/Component;)Lnet/minecraft/network/chat/MutableComponent;
+        11: aload_0
+        12: invokedynamic #4282,  0           // InvokeDynamic #18:apply:(Lnet/minecraft/world/entity/Entity;)Ljava/util/function/UnaryOperator;
+        17: invokevirtual #4286               // Method net/minecraft/network/chat/MutableComponent.withStyle:(Ljava/util/function/UnaryOperator;)Lnet/minecraft/network/chat/MutableComponent;
+        20: areturn
+
+  public void setCustomName(net.minecraft.network.chat.Component);
+    Code:
+         0: aload_0
+         1: getfield      #651                // Field entityData:Lnet/minecraft/network/syncher/SynchedEntityData;
+         4: getstatic     #627                // Field DATA_CUSTOM_NAME:Lnet/minecraft/network/syncher/EntityDataAccessor;
+         7: aload_1
+         8: invokestatic  #4290               // Method java/util/Optional.ofNullable:(Ljava/lang/Object;)Ljava/util/Optional;
+        11: invokevirtual #854                // Method net/minecraft/network/syncher/SynchedEntityData.set:(Lnet/minecraft/network/syncher/EntityDataAccessor;Ljava/lang/Object;)V
+        14: return
+
+  public net.minecraft.network.chat.Component getCustomName();
+    Code:
+         0: aload_0
+         1: getfield      #651                // Field entityData:Lnet/minecraft/network/syncher/SynchedEntityData;
+         4: getstatic     #627                // Field DATA_CUSTOM_NAME:Lnet/minecraft/network/syncher/EntityDataAccessor;
+         7: invokevirtual #859                // Method net/minecraft/network/syncher/SynchedEntityData.get:(Lnet/minecraft/network/syncher/EntityDataAccessor;)Ljava/lang/Object;
+        10: checkcast     #524                // class java/util/Optional
+        13: aconst_null
+        14: invokevirtual #2285               // Method java/util/Optional.orElse:(Ljava/lang/Object;)Ljava/lang/Object;
+        17: checkcast     #2934               // class net/minecraft/network/chat/Component
+        20: areturn
+
+  public boolean hasCustomName();
+    Code:
+         0: aload_0
+         1: getfield      #651                // Field entityData:Lnet/minecraft/network/syncher/SynchedEntityData;
+         4: getstatic     #627                // Field DATA_CUSTOM_NAME:Lnet/minecraft/network/syncher/EntityDataAccessor;
+         7: invokevirtual #859                // Method net/minecraft/network/syncher/SynchedEntityData.get:(Lnet/minecraft/network/syncher/EntityDataAccessor;)Ljava/lang/Object;
+        10: checkcast     #524                // class java/util/Optional
+        13: invokevirtual #724                // Method java/util/Optional.isPresent:()Z
+        16: ireturn
+
+  public void setCustomNameVisible(boolean);
+    Code:
+         0: aload_0
+         1: getfield      #651                // Field entityData:Lnet/minecraft/network/syncher/SynchedEntityData;
+         4: getstatic     #620                // Field DATA_CUSTOM_NAME_VISIBLE:Lnet/minecraft/network/syncher/EntityDataAccessor;
+         7: iload_1
+         8: invokestatic  #625                // Method java/lang/Boolean.valueOf:(Z)Ljava/lang/Boolean;
+        11: invokevirtual #854                // Method net/minecraft/network/syncher/SynchedEntityData.set:(Lnet/minecraft/network/syncher/EntityDataAccessor;Ljava/lang/Object;)V
+        14: return
+
+  public boolean isCustomNameVisible();
+    Code:
+         0: aload_0
+         1: getfield      #651                // Field entityData:Lnet/minecraft/network/syncher/SynchedEntityData;
+         4: getstatic     #620                // Field DATA_CUSTOM_NAME_VISIBLE:Lnet/minecraft/network/syncher/EntityDataAccessor;
+         7: invokevirtual #859                // Method net/minecraft/network/syncher/SynchedEntityData.get:(Lnet/minecraft/network/syncher/EntityDataAccessor;)Ljava/lang/Object;
+        10: checkcast     #622                // class java/lang/Boolean
+        13: invokevirtual #2236               // Method java/lang/Boolean.booleanValue:()Z
+        16: ireturn
+
+  public net.minecraft.network.chat.Component belowNameDisplay();
+    Code:
+         0: aload_0
+         1: invokevirtual #672                // Method level:()Lnet/minecraft/world/level/Level;
+         4: invokevirtual #3653               // Method net/minecraft/world/level/Level.getScoreboard:()Lnet/minecraft/world/scores/Scoreboard;
+         7: astore_1
+         8: aload_1
+         9: getstatic     #4299               // Field net/minecraft/world/scores/DisplaySlot.BELOW_NAME:Lnet/minecraft/world/scores/DisplaySlot;
+        12: invokevirtual #4303               // Method net/minecraft/world/scores/Scoreboard.getDisplayObjective:(Lnet/minecraft/world/scores/DisplaySlot;)Lnet/minecraft/world/scores/Objective;
+        15: astore_2
+        16: aload_2
+        17: ifnull        68
+        20: aload_1
+        21: aload_0
+        22: aload_2
+        23: invokevirtual #4307               // Method net/minecraft/world/scores/Scoreboard.getPlayerScoreInfo:(Lnet/minecraft/world/scores/ScoreHolder;Lnet/minecraft/world/scores/Objective;)Lnet/minecraft/world/scores/ReadOnlyScoreInfo;
+        26: astore_3
+        27: aload_3
+        28: ifnull        68
+        31: aload_3
+        32: aload_2
+        33: getstatic     #4313               // Field net/minecraft/network/chat/numbers/StyledFormat.NO_STYLE:Lnet/minecraft/network/chat/numbers/StyledFormat;
+        36: invokevirtual #4319               // Method net/minecraft/world/scores/Objective.numberFormatOrDefault:(Lnet/minecraft/network/chat/numbers/NumberFormat;)Lnet/minecraft/network/chat/numbers/NumberFormat;
+        39: invokeinterface #4325,  2         // InterfaceMethod net/minecraft/world/scores/ReadOnlyScoreInfo.formatValue:(Lnet/minecraft/network/chat/numbers/NumberFormat;)Lnet/minecraft/network/chat/MutableComponent;
+        44: astore        4
+        46: invokestatic  #4327               // InterfaceMethod net/minecraft/network/chat/Component.empty:()Lnet/minecraft/network/chat/MutableComponent;
+        49: aload         4
+        51: invokevirtual #3832               // Method net/minecraft/network/chat/MutableComponent.append:(Lnet/minecraft/network/chat/Component;)Lnet/minecraft/network/chat/MutableComponent;
+        54: getstatic     #4332               // Field net/minecraft/network/chat/CommonComponents.SPACE:Lnet/minecraft/network/chat/Component;
+        57: invokevirtual #3832               // Method net/minecraft/network/chat/MutableComponent.append:(Lnet/minecraft/network/chat/Component;)Lnet/minecraft/network/chat/MutableComponent;
+        60: aload_2
+        61: invokevirtual #4334               // Method net/minecraft/world/scores/Objective.getDisplayName:()Lnet/minecraft/network/chat/Component;
+        64: invokevirtual #3832               // Method net/minecraft/network/chat/MutableComponent.append:(Lnet/minecraft/network/chat/Component;)Lnet/minecraft/network/chat/MutableComponent;
+        67: areturn
+        68: aconst_null
+        69: areturn
+
+  public boolean teleportTo(net.minecraft.server.level.ServerLevel, double, double, double, java.util.Set<net.minecraft.world.entity.Relative>, float, float, boolean);
+    Code:
+         0: aload_0
+         1: new           #143                // class net/minecraft/world/level/portal/TeleportTransition
+         4: dup
+         5: aload_1
+         6: new           #440                // class net/minecraft/world/phys/Vec3
+         9: dup
+        10: dload_2
+        11: dload         4
+        13: dload         6
+        15: invokespecial #765                // Method net/minecraft/world/phys/Vec3."<init>":(DDD)V
+        18: getstatic     #443                // Field net/minecraft/world/phys/Vec3.ZERO:Lnet/minecraft/world/phys/Vec3;
+        21: fload         9
+        23: fload         10
+        25: aload         8
+        27: getstatic     #4351               // Field net/minecraft/world/level/portal/TeleportTransition.DO_NOTHING:Lnet/minecraft/world/level/portal/TeleportTransition$PostTeleportTransition;
+        30: invokespecial #4354               // Method net/minecraft/world/level/portal/TeleportTransition."<init>":(Lnet/minecraft/server/level/ServerLevel;Lnet/minecraft/world/phys/Vec3;Lnet/minecraft/world/phys/Vec3;FFLjava/util/Set;Lnet/minecraft/world/level/portal/TeleportTransition$PostTeleportTransition;)V
+        33: invokevirtual #3581               // Method teleport:(Lnet/minecraft/world/level/portal/TeleportTransition;)Lnet/minecraft/world/entity/Entity;
+        36: astore        12
+        38: aload         12
+        40: ifnull        47
+        43: iconst_1
+        44: goto          48
+        47: iconst_0
+        48: ireturn
+
+  public void dismountTo(double, double, double);
+    Code:
+         0: aload_0
+         1: dload_1
+         2: dload_3
+         3: dload         5
+         5: invokevirtual #4357               // Method teleportTo:(DDD)V
+         8: return
+
+  public void teleportTo(double, double, double);
+    Code:
+         0: aload_0
+         1: invokevirtual #672                // Method level:()Lnet/minecraft/world/level/Level;
+         4: instanceof    #1016               // class net/minecraft/server/level/ServerLevel
+         7: ifne          11
+        10: return
+        11: aload_0
+        12: dload_1
+        13: dload_3
+        14: dload         5
+        16: aload_0
+        17: invokevirtual #945                // Method getYRot:()F
+        20: aload_0
+        21: invokevirtual #942                // Method getXRot:()F
+        24: invokevirtual #2520               // Method snapTo:(DDDFF)V
+        27: aload_0
+        28: invokevirtual #4360               // Method teleportPassengers:()V
+        31: return
+
+  private void teleportPassengers();
+    Code:
+         0: aload_0
+         1: invokevirtual #4363               // Method getSelfAndPassengers:()Ljava/util/stream/Stream;
+         4: invokedynamic #4368,  0           // InvokeDynamic #19:accept:()Ljava/util/function/Consumer;
+         9: invokeinterface #3355,  2         // InterfaceMethod java/util/stream/Stream.forEach:(Ljava/util/function/Consumer;)V
+        14: return
+
+  public void teleportRelative(double, double, double);
+    Code:
+         0: aload_0
+         1: aload_0
+         2: invokevirtual #880                // Method getX:()D
+         5: dload_1
+         6: dadd
+         7: aload_0
+         8: invokevirtual #883                // Method getY:()D
+        11: dload_3
+        12: dadd
+        13: aload_0
+        14: invokevirtual #886                // Method getZ:()D
+        17: dload         5
+        19: dadd
+        20: invokevirtual #4357               // Method teleportTo:(DDD)V
+        23: return
+
+  public boolean shouldShowName();
+    Code:
+         0: aload_0
+         1: invokevirtual #2789               // Method isCustomNameVisible:()Z
+         4: ireturn
+
+  public void onSyncedDataUpdated(java.util.List<net.minecraft.network.syncher.SynchedEntityData$DataValue<?>>);
+    Code:
+         0: return
+
+  public void onSyncedDataUpdated(net.minecraft.network.syncher.EntityDataAccessor<?>);
+    Code:
+         0: getstatic     #633                // Field DATA_POSE:Lnet/minecraft/network/syncher/EntityDataAccessor;
+         3: aload_1
+         4: invokevirtual #4380               // Method net/minecraft/network/syncher/EntityDataAccessor.equals:(Ljava/lang/Object;)Z
+         7: ifeq          14
+        10: aload_0
+        11: invokevirtual #4383               // Method refreshDimensions:()V
+        14: return
+
+  protected void fixupDimensions();
+    Code:
+         0: aload_0
+         1: invokevirtual #863                // Method getPose:()Lnet/minecraft/world/entity/Pose;
+         4: astore_1
+         5: aload_0
+         6: aload_1
+         7: invokevirtual #4174               // Method getDimensions:(Lnet/minecraft/world/entity/Pose;)Lnet/minecraft/world/entity/EntityDimensions;
+        10: astore_2
+        11: aload_0
+        12: aload_2
+        13: putfield      #581                // Field dimensions:Lnet/minecraft/world/entity/EntityDimensions;
+        16: aload_0
+        17: aload_2
+        18: invokevirtual #660                // Method net/minecraft/world/entity/EntityDimensions.eyeHeight:()F
+        21: putfield      #662                // Field eyeHeight:F
+        24: return
+
+  public void refreshDimensions();
+    Code:
+         0: aload_0
+         1: getfield      #581                // Field dimensions:Lnet/minecraft/world/entity/EntityDimensions;
+         4: astore_1
+         5: aload_0
+         6: invokevirtual #863                // Method getPose:()Lnet/minecraft/world/entity/Pose;
+         9: astore_2
+        10: aload_0
+        11: aload_2
+        12: invokevirtual #4174               // Method getDimensions:(Lnet/minecraft/world/entity/Pose;)Lnet/minecraft/world/entity/EntityDimensions;
+        15: astore_3
+        16: aload_0
+        17: aload_3
+        18: putfield      #581                // Field dimensions:Lnet/minecraft/world/entity/EntityDimensions;
+        21: aload_0
+        22: aload_3
+        23: invokevirtual #660                // Method net/minecraft/world/entity/EntityDimensions.eyeHeight:()F
+        26: putfield      #662                // Field eyeHeight:F
+        29: aload_0
+        30: invokevirtual #2532               // Method reapplyPosition:()V
+        33: aload_3
+        34: invokevirtual #2410               // Method net/minecraft/world/entity/EntityDimensions.width:()F
+        37: ldc_w         #1107               // float 4.0f
+        40: fcmpg
+        41: ifgt          59
+        44: aload_3
+        45: invokevirtual #4389               // Method net/minecraft/world/entity/EntityDimensions.height:()F
+        48: ldc_w         #1107               // float 4.0f
+        51: fcmpg
+        52: ifgt          59
+        55: iconst_1
+        56: goto          60
+        59: iconst_0
+        60: istore        4
+        62: aload_0
+        63: getfield      #567                // Field level:Lnet/minecraft/world/level/Level;
+        66: invokevirtual #1054               // Method net/minecraft/world/level/Level.isClientSide:()Z
+        69: ifne          128
+        72: aload_0
+        73: getfield      #484                // Field firstTick:Z
+        76: ifne          128
+        79: aload_0
+        80: getfield      #1231               // Field noPhysics:Z
+        83: ifne          128
+        86: iload         4
+        88: ifeq          128
+        91: aload_3
+        92: invokevirtual #2410               // Method net/minecraft/world/entity/EntityDimensions.width:()F
+        95: aload_1
+        96: invokevirtual #2410               // Method net/minecraft/world/entity/EntityDimensions.width:()F
+        99: fcmpl
+       100: ifgt          115
+       103: aload_3
+       104: invokevirtual #4389               // Method net/minecraft/world/entity/EntityDimensions.height:()F
+       107: aload_1
+       108: invokevirtual #4389               // Method net/minecraft/world/entity/EntityDimensions.height:()F
+       111: fcmpl
+       112: ifle          128
+       115: aload_0
+       116: instanceof    #3076               // class net/minecraft/world/entity/player/Player
+       119: ifne          128
+       122: aload_0
+       123: aload_1
+       124: invokevirtual #4393               // Method fudgePositionAfterSizeChange:(Lnet/minecraft/world/entity/EntityDimensions;)Z
+       127: pop
+       128: return
+
+  public boolean fudgePositionAfterSizeChange(net.minecraft.world.entity.EntityDimensions);
+    Code:
+         0: aload_0
+         1: aload_0
+         2: invokevirtual #863                // Method getPose:()Lnet/minecraft/world/entity/Pose;
+         5: invokevirtual #4174               // Method getDimensions:(Lnet/minecraft/world/entity/Pose;)Lnet/minecraft/world/entity/EntityDimensions;
+         8: astore_2
+         9: aload_0
+        10: invokevirtual #870                // Method position:()Lnet/minecraft/world/phys/Vec3;
+        13: dconst_0
+        14: aload_1
+        15: invokevirtual #4389               // Method net/minecraft/world/entity/EntityDimensions.height:()F
+        18: f2d
+        19: ldc2_w        #2414               // double 2.0d
+        22: ddiv
+        23: dconst_0
+        24: invokevirtual #2249               // Method net/minecraft/world/phys/Vec3.add:(DDD)Lnet/minecraft/world/phys/Vec3;
+        27: astore_3
+        28: fconst_0
+        29: aload_2
+        30: invokevirtual #2410               // Method net/minecraft/world/entity/EntityDimensions.width:()F
+        33: aload_1
+        34: invokevirtual #2410               // Method net/minecraft/world/entity/EntityDimensions.width:()F
+        37: fsub
+        38: invokestatic  #4398               // Method java/lang/Math.max:(FF)F
+        41: f2d
+        42: ldc2_w        #1202               // double 1.0E-6d
+        45: dadd
+        46: dstore        4
+        48: fconst_0
+        49: aload_2
+        50: invokevirtual #4389               // Method net/minecraft/world/entity/EntityDimensions.height:()F
+        53: aload_1
+        54: invokevirtual #4389               // Method net/minecraft/world/entity/EntityDimensions.height:()F
+        57: fsub
+        58: invokestatic  #4398               // Method java/lang/Math.max:(FF)F
+        61: f2d
+        62: ldc2_w        #1202               // double 1.0E-6d
+        65: dadd
+        66: dstore        6
+        68: aload_3
+        69: dload         4
+        71: dload         6
+        73: dload         4
+        75: invokestatic  #3047               // Method net/minecraft/world/phys/AABB.ofSize:(Lnet/minecraft/world/phys/Vec3;DDD)Lnet/minecraft/world/phys/AABB;
+        78: invokestatic  #698                // Method net/minecraft/world/phys/shapes/Shapes.create:(Lnet/minecraft/world/phys/AABB;)Lnet/minecraft/world/phys/shapes/VoxelShape;
+        81: astore        8
+        83: aload_0
+        84: getfield      #567                // Field level:Lnet/minecraft/world/level/Level;
+        87: aload_0
+        88: aload         8
+        90: aload_3
+        91: aload_2
+        92: invokevirtual #2410               // Method net/minecraft/world/entity/EntityDimensions.width:()F
+        95: f2d
+        96: aload_2
+        97: invokevirtual #4389               // Method net/minecraft/world/entity/EntityDimensions.height:()F
+       100: f2d
+       101: aload_2
+       102: invokevirtual #2410               // Method net/minecraft/world/entity/EntityDimensions.width:()F
+       105: f2d
+       106: invokevirtual #4402               // Method net/minecraft/world/level/Level.findFreePosition:(Lnet/minecraft/world/entity/Entity;Lnet/minecraft/world/phys/shapes/VoxelShape;Lnet/minecraft/world/phys/Vec3;DDD)Ljava/util/Optional;
+       109: astore        9
+       111: aload         9
+       113: invokevirtual #724                // Method java/util/Optional.isPresent:()Z
+       116: ifeq          148
+       119: aload_0
+       120: aload         9
+       122: invokevirtual #728                // Method java/util/Optional.get:()Ljava/lang/Object;
+       125: checkcast     #440                // class net/minecraft/world/phys/Vec3
+       128: dconst_0
+       129: aload_2
+       130: invokevirtual #4389               // Method net/minecraft/world/entity/EntityDimensions.height:()F
+       133: fneg
+       134: f2d
+       135: ldc2_w        #2414               // double 2.0d
+       138: ddiv
+       139: dconst_0
+       140: invokevirtual #2249               // Method net/minecraft/world/phys/Vec3.add:(DDD)Lnet/minecraft/world/phys/Vec3;
+       143: invokevirtual #1315               // Method setPos:(Lnet/minecraft/world/phys/Vec3;)V
+       146: iconst_1
+       147: ireturn
+       148: aload_2
+       149: invokevirtual #2410               // Method net/minecraft/world/entity/EntityDimensions.width:()F
+       152: aload_1
+       153: invokevirtual #2410               // Method net/minecraft/world/entity/EntityDimensions.width:()F
+       156: fcmpl
+       157: ifle          257
+       160: aload_2
+       161: invokevirtual #4389               // Method net/minecraft/world/entity/EntityDimensions.height:()F
+       164: aload_1
+       165: invokevirtual #4389               // Method net/minecraft/world/entity/EntityDimensions.height:()F
+       168: fcmpl
+       169: ifle          257
+       172: aload_3
+       173: dload         4
+       175: ldc2_w        #1202               // double 1.0E-6d
+       178: dload         4
+       180: invokestatic  #3047               // Method net/minecraft/world/phys/AABB.ofSize:(Lnet/minecraft/world/phys/Vec3;DDD)Lnet/minecraft/world/phys/AABB;
+       183: invokestatic  #698                // Method net/minecraft/world/phys/shapes/Shapes.create:(Lnet/minecraft/world/phys/AABB;)Lnet/minecraft/world/phys/shapes/VoxelShape;
+       186: astore        10
+       188: aload_0
+       189: getfield      #567                // Field level:Lnet/minecraft/world/level/Level;
+       192: aload_0
+       193: aload         10
+       195: aload_3
+       196: aload_2
+       197: invokevirtual #2410               // Method net/minecraft/world/entity/EntityDimensions.width:()F
+       200: f2d
+       201: aload_1
+       202: invokevirtual #4389               // Method net/minecraft/world/entity/EntityDimensions.height:()F
+       205: f2d
+       206: aload_2
+       207: invokevirtual #2410               // Method net/minecraft/world/entity/EntityDimensions.width:()F
+       210: f2d
+       211: invokevirtual #4402               // Method net/minecraft/world/level/Level.findFreePosition:(Lnet/minecraft/world/entity/Entity;Lnet/minecraft/world/phys/shapes/VoxelShape;Lnet/minecraft/world/phys/Vec3;DDD)Ljava/util/Optional;
+       214: astore        11
+       216: aload         11
+       218: invokevirtual #724                // Method java/util/Optional.isPresent:()Z
+       221: ifeq          257
+       224: aload_0
+       225: aload         11
+       227: invokevirtual #728                // Method java/util/Optional.get:()Ljava/lang/Object;
+       230: checkcast     #440                // class net/minecraft/world/phys/Vec3
+       233: dconst_0
+       234: aload_1
+       235: invokevirtual #4389               // Method net/minecraft/world/entity/EntityDimensions.height:()F
+       238: fneg
+       239: f2d
+       240: ldc2_w        #2414               // double 2.0d
+       243: ddiv
+       244: ldc2_w        #1202               // double 1.0E-6d
+       247: dadd
+       248: dconst_0
+       249: invokevirtual #2249               // Method net/minecraft/world/phys/Vec3.add:(DDD)Lnet/minecraft/world/phys/Vec3;
+       252: invokevirtual #1315               // Method setPos:(Lnet/minecraft/world/phys/Vec3;)V
+       255: iconst_1
+       256: ireturn
+       257: iconst_0
+       258: ireturn
+
+  public net.minecraft.core.Direction getDirection();
+    Code:
+         0: aload_0
+         1: invokevirtual #945                // Method getYRot:()F
+         4: f2d
+         5: invokestatic  #4415               // Method net/minecraft/core/Direction.fromYRot:(D)Lnet/minecraft/core/Direction;
+         8: areturn
+
+  public net.minecraft.core.Direction getMotionDirection();
+    Code:
+         0: aload_0
+         1: invokevirtual #4418               // Method getDirection:()Lnet/minecraft/core/Direction;
+         4: areturn
+
+  protected net.minecraft.network.chat.HoverEvent createHoverEvent();
+    Code:
+         0: new           #151                // class net/minecraft/network/chat/HoverEvent$ShowEntity
+         3: dup
+         4: new           #156                // class net/minecraft/network/chat/HoverEvent$EntityTooltipInfo
+         7: dup
+         8: aload_0
+         9: invokevirtual #2287               // Method getType:()Lnet/minecraft/world/entity/EntityType;
+        12: aload_0
+        13: invokevirtual #2776               // Method getUUID:()Ljava/util/UUID;
+        16: aload_0
+        17: invokevirtual #4269               // Method getName:()Lnet/minecraft/network/chat/Component;
+        20: invokespecial #4423               // Method net/minecraft/network/chat/HoverEvent$EntityTooltipInfo."<init>":(Lnet/minecraft/world/entity/EntityType;Ljava/util/UUID;Lnet/minecraft/network/chat/Component;)V
+        23: invokespecial #4426               // Method net/minecraft/network/chat/HoverEvent$ShowEntity."<init>":(Lnet/minecraft/network/chat/HoverEvent$EntityTooltipInfo;)V
+        26: areturn
+
+  public boolean broadcastToPlayer(net.minecraft.server.level.ServerPlayer);
+    Code:
+         0: iconst_1
+         1: ireturn
+
+  public final net.minecraft.world.phys.AABB getBoundingBox();
+    Code:
+         0: aload_0
+         1: getfield      #449                // Field bb:Lnet/minecraft/world/phys/AABB;
+         4: areturn
+
+  public final void setBoundingBox(net.minecraft.world.phys.AABB);
+    Code:
+         0: aload_0
+         1: aload_1
+         2: putfield      #449                // Field bb:Lnet/minecraft/world/phys/AABB;
+         5: return
+
+  public final float getEyeHeight(net.minecraft.world.entity.Pose);
+    Code:
+         0: aload_0
+         1: aload_1
+         2: invokevirtual #4174               // Method getDimensions:(Lnet/minecraft/world/entity/Pose;)Lnet/minecraft/world/entity/EntityDimensions;
+         5: invokevirtual #660                // Method net/minecraft/world/entity/EntityDimensions.eyeHeight:()F
+         8: freturn
+
+  public final float getEyeHeight();
+    Code:
+         0: aload_0
+         1: getfield      #662                // Field eyeHeight:F
+         4: freturn
+
+  public net.minecraft.world.entity.SlotAccess getSlot(int);
+    Code:
+         0: aconst_null
+         1: areturn
+
+  public boolean ignoreExplosion(net.minecraft.world.level.Explosion);
+    Code:
+         0: iconst_0
+         1: ireturn
+
+  public void startSeenByPlayer(net.minecraft.server.level.ServerPlayer);
+    Code:
+         0: return
+
+  public void stopSeenByPlayer(net.minecraft.server.level.ServerPlayer);
+    Code:
+         0: return
+
+  public float rotate(net.minecraft.world.level.block.Rotation);
+    Code:
+         0: aload_0
+         1: invokevirtual #945                // Method getYRot:()F
+         4: invokestatic  #4442               // Method net/minecraft/util/Mth.wrapDegrees:(F)F
+         7: fstore_2
+         8: getstatic     #4446               // Field net/minecraft/world/entity/Entity$1.$SwitchMap$net$minecraft$world$level$block$Rotation:[I
+        11: aload_1
+        12: invokevirtual #4449               // Method net/minecraft/world/level/block/Rotation.ordinal:()I
+        15: iaload
+        16: tableswitch   { // 1 to 3
+                       1: 44
+                       2: 52
+                       3: 60
+                 default: 68
+            }
+        44: fload_2
+        45: ldc_w         #4450               // float 180.0f
+        48: fadd
+        49: goto          69
+        52: fload_2
+        53: ldc_w         #4451               // float 270.0f
+        56: fadd
+        57: goto          69
+        60: fload_2
+        61: ldc_w         #947                // float 90.0f
+        64: fadd
+        65: goto          69
+        68: fload_2
+        69: freturn
+
+  public float mirror(net.minecraft.world.level.block.Mirror);
+    Code:
+         0: aload_0
+         1: invokevirtual #945                // Method getYRot:()F
+         4: invokestatic  #4442               // Method net/minecraft/util/Mth.wrapDegrees:(F)F
+         7: fstore_2
+         8: getstatic     #4458               // Field net/minecraft/world/entity/Entity$1.$SwitchMap$net$minecraft$world$level$block$Mirror:[I
+        11: aload_1
+        12: invokevirtual #4461               // Method net/minecraft/world/level/block/Mirror.ordinal:()I
+        15: iaload
+        16: lookupswitch  { // 2
+                       1: 44
+                       2: 49
+                 default: 57
+            }
+        44: fload_2
+        45: fneg
+        46: goto          58
+        49: ldc_w         #4450               // float 180.0f
+        52: fload_2
+        53: fsub
+        54: goto          58
+        57: fload_2
+        58: freturn
+
+  public net.minecraft.world.entity.projectile.ProjectileDeflection deflection(net.minecraft.world.entity.projectile.Projectile);
+    Code:
+         0: aload_0
+         1: getstatic     #4468               // Field net/minecraft/tags/EntityTypeTags.DEFLECTS_PROJECTILES:Lnet/minecraft/tags/TagKey;
+         4: invokevirtual #2298               // Method is:(Lnet/minecraft/tags/TagKey;)Z
+         7: ifeq          16
+        10: getstatic     #4474               // Field net/minecraft/world/entity/projectile/ProjectileDeflection.REVERSE:Lnet/minecraft/world/entity/projectile/ProjectileDeflection;
+        13: goto          19
+        16: getstatic     #4476               // Field net/minecraft/world/entity/projectile/ProjectileDeflection.NONE:Lnet/minecraft/world/entity/projectile/ProjectileDeflection;
+        19: areturn
+
+  public net.minecraft.world.entity.LivingEntity getControllingPassenger();
+    Code:
+         0: aconst_null
+         1: areturn
+
+  public final boolean hasControllingPassenger();
+    Code:
+         0: aload_0
+         1: invokevirtual #2141               // Method getControllingPassenger:()Lnet/minecraft/world/entity/LivingEntity;
+         4: ifnull        11
+         7: iconst_1
+         8: goto          12
+        11: iconst_0
+        12: ireturn
+
+  public final java.util.List<net.minecraft.world.entity.Entity> getPassengers();
+    Code:
+         0: aload_0
+         1: getfield      #438                // Field passengers:Lcom/google/common/collect/ImmutableList;
+         4: areturn
+
+  public net.minecraft.world.entity.Entity getFirstPassenger();
+    Code:
+         0: aload_0
+         1: getfield      #438                // Field passengers:Lcom/google/common/collect/ImmutableList;
+         4: invokevirtual #3383               // Method com/google/common/collect/ImmutableList.isEmpty:()Z
+         7: ifeq          14
+        10: aconst_null
+        11: goto          25
+        14: aload_0
+        15: getfield      #438                // Field passengers:Lcom/google/common/collect/ImmutableList;
+        18: iconst_0
+        19: invokevirtual #3363               // Method com/google/common/collect/ImmutableList.get:(I)Ljava/lang/Object;
+        22: checkcast     #2                  // class net/minecraft/world/entity/Entity
+        25: areturn
+
+  public boolean hasPassenger(net.minecraft.world.entity.Entity);
+    Code:
+         0: aload_0
+         1: getfield      #438                // Field passengers:Lcom/google/common/collect/ImmutableList;
+         4: aload_1
+         5: invokevirtual #4480               // Method com/google/common/collect/ImmutableList.contains:(Ljava/lang/Object;)Z
+         8: ireturn
+
+  public boolean hasPassenger(java.util.function.Predicate<net.minecraft.world.entity.Entity>);
+    Code:
+         0: aload_0
+         1: getfield      #438                // Field passengers:Lcom/google/common/collect/ImmutableList;
+         4: invokevirtual #1923               // Method com/google/common/collect/ImmutableList.iterator:()Lcom/google/common/collect/UnmodifiableIterator;
+         7: astore_2
+         8: aload_2
+         9: invokeinterface #1827,  1         // InterfaceMethod java/util/Iterator.hasNext:()Z
+        14: ifeq          42
+        17: aload_2
+        18: invokeinterface #1830,  1         // InterfaceMethod java/util/Iterator.next:()Ljava/lang/Object;
+        23: checkcast     #2                  // class net/minecraft/world/entity/Entity
+        26: astore_3
+        27: aload_1
+        28: aload_3
+        29: invokeinterface #4485,  2         // InterfaceMethod java/util/function/Predicate.test:(Ljava/lang/Object;)Z
+        34: ifeq          39
+        37: iconst_1
+        38: ireturn
+        39: goto          8
+        42: iconst_0
+        43: ireturn
+
+  private java.util.stream.Stream<net.minecraft.world.entity.Entity> getIndirectPassengersStream();
+    Code:
+         0: aload_0
+         1: getfield      #438                // Field passengers:Lcom/google/common/collect/ImmutableList;
+         4: invokevirtual #3408               // Method com/google/common/collect/ImmutableList.stream:()Ljava/util/stream/Stream;
+         7: invokedynamic #4494,  0           // InvokeDynamic #20:apply:()Ljava/util/function/Function;
+        12: invokeinterface #4498,  2         // InterfaceMethod java/util/stream/Stream.flatMap:(Ljava/util/function/Function;)Ljava/util/stream/Stream;
+        17: areturn
+
+  public java.util.stream.Stream<net.minecraft.world.entity.Entity> getSelfAndPassengers();
+    Code:
+         0: aload_0
+         1: invokestatic  #4501               // InterfaceMethod java/util/stream/Stream.of:(Ljava/lang/Object;)Ljava/util/stream/Stream;
+         4: aload_0
+         5: invokevirtual #3332               // Method getIndirectPassengersStream:()Ljava/util/stream/Stream;
+         8: invokestatic  #4505               // InterfaceMethod java/util/stream/Stream.concat:(Ljava/util/stream/Stream;Ljava/util/stream/Stream;)Ljava/util/stream/Stream;
+        11: areturn
+
+  public java.util.stream.Stream<net.minecraft.world.entity.Entity> getPassengersAndSelf();
+    Code:
+         0: aload_0
+         1: getfield      #438                // Field passengers:Lcom/google/common/collect/ImmutableList;
+         4: invokevirtual #3408               // Method com/google/common/collect/ImmutableList.stream:()Ljava/util/stream/Stream;
+         7: invokedynamic #4510,  0           // InvokeDynamic #21:apply:()Ljava/util/function/Function;
+        12: invokeinterface #4498,  2         // InterfaceMethod java/util/stream/Stream.flatMap:(Ljava/util/function/Function;)Ljava/util/stream/Stream;
+        17: aload_0
+        18: invokestatic  #4501               // InterfaceMethod java/util/stream/Stream.of:(Ljava/lang/Object;)Ljava/util/stream/Stream;
+        21: invokestatic  #4505               // InterfaceMethod java/util/stream/Stream.concat:(Ljava/util/stream/Stream;Ljava/util/stream/Stream;)Ljava/util/stream/Stream;
+        24: areturn
+
+  public java.lang.Iterable<net.minecraft.world.entity.Entity> getIndirectPassengers();
+    Code:
+         0: aload_0
+         1: invokedynamic #4519,  0           // InvokeDynamic #22:iterator:(Lnet/minecraft/world/entity/Entity;)Ljava/lang/Iterable;
+         6: areturn
+
+  public int countPlayerPassengers();
+    Code:
+         0: aload_0
+         1: invokevirtual #3332               // Method getIndirectPassengersStream:()Ljava/util/stream/Stream;
+         4: invokedynamic #4525,  0           // InvokeDynamic #23:test:()Ljava/util/function/Predicate;
+         9: invokeinterface #3344,  2         // InterfaceMethod java/util/stream/Stream.filter:(Ljava/util/function/Predicate;)Ljava/util/stream/Stream;
+        14: invokeinterface #4528,  1         // InterfaceMethod java/util/stream/Stream.count:()J
+        19: l2i
+        20: ireturn
+
+  public boolean hasExactlyOnePlayerPassenger();
+    Code:
+         0: aload_0
+         1: invokevirtual #4531               // Method countPlayerPassengers:()I
+         4: iconst_1
+         5: if_icmpne     12
+         8: iconst_1
+         9: goto          13
+        12: iconst_0
+        13: ireturn
+
+  public net.minecraft.world.entity.Entity getRootVehicle();
+    Code:
+         0: aload_0
+         1: astore_1
+         2: aload_1
+         3: invokevirtual #756                // Method isPassenger:()Z
+         6: ifeq          17
+         9: aload_1
+        10: invokevirtual #987                // Method getVehicle:()Lnet/minecraft/world/entity/Entity;
+        13: astore_1
+        14: goto          2
+        17: aload_1
+        18: areturn
+
+  public boolean isPassengerOfSameVehicle(net.minecraft.world.entity.Entity);
+    Code:
+         0: aload_0
+         1: invokevirtual #4534               // Method getRootVehicle:()Lnet/minecraft/world/entity/Entity;
+         4: aload_1
+         5: invokevirtual #4534               // Method getRootVehicle:()Lnet/minecraft/world/entity/Entity;
+         8: if_acmpne     15
+        11: iconst_1
+        12: goto          16
+        15: iconst_0
+        16: ireturn
+
+  public boolean hasIndirectPassenger(net.minecraft.world.entity.Entity);
+    Code:
+         0: aload_1
+         1: invokevirtual #756                // Method isPassenger:()Z
+         4: ifne          9
+         7: iconst_0
+         8: ireturn
+         9: aload_1
+        10: invokevirtual #987                // Method getVehicle:()Lnet/minecraft/world/entity/Entity;
+        13: astore_2
+        14: aload_2
+        15: aload_0
+        16: if_acmpne     21
+        19: iconst_1
+        20: ireturn
+        21: aload_0
+        22: aload_2
+        23: invokevirtual #4537               // Method hasIndirectPassenger:(Lnet/minecraft/world/entity/Entity;)Z
+        26: ireturn
+
+  public final boolean isLocalInstanceAuthoritative();
+    Code:
+         0: aload_0
+         1: getfield      #567                // Field level:Lnet/minecraft/world/level/Level;
+         4: invokevirtual #1054               // Method net/minecraft/world/level/Level.isClientSide:()Z
+         7: ifeq          15
+        10: aload_0
+        11: invokevirtual #4541               // Method isLocalClientAuthoritative:()Z
+        14: ireturn
+        15: aload_0
+        16: invokevirtual #4544               // Method isClientAuthoritative:()Z
+        19: ifne          26
+        22: iconst_1
+        23: goto          27
+        26: iconst_0
+        27: ireturn
+
+  protected boolean isLocalClientAuthoritative();
+    Code:
+         0: aload_0
+         1: invokevirtual #2141               // Method getControllingPassenger:()Lnet/minecraft/world/entity/LivingEntity;
+         4: astore_1
+         5: aload_1
+         6: ifnull        20
+         9: aload_1
+        10: invokevirtual #4545               // Method net/minecraft/world/entity/LivingEntity.isLocalClientAuthoritative:()Z
+        13: ifeq          20
+        16: iconst_1
+        17: goto          21
+        20: iconst_0
+        21: ireturn
+
+  public boolean isClientAuthoritative();
+    Code:
+         0: aload_0
+         1: invokevirtual #2141               // Method getControllingPassenger:()Lnet/minecraft/world/entity/LivingEntity;
+         4: astore_1
+         5: aload_1
+         6: ifnull        20
+         9: aload_1
+        10: invokevirtual #4546               // Method net/minecraft/world/entity/LivingEntity.isClientAuthoritative:()Z
+        13: ifeq          20
+        16: iconst_1
+        17: goto          21
+        20: iconst_0
+        21: ireturn
+
+  public boolean canSimulateMovement();
+    Code:
+         0: aload_0
+         1: invokevirtual #1327               // Method isLocalInstanceAuthoritative:()Z
+         4: ireturn
+
+  public boolean isEffectiveAi();
+    Code:
+         0: aload_0
+         1: invokevirtual #1327               // Method isLocalInstanceAuthoritative:()Z
+         4: ireturn
+
+  protected static net.minecraft.world.phys.Vec3 getCollisionHorizontalEscapeVector(double, double, float);
+    Code:
+         0: dload_0
+         1: dload_2
+         2: dadd
+         3: ldc2_w        #1574               // double 9.999999747378752E-6d
+         6: dadd
+         7: ldc2_w        #2414               // double 2.0d
+        10: ddiv
+        11: dstore        5
+        13: fload         4
+        15: ldc_w         #2472               // float 0.017453292f
+        18: fmul
+        19: f2d
+        20: invokestatic  #2476               // Method net/minecraft/util/Mth.sin:(D)F
+        23: fneg
+        24: fstore        7
+        26: fload         4
+        28: ldc_w         #2472               // float 0.017453292f
+        31: fmul
+        32: f2d
+        33: invokestatic  #2479               // Method net/minecraft/util/Mth.cos:(D)F
+        36: fstore        8
+        38: fload         7
+        40: invokestatic  #4554               // Method java/lang/Math.abs:(F)F
+        43: fload         8
+        45: invokestatic  #4554               // Method java/lang/Math.abs:(F)F
+        48: invokestatic  #4398               // Method java/lang/Math.max:(FF)F
+        51: fstore        9
+        53: new           #440                // class net/minecraft/world/phys/Vec3
+        56: dup
+        57: fload         7
+        59: f2d
+        60: dload         5
+        62: dmul
+        63: fload         9
+        65: f2d
+        66: ddiv
+        67: dconst_0
+        68: fload         8
+        70: f2d
+        71: dload         5
+        73: dmul
+        74: fload         9
+        76: f2d
+        77: ddiv
+        78: invokespecial #765                // Method net/minecraft/world/phys/Vec3."<init>":(DDD)V
+        81: areturn
+
+  public net.minecraft.world.phys.Vec3 getDismountLocationForPassenger(net.minecraft.world.entity.LivingEntity);
+    Code:
+         0: new           #440                // class net/minecraft/world/phys/Vec3
+         3: dup
+         4: aload_0
+         5: invokevirtual #880                // Method getX:()D
+         8: aload_0
+         9: invokevirtual #693                // Method getBoundingBox:()Lnet/minecraft/world/phys/AABB;
+        12: getfield      #2318               // Field net/minecraft/world/phys/AABB.maxY:D
+        15: aload_0
+        16: invokevirtual #886                // Method getZ:()D
+        19: invokespecial #765                // Method net/minecraft/world/phys/Vec3."<init>":(DDD)V
+        22: areturn
+
+  public net.minecraft.world.entity.Entity getVehicle();
+    Code:
+         0: aload_0
+         1: getfield      #957                // Field vehicle:Lnet/minecraft/world/entity/Entity;
+         4: areturn
+
+  public net.minecraft.world.entity.Entity getControlledVehicle();
+    Code:
+         0: aload_0
+         1: getfield      #957                // Field vehicle:Lnet/minecraft/world/entity/Entity;
+         4: ifnull        25
+         7: aload_0
+         8: getfield      #957                // Field vehicle:Lnet/minecraft/world/entity/Entity;
+        11: invokevirtual #2141               // Method getControllingPassenger:()Lnet/minecraft/world/entity/LivingEntity;
+        14: aload_0
+        15: if_acmpne     25
+        18: aload_0
+        19: getfield      #957                // Field vehicle:Lnet/minecraft/world/entity/Entity;
+        22: goto          26
+        25: aconst_null
+        26: areturn
+
+  public net.minecraft.world.level.material.PushReaction getPistonPushReaction();
+    Code:
+         0: getstatic     #4567               // Field net/minecraft/world/level/material/PushReaction.NORMAL:Lnet/minecraft/world/level/material/PushReaction;
+         3: areturn
+
+  public net.minecraft.sounds.SoundSource getSoundSource();
+    Code:
+         0: getstatic     #4571               // Field net/minecraft/sounds/SoundSource.NEUTRAL:Lnet/minecraft/sounds/SoundSource;
+         3: areturn
+
+  protected int getFireImmuneTicks();
+    Code:
+         0: iconst_0
+         1: ireturn
+
+  public net.minecraft.commands.CommandSourceStack createCommandSourceStackForNameResolution(net.minecraft.server.level.ServerLevel);
+    Code:
+         0: new           #4575               // class net/minecraft/commands/CommandSourceStack
+         3: dup
+         4: getstatic     #4580               // Field net/minecraft/commands/CommandSource.NULL:Lnet/minecraft/commands/CommandSource;
+         7: aload_0
+         8: invokevirtual #870                // Method position:()Lnet/minecraft/world/phys/Vec3;
+        11: aload_0
+        12: invokevirtual #3513               // Method getRotationVector:()Lnet/minecraft/world/phys/Vec2;
+        15: aload_1
+        16: getstatic     #4586               // Field net/minecraft/server/permissions/PermissionSet.NO_PERMISSIONS:Lnet/minecraft/server/permissions/PermissionSet;
+        19: aload_0
+        20: invokevirtual #3871               // Method getPlainTextName:()Ljava/lang/String;
+        23: aload_0
+        24: invokevirtual #4587               // Method getDisplayName:()Lnet/minecraft/network/chat/Component;
+        27: aload_1
+        28: invokevirtual #1973               // Method net/minecraft/server/level/ServerLevel.getServer:()Lnet/minecraft/server/MinecraftServer;
+        31: aload_0
+        32: invokespecial #4590               // Method net/minecraft/commands/CommandSourceStack."<init>":(Lnet/minecraft/commands/CommandSource;Lnet/minecraft/world/phys/Vec3;Lnet/minecraft/world/phys/Vec2;Lnet/minecraft/server/level/ServerLevel;Lnet/minecraft/server/permissions/PermissionSet;Ljava/lang/String;Lnet/minecraft/network/chat/Component;Lnet/minecraft/server/MinecraftServer;Lnet/minecraft/world/entity/Entity;)V
+        35: areturn
+
+  public void lookAt(net.minecraft.commands.arguments.EntityAnchorArgument$Anchor, net.minecraft.world.phys.Vec3);
+    Code:
+         0: aload_1
+         1: aload_0
+         2: invokevirtual #4595               // Method net/minecraft/commands/arguments/EntityAnchorArgument$Anchor.apply:(Lnet/minecraft/world/entity/Entity;)Lnet/minecraft/world/phys/Vec3;
+         5: astore_3
+         6: aload_2
+         7: getfield      #932                // Field net/minecraft/world/phys/Vec3.x:D
+        10: aload_3
+        11: getfield      #932                // Field net/minecraft/world/phys/Vec3.x:D
+        14: dsub
+        15: dstore        4
+        17: aload_2
+        18: getfield      #934                // Field net/minecraft/world/phys/Vec3.y:D
+        21: aload_3
+        22: getfield      #934                // Field net/minecraft/world/phys/Vec3.y:D
+        25: dsub
+        26: dstore        6
+        28: aload_2
+        29: getfield      #936                // Field net/minecraft/world/phys/Vec3.z:D
+        32: aload_3
+        33: getfield      #936                // Field net/minecraft/world/phys/Vec3.z:D
+        36: dsub
+        37: dstore        8
+        39: dload         4
+        41: dload         4
+        43: dmul
+        44: dload         8
+        46: dload         8
+        48: dmul
+        49: dadd
+        50: invokestatic  #2153               // Method java/lang/Math.sqrt:(D)D
+        53: dstore        10
+        55: aload_0
+        56: dload         6
+        58: dload         10
+        60: invokestatic  #4598               // Method net/minecraft/util/Mth.atan2:(DD)D
+        63: ldc2_w        #4599               // double 57.2957763671875d
+        66: dmul
+        67: dneg
+        68: d2f
+        69: invokestatic  #4442               // Method net/minecraft/util/Mth.wrapDegrees:(F)F
+        72: invokevirtual #907                // Method setXRot:(F)V
+        75: aload_0
+        76: dload         8
+        78: dload         4
+        80: invokestatic  #4598               // Method net/minecraft/util/Mth.atan2:(DD)D
+        83: ldc2_w        #4599               // double 57.2957763671875d
+        86: dmul
+        87: d2f
+        88: ldc_w         #947                // float 90.0f
+        91: fsub
+        92: invokestatic  #4442               // Method net/minecraft/util/Mth.wrapDegrees:(F)F
+        95: invokevirtual #904                // Method setYRot:(F)V
+        98: aload_0
+        99: aload_0
+       100: invokevirtual #945                // Method getYRot:()F
+       103: invokevirtual #2889               // Method setYHeadRot:(F)V
+       106: aload_0
+       107: aload_0
+       108: invokevirtual #942                // Method getXRot:()F
+       111: putfield      #953                // Field xRotO:F
+       114: aload_0
+       115: aload_0
+       116: invokevirtual #945                // Method getYRot:()F
+       119: putfield      #955                // Field yRotO:F
+       122: return
+
+  public float getPreciseBodyRotation(float);
+    Code:
+         0: fload_1
+         1: aload_0
+         2: getfield      #955                // Field yRotO:F
+         5: aload_0
+         6: getfield      #3275               // Field yRot:F
+         9: invokestatic  #2630               // Method net/minecraft/util/Mth.lerp:(FFF)F
+        12: freturn
+
+  public boolean touchingUnloadedChunk();
+    Code:
+         0: aload_0
+         1: invokevirtual #693                // Method getBoundingBox:()Lnet/minecraft/world/phys/AABB;
+         4: dconst_1
+         5: invokevirtual #4607               // Method net/minecraft/world/phys/AABB.inflate:(D)Lnet/minecraft/world/phys/AABB;
+         8: astore_1
+         9: aload_1
+        10: getfield      #1198               // Field net/minecraft/world/phys/AABB.minX:D
+        13: invokestatic  #1684               // Method net/minecraft/util/Mth.floor:(D)I
+        16: istore_2
+        17: aload_1
+        18: getfield      #1209               // Field net/minecraft/world/phys/AABB.maxX:D
+        21: invokestatic  #4610               // Method net/minecraft/util/Mth.ceil:(D)I
+        24: istore_3
+        25: aload_1
+        26: getfield      #1206               // Field net/minecraft/world/phys/AABB.minZ:D
+        29: invokestatic  #1684               // Method net/minecraft/util/Mth.floor:(D)I
+        32: istore        4
+        34: aload_1
+        35: getfield      #1212               // Field net/minecraft/world/phys/AABB.maxZ:D
+        38: invokestatic  #4610               // Method net/minecraft/util/Mth.ceil:(D)I
+        41: istore        5
+        43: aload_0
+        44: invokevirtual #672                // Method level:()Lnet/minecraft/world/level/Level;
+        47: iload_2
+        48: iload         4
+        50: iload_3
+        51: iload         5
+        53: invokevirtual #4614               // Method net/minecraft/world/level/Level.hasChunksAt:(IIII)Z
+        56: ifne          63
+        59: iconst_1
+        60: goto          64
+        63: iconst_0
+        64: ireturn
+
+  public double getFluidHeight(net.minecraft.tags.TagKey<net.minecraft.world.level.material.Fluid>);
+    Code:
+         0: aload_0
+         1: getfield      #482                // Field fluidInteraction:Lnet/minecraft/world/entity/EntityFluidInteraction;
+         4: aload_1
+         5: invokevirtual #4623               // Method net/minecraft/world/entity/EntityFluidInteraction.getFluidHeight:(Lnet/minecraft/tags/TagKey;)D
+         8: dreturn
+
+  public double getFluidJumpThreshold();
+    Code:
+         0: aload_0
+         1: invokevirtual #2648               // Method getEyeHeight:()F
+         4: f2d
+         5: ldc2_w        #4625               // double 0.4d
+         8: dcmpg
+         9: ifge          16
+        12: dconst_0
+        13: goto          19
+        16: ldc2_w        #4625               // double 0.4d
+        19: dreturn
+
+  public final float getBbWidth();
+    Code:
+         0: aload_0
+         1: getfield      #581                // Field dimensions:Lnet/minecraft/world/entity/EntityDimensions;
+         4: invokevirtual #2410               // Method net/minecraft/world/entity/EntityDimensions.width:()F
+         7: freturn
+
+  public final float getBbHeight();
+    Code:
+         0: aload_0
+         1: getfield      #581                // Field dimensions:Lnet/minecraft/world/entity/EntityDimensions;
+         4: invokevirtual #4389               // Method net/minecraft/world/entity/EntityDimensions.height:()F
+         7: freturn
+
+  public net.minecraft.network.protocol.Packet<net.minecraft.network.protocol.game.ClientGamePacketListener> getAddEntityPacket(net.minecraft.server.level.ServerEntity);
+    Code:
+         0: new           #4633               // class net/minecraft/network/protocol/game/ClientboundAddEntityPacket
+         3: dup
+         4: aload_0
+         5: aload_1
+         6: invokespecial #4636               // Method net/minecraft/network/protocol/game/ClientboundAddEntityPacket."<init>":(Lnet/minecraft/world/entity/Entity;Lnet/minecraft/server/level/ServerEntity;)V
+         9: areturn
+
+  public net.minecraft.world.entity.EntityDimensions getDimensions(net.minecraft.world.entity.Pose);
+    Code:
+         0: aload_0
+         1: getfield      #565                // Field type:Lnet/minecraft/world/entity/EntityType;
+         4: invokevirtual #579                // Method net/minecraft/world/entity/EntityType.getDimensions:()Lnet/minecraft/world/entity/EntityDimensions;
+         7: areturn
+
+  public final net.minecraft.world.entity.EntityAttachments getAttachments();
+    Code:
+         0: aload_0
+         1: getfield      #581                // Field dimensions:Lnet/minecraft/world/entity/EntityDimensions;
+         4: invokevirtual #3287               // Method net/minecraft/world/entity/EntityDimensions.attachments:()Lnet/minecraft/world/entity/EntityAttachments;
+         7: areturn
+
+  public net.minecraft.world.phys.Vec3 position();
+    Code:
+         0: aload_0
+         1: getfield      #583                // Field position:Lnet/minecraft/world/phys/Vec3;
+         4: areturn
+
+  public net.minecraft.world.phys.Vec3 trackingPosition();
+    Code:
+         0: aload_0
+         1: invokevirtual #870                // Method position:()Lnet/minecraft/world/phys/Vec3;
+         4: areturn
+
+  public net.minecraft.core.BlockPos blockPosition();
+    Code:
+         0: aload_0
+         1: getfield      #587                // Field blockPosition:Lnet/minecraft/core/BlockPos;
+         4: areturn
+
+  public net.minecraft.world.level.block.state.BlockState getInBlockState();
+    Code:
+         0: aload_0
+         1: getfield      #536                // Field inBlockState:Lnet/minecraft/world/level/block/state/BlockState;
+         4: ifnonnull     22
+         7: aload_0
+         8: aload_0
+         9: invokevirtual #672                // Method level:()Lnet/minecraft/world/level/Level;
+        12: aload_0
+        13: invokevirtual #1698               // Method blockPosition:()Lnet/minecraft/core/BlockPos;
+        16: invokevirtual #1339               // Method net/minecraft/world/level/Level.getBlockState:(Lnet/minecraft/core/BlockPos;)Lnet/minecraft/world/level/block/state/BlockState;
+        19: putfield      #536                // Field inBlockState:Lnet/minecraft/world/level/block/state/BlockState;
+        22: aload_0
+        23: getfield      #536                // Field inBlockState:Lnet/minecraft/world/level/block/state/BlockState;
+        26: areturn
+
+  public net.minecraft.world.level.ChunkPos chunkPosition();
+    Code:
+         0: aload_0
+         1: getfield      #593                // Field chunkPosition:Lnet/minecraft/world/level/ChunkPos;
+         4: areturn
+
+  public net.minecraft.world.phys.Vec3 getDeltaMovement();
+    Code:
+         0: aload_0
+         1: getfield      #445                // Field deltaMovement:Lnet/minecraft/world/phys/Vec3;
+         4: areturn
+
+  public void setDeltaMovement(net.minecraft.world.phys.Vec3);
+    Code:
+         0: aload_1
+         1: invokevirtual #2586               // Method net/minecraft/world/phys/Vec3.isFinite:()Z
+         4: ifeq          12
+         7: aload_0
+         8: aload_1
+         9: putfield      #445                // Field deltaMovement:Lnet/minecraft/world/phys/Vec3;
+        12: return
+
+  public void addDeltaMovement(net.minecraft.world.phys.Vec3);
+    Code:
+         0: aload_1
+         1: invokevirtual #2586               // Method net/minecraft/world/phys/Vec3.isFinite:()Z
+         4: ifeq          19
+         7: aload_0
+         8: aload_0
+         9: invokevirtual #1369               // Method getDeltaMovement:()Lnet/minecraft/world/phys/Vec3;
+        12: aload_1
+        13: invokevirtual #1280               // Method net/minecraft/world/phys/Vec3.add:(Lnet/minecraft/world/phys/Vec3;)Lnet/minecraft/world/phys/Vec3;
+        16: invokevirtual #1259               // Method setDeltaMovement:(Lnet/minecraft/world/phys/Vec3;)V
+        19: return
+
+  public void setDeltaMovement(double, double, double);
+    Code:
+         0: aload_0
+         1: new           #440                // class net/minecraft/world/phys/Vec3
+         4: dup
+         5: dload_1
+         6: dload_3
+         7: dload         5
+         9: invokespecial #765                // Method net/minecraft/world/phys/Vec3."<init>":(DDD)V
+        12: invokevirtual #1259               // Method setDeltaMovement:(Lnet/minecraft/world/phys/Vec3;)V
+        15: return
+
+  public final int getBlockX();
+    Code:
+         0: aload_0
+         1: getfield      #587                // Field blockPosition:Lnet/minecraft/core/BlockPos;
+         4: invokevirtual #2099               // Method net/minecraft/core/BlockPos.getX:()I
+         7: ireturn
+
+  public final double getX();
+    Code:
+         0: aload_0
+         1: getfield      #583                // Field position:Lnet/minecraft/world/phys/Vec3;
+         4: getfield      #932                // Field net/minecraft/world/phys/Vec3.x:D
+         7: dreturn
+
+  public double getX(double);
+    Code:
+         0: aload_0
+         1: getfield      #583                // Field position:Lnet/minecraft/world/phys/Vec3;
+         4: getfield      #932                // Field net/minecraft/world/phys/Vec3.x:D
+         7: aload_0
+         8: invokevirtual #4645               // Method getBbWidth:()F
+        11: f2d
+        12: dload_1
+        13: dmul
+        14: dadd
+        15: dreturn
+
+  public double getRandomX(double);
+    Code:
+         0: aload_0
+         1: ldc2_w        #2414               // double 2.0d
+         4: aload_0
+         5: getfield      #461                // Field random:Lnet/minecraft/util/RandomSource;
+         8: invokeinterface #2413,  1         // InterfaceMethod net/minecraft/util/RandomSource.nextDouble:()D
+        13: dmul
+        14: dconst_1
+        15: dsub
+        16: dload_1
+        17: dmul
+        18: invokevirtual #4649               // Method getX:(D)D
+        21: dreturn
+
+  public final int getBlockY();
+    Code:
+         0: aload_0
+         1: getfield      #587                // Field blockPosition:Lnet/minecraft/core/BlockPos;
+         4: invokevirtual #3719               // Method net/minecraft/core/BlockPos.getY:()I
+         7: ireturn
+
+  public final double getY();
+    Code:
+         0: aload_0
+         1: getfield      #583                // Field position:Lnet/minecraft/world/phys/Vec3;
+         4: getfield      #934                // Field net/minecraft/world/phys/Vec3.y:D
+         7: dreturn
+
+  public double getY(double);
+    Code:
+         0: aload_0
+         1: getfield      #583                // Field position:Lnet/minecraft/world/phys/Vec3;
+         4: getfield      #934                // Field net/minecraft/world/phys/Vec3.y:D
+         7: aload_0
+         8: invokevirtual #2361               // Method getBbHeight:()F
+        11: f2d
+        12: dload_1
+        13: dmul
+        14: dadd
+        15: dreturn
+
+  public double getRandomY(double);
+    Code:
+         0: aload_0
+         1: ldc2_w        #2414               // double 2.0d
+         4: aload_0
+         5: getfield      #461                // Field random:Lnet/minecraft/util/RandomSource;
+         8: invokeinterface #2413,  1         // InterfaceMethod net/minecraft/util/RandomSource.nextDouble:()D
+        13: dmul
+        14: dconst_1
+        15: dsub
+        16: dload_1
+        17: dmul
+        18: invokevirtual #4653               // Method getY:(D)D
+        21: dreturn
+
+  public double getRandomY();
+    Code:
+         0: aload_0
+         1: aload_0
+         2: getfield      #461                // Field random:Lnet/minecraft/util/RandomSource;
+         5: invokeinterface #2413,  1         // InterfaceMethod net/minecraft/util/RandomSource.nextDouble:()D
+        10: invokevirtual #4653               // Method getY:(D)D
+        13: dreturn
+
+  public double getEyeY();
+    Code:
+         0: aload_0
+         1: getfield      #583                // Field position:Lnet/minecraft/world/phys/Vec3;
+         4: getfield      #934                // Field net/minecraft/world/phys/Vec3.y:D
+         7: aload_0
+         8: getfield      #662                // Field eyeHeight:F
+        11: f2d
+        12: dadd
+        13: dreturn
+
+  public final int getBlockZ();
+    Code:
+         0: aload_0
+         1: getfield      #587                // Field blockPosition:Lnet/minecraft/core/BlockPos;
+         4: invokevirtual #2101               // Method net/minecraft/core/BlockPos.getZ:()I
+         7: ireturn
+
+  public final double getZ();
+    Code:
+         0: aload_0
+         1: getfield      #583                // Field position:Lnet/minecraft/world/phys/Vec3;
+         4: getfield      #936                // Field net/minecraft/world/phys/Vec3.z:D
+         7: dreturn
+
+  public double getZ(double);
+    Code:
+         0: aload_0
+         1: getfield      #583                // Field position:Lnet/minecraft/world/phys/Vec3;
+         4: getfield      #936                // Field net/minecraft/world/phys/Vec3.z:D
+         7: aload_0
+         8: invokevirtual #4645               // Method getBbWidth:()F
+        11: f2d
+        12: dload_1
+        13: dmul
+        14: dadd
+        15: dreturn
+
+  public double getRandomZ(double);
+    Code:
+         0: aload_0
+         1: ldc2_w        #2414               // double 2.0d
+         4: aload_0
+         5: getfield      #461                // Field random:Lnet/minecraft/util/RandomSource;
+         8: invokeinterface #2413,  1         // InterfaceMethod net/minecraft/util/RandomSource.nextDouble:()D
+        13: dmul
+        14: dconst_1
+        15: dsub
+        16: dload_1
+        17: dmul
+        18: invokevirtual #4656               // Method getZ:(D)D
+        21: dreturn
+
+  public final void setPosRaw(double, double, double);
+    Code:
+         0: aload_0
+         1: getfield      #583                // Field position:Lnet/minecraft/world/phys/Vec3;
+         4: getfield      #932                // Field net/minecraft/world/phys/Vec3.x:D
+         7: dload_1
+         8: dcmpl
+         9: ifne          37
+        12: aload_0
+        13: getfield      #583                // Field position:Lnet/minecraft/world/phys/Vec3;
+        16: getfield      #934                // Field net/minecraft/world/phys/Vec3.y:D
+        19: dload_3
+        20: dcmpl
+        21: ifne          37
+        24: aload_0
+        25: getfield      #583                // Field position:Lnet/minecraft/world/phys/Vec3;
+        28: getfield      #936                // Field net/minecraft/world/phys/Vec3.z:D
+        31: dload         5
+        33: dcmpl
+        34: ifeq          296
+        37: aload_0
+        38: new           #440                // class net/minecraft/world/phys/Vec3
+        41: dup
+        42: dload_1
+        43: dload_3
+        44: dload         5
+        46: invokespecial #765                // Method net/minecraft/world/phys/Vec3."<init>":(DDD)V
+        49: putfield      #583                // Field position:Lnet/minecraft/world/phys/Vec3;
+        52: dload_1
+        53: invokestatic  #1684               // Method net/minecraft/util/Mth.floor:(D)I
+        56: istore        7
+        58: dload_3
+        59: invokestatic  #1684               // Method net/minecraft/util/Mth.floor:(D)I
+        62: istore        8
+        64: dload         5
+        66: invokestatic  #1684               // Method net/minecraft/util/Mth.floor:(D)I
+        69: istore        9
+        71: iload         7
+        73: aload_0
+        74: getfield      #587                // Field blockPosition:Lnet/minecraft/core/BlockPos;
+        77: invokevirtual #2099               // Method net/minecraft/core/BlockPos.getX:()I
+        80: if_icmpne     107
+        83: iload         8
+        85: aload_0
+        86: getfield      #587                // Field blockPosition:Lnet/minecraft/core/BlockPos;
+        89: invokevirtual #3719               // Method net/minecraft/core/BlockPos.getY:()I
+        92: if_icmpne     107
+        95: iload         9
+        97: aload_0
+        98: getfield      #587                // Field blockPosition:Lnet/minecraft/core/BlockPos;
+       101: invokevirtual #2101               // Method net/minecraft/core/BlockPos.getZ:()I
+       104: if_icmpeq     170
+       107: aload_0
+       108: new           #122                // class net/minecraft/core/BlockPos
+       111: dup
+       112: iload         7
+       114: iload         8
+       116: iload         9
+       118: invokespecial #1691               // Method net/minecraft/core/BlockPos."<init>":(III)V
+       121: putfield      #587                // Field blockPosition:Lnet/minecraft/core/BlockPos;
+       124: aload_0
+       125: aconst_null
+       126: putfield      #536                // Field inBlockState:Lnet/minecraft/world/level/block/state/BlockState;
+       129: iload         7
+       131: invokestatic  #4661               // Method net/minecraft/core/SectionPos.blockToSectionCoord:(I)I
+       134: aload_0
+       135: getfield      #593                // Field chunkPosition:Lnet/minecraft/world/level/ChunkPos;
+       138: invokevirtual #4663               // Method net/minecraft/world/level/ChunkPos.x:()I
+       141: if_icmpne     159
+       144: iload         9
+       146: invokestatic  #4661               // Method net/minecraft/core/SectionPos.blockToSectionCoord:(I)I
+       149: aload_0
+       150: getfield      #593                // Field chunkPosition:Lnet/minecraft/world/level/ChunkPos;
+       153: invokevirtual #4665               // Method net/minecraft/world/level/ChunkPos.z:()I
+       156: if_icmpeq     170
+       159: aload_0
+       160: aload_0
+       161: getfield      #587                // Field blockPosition:Lnet/minecraft/core/BlockPos;
+       164: invokestatic  #4145               // Method net/minecraft/world/level/ChunkPos.containing:(Lnet/minecraft/core/BlockPos;)Lnet/minecraft/world/level/ChunkPos;
+       167: putfield      #593                // Field chunkPosition:Lnet/minecraft/world/level/ChunkPos;
+       170: aload_0
+       171: getfield      #491                // Field levelCallback:Lnet/minecraft/world/level/entity/EntityInLevelCallback;
+       174: invokeinterface #4668,  1         // InterfaceMethod net/minecraft/world/level/entity/EntityInLevelCallback.onMove:()V
+       179: aload_0
+       180: getfield      #484                // Field firstTick:Z
+       183: ifne          296
+       186: aload_0
+       187: getfield      #567                // Field level:Lnet/minecraft/world/level/Level;
+       190: astore        11
+       192: aload         11
+       194: instanceof    #1016               // class net/minecraft/server/level/ServerLevel
+       197: ifeq          296
+       200: aload         11
+       202: checkcast     #1016               // class net/minecraft/server/level/ServerLevel
+       205: astore        10
+       207: aload_0
+       208: invokevirtual #744                // Method isRemoved:()Z
+       211: ifne          296
+       214: aload_0
+       215: astore        12
+       217: aload         12
+       219: instanceof    #4156               // class net/minecraft/world/waypoints/WaypointTransmitter
+       222: ifeq          252
+       225: aload         12
+       227: checkcast     #4156               // class net/minecraft/world/waypoints/WaypointTransmitter
+       230: astore        11
+       232: aload         11
+       234: invokeinterface #4671,  1         // InterfaceMethod net/minecraft/world/waypoints/WaypointTransmitter.isTransmittingWaypoint:()Z
+       239: ifeq          252
+       242: aload         10
+       244: invokevirtual #4160               // Method net/minecraft/server/level/ServerLevel.getWaypointManager:()Lnet/minecraft/server/waypoints/ServerWaypointManager;
+       247: aload         11
+       249: invokevirtual #4674               // Method net/minecraft/server/waypoints/ServerWaypointManager.updateWaypoint:(Lnet/minecraft/world/waypoints/WaypointTransmitter;)V
+       252: aload_0
+       253: astore        12
+       255: aload         12
+       257: instanceof    #2680               // class net/minecraft/server/level/ServerPlayer
+       260: ifeq          296
+       263: aload         12
+       265: checkcast     #2680               // class net/minecraft/server/level/ServerPlayer
+       268: astore        11
+       270: aload         11
+       272: invokevirtual #4677               // Method net/minecraft/server/level/ServerPlayer.isReceivingWaypoints:()Z
+       275: ifeq          296
+       278: aload         11
+       280: getfield      #4088               // Field net/minecraft/server/level/ServerPlayer.connection:Lnet/minecraft/server/network/ServerGamePacketListenerImpl;
+       283: ifnull        296
+       286: aload         10
+       288: invokevirtual #4160               // Method net/minecraft/server/level/ServerLevel.getWaypointManager:()Lnet/minecraft/server/waypoints/ServerWaypointManager;
+       291: aload         11
+       293: invokevirtual #4680               // Method net/minecraft/server/waypoints/ServerWaypointManager.updatePlayer:(Lnet/minecraft/server/level/ServerPlayer;)V
+       296: return
+
+  public void checkDespawn();
+    Code:
+         0: return
+
+  public net.minecraft.world.phys.Vec3[] getQuadLeashHolderOffsets();
+    Code:
+         0: aload_0
+         1: dconst_0
+         2: ldc2_w        #1047               // double 0.5d
+         5: ldc2_w        #1047               // double 0.5d
+         8: dconst_0
+         9: invokestatic  #4690               // InterfaceMethod net/minecraft/world/entity/Leashable.createQuadLeashOffsets:(Lnet/minecraft/world/entity/Entity;DDDD)[Lnet/minecraft/world/phys/Vec3;
+        12: areturn
+
+  public boolean supportQuadLeashAsHolder();
+    Code:
+         0: iconst_0
+         1: ireturn
+
+  public void notifyLeashHolder(net.minecraft.world.entity.Leashable);
+    Code:
+         0: return
+
+  public void notifyLeasheeRemoved(net.minecraft.world.entity.Leashable);
+    Code:
+         0: return
+
+  public net.minecraft.world.phys.Vec3 getRopeHoldPosition(float);
+    Code:
+         0: aload_0
+         1: fload_1
+         2: invokevirtual #4697               // Method getPosition:(F)Lnet/minecraft/world/phys/Vec3;
+         5: dconst_0
+         6: aload_0
+         7: getfield      #662                // Field eyeHeight:F
+        10: f2d
+        11: ldc2_w        #3734               // double 0.7d
+        14: dmul
+        15: dconst_0
+        16: invokevirtual #2249               // Method net/minecraft/world/phys/Vec3.add:(DDD)Lnet/minecraft/world/phys/Vec3;
+        19: areturn
+
+  public void recreateFromPacket(net.minecraft.network.protocol.game.ClientboundAddEntityPacket);
+    Code:
+         0: aload_1
+         1: invokevirtual #4701               // Method net/minecraft/network/protocol/game/ClientboundAddEntityPacket.getId:()I
+         4: istore_2
+         5: aload_1
+         6: invokevirtual #4702               // Method net/minecraft/network/protocol/game/ClientboundAddEntityPacket.getX:()D
+         9: dstore_3
+        10: aload_1
+        11: invokevirtual #4703               // Method net/minecraft/network/protocol/game/ClientboundAddEntityPacket.getY:()D
+        14: dstore        5
+        16: aload_1
+        17: invokevirtual #4704               // Method net/minecraft/network/protocol/game/ClientboundAddEntityPacket.getZ:()D
+        20: dstore        7
+        22: aload_0
+        23: dload_3
+        24: dload         5
+        26: dload         7
+        28: invokevirtual #4706               // Method syncPacketPositionCodec:(DDD)V
+        31: aload_0
+        32: dload_3
+        33: dload         5
+        35: dload         7
+        37: aload_1
+        38: invokevirtual #4707               // Method net/minecraft/network/protocol/game/ClientboundAddEntityPacket.getYRot:()F
+        41: aload_1
+        42: invokevirtual #4708               // Method net/minecraft/network/protocol/game/ClientboundAddEntityPacket.getXRot:()F
+        45: invokevirtual #2520               // Method snapTo:(DDDFF)V
+        48: aload_0
+        49: iload_2
+        50: invokevirtual #4710               // Method setId:(I)V
+        53: aload_0
+        54: aload_1
+        55: invokevirtual #4711               // Method net/minecraft/network/protocol/game/ClientboundAddEntityPacket.getUUID:()Ljava/util/UUID;
+        58: invokevirtual #4713               // Method setUUID:(Ljava/util/UUID;)V
+        61: aload_0
+        62: aload_1
+        63: invokevirtual #4716               // Method net/minecraft/network/protocol/game/ClientboundAddEntityPacket.getMovement:()Lnet/minecraft/world/phys/Vec3;
+        66: invokevirtual #1259               // Method setDeltaMovement:(Lnet/minecraft/world/phys/Vec3;)V
+        69: return
+
+  public net.minecraft.world.item.ItemStack getPickResult();
+    Code:
+         0: aconst_null
+         1: areturn
+
+  public void setIsInPowderSnow(boolean);
+    Code:
+         0: aload_0
+         1: iload_1
+         2: putfield      #1000               // Field isInPowderSnow:Z
+         5: return
+
+  public boolean canFreeze();
+    Code:
+         0: aload_0
+         1: getstatic     #4724               // Field net/minecraft/tags/EntityTypeTags.FREEZE_IMMUNE_ENTITY_TYPES:Lnet/minecraft/tags/TagKey;
+         4: invokevirtual #2298               // Method is:(Lnet/minecraft/tags/TagKey;)Z
+         7: ifne          14
+        10: iconst_1
+        11: goto          15
+        14: iconst_0
+        15: ireturn
+
+  public boolean isFreezing();
+    Code:
+         0: aload_0
+         1: invokevirtual #2796               // Method getTicksFrozen:()I
+         4: ifle          11
+         7: iconst_1
+         8: goto          12
+        11: iconst_0
+        12: ireturn
+
+  public float getYRot();
+    Code:
+         0: aload_0
+         1: getfield      #3275               // Field yRot:F
+         4: freturn
+
+  public float getVisualRotationYInDegrees();
+    Code:
+         0: aload_0
+         1: invokevirtual #945                // Method getYRot:()F
+         4: freturn
+
+  public void setYRot(float);
+    Code:
+         0: fload_1
+         1: invokestatic  #4727               // Method java/lang/Float.isFinite:(F)Z
+         4: ifne          17
+         7: fload_1
+         8: invokedynamic #4739,  0           // InvokeDynamic #24:makeConcatWithConstants:(F)Ljava/lang/String;
+        13: invokestatic  #4744               // Method net/minecraft/util/Util.logAndPauseIfInIde:(Ljava/lang/String;)V
+        16: return
+        17: aload_0
+        18: fload_1
+        19: putfield      #3275               // Field yRot:F
+        22: return
+
+  public float getXRot();
+    Code:
+         0: aload_0
+         1: getfield      #4746               // Field xRot:F
+         4: freturn
+
+  public void setXRot(float);
+    Code:
+         0: fload_1
+         1: invokestatic  #4727               // Method java/lang/Float.isFinite:(F)Z
+         4: ifne          17
+         7: fload_1
+         8: invokedynamic #4739,  0           // InvokeDynamic #24:makeConcatWithConstants:(F)Ljava/lang/String;
+        13: invokestatic  #4744               // Method net/minecraft/util/Util.logAndPauseIfInIde:(Ljava/lang/String;)V
+        16: return
+        17: aload_0
+        18: fload_1
+        19: ldc_w         #900                // float 360.0f
+        22: frem
+        23: ldc_w         #946                // float -90.0f
+        26: ldc_w         #947                // float 90.0f
+        29: invokestatic  #4747               // Method java/lang/Math.clamp:(FFF)F
+        32: putfield      #4746               // Field xRot:F
+        35: return
+
+  public boolean canSprint();
+    Code:
+         0: iconst_0
+         1: ireturn
+
+  public float maxUpStep();
+    Code:
+         0: fconst_0
+         1: freturn
+
+  public void onExplosionHit(net.minecraft.world.entity.Entity);
+    Code:
+         0: return
+
+  public final boolean isRemoved();
+    Code:
+         0: aload_0
+         1: getfield      #2714               // Field removalReason:Lnet/minecraft/world/entity/Entity$RemovalReason;
+         4: ifnull        11
+         7: iconst_1
+         8: goto          12
+        11: iconst_0
+        12: ireturn
+
+  public net.minecraft.world.entity.Entity$RemovalReason getRemovalReason();
+    Code:
+         0: aload_0
+         1: getfield      #2714               // Field removalReason:Lnet/minecraft/world/entity/Entity$RemovalReason;
+         4: areturn
+
+  public final void setRemoved(net.minecraft.world.entity.Entity$RemovalReason);
+    Code:
+         0: aload_0
+         1: getfield      #2714               // Field removalReason:Lnet/minecraft/world/entity/Entity$RemovalReason;
+         4: ifnonnull     12
+         7: aload_0
+         8: aload_1
+         9: putfield      #2714               // Field removalReason:Lnet/minecraft/world/entity/Entity$RemovalReason;
+        12: aload_0
+        13: getfield      #2714               // Field removalReason:Lnet/minecraft/world/entity/Entity$RemovalReason;
+        16: invokevirtual #3374               // Method net/minecraft/world/entity/Entity$RemovalReason.shouldDestroy:()Z
+        19: ifeq          26
+        22: aload_0
+        23: invokevirtual #759                // Method stopRiding:()V
+        26: aload_0
+        27: invokevirtual #2307               // Method getPassengers:()Ljava/util/List;
+        30: invokedynamic #4752,  0           // InvokeDynamic #25:accept:()Ljava/util/function/Consumer;
+        35: invokeinterface #4753,  2         // InterfaceMethod java/util/List.forEach:(Ljava/util/function/Consumer;)V
+        40: aload_0
+        41: getfield      #491                // Field levelCallback:Lnet/minecraft/world/level/entity/EntityInLevelCallback;
+        44: aload_1
+        45: invokeinterface #4756,  2         // InterfaceMethod net/minecraft/world/level/entity/EntityInLevelCallback.onRemove:(Lnet/minecraft/world/entity/Entity$RemovalReason;)V
+        50: aload_0
+        51: aload_1
+        52: invokevirtual #4758               // Method onRemoval:(Lnet/minecraft/world/entity/Entity$RemovalReason;)V
+        55: return
+
+  protected void unsetRemoved();
+    Code:
+         0: aload_0
+         1: aconst_null
+         2: putfield      #2714               // Field removalReason:Lnet/minecraft/world/entity/Entity$RemovalReason;
+         5: return
+
+  public void setLevelCallback(net.minecraft.world.level.entity.EntityInLevelCallback);
+    Code:
+         0: aload_0
+         1: aload_1
+         2: putfield      #491                // Field levelCallback:Lnet/minecraft/world/level/entity/EntityInLevelCallback;
+         5: return
+
+  public boolean shouldBeSaved();
+    Code:
+         0: aload_0
+         1: getfield      #2714               // Field removalReason:Lnet/minecraft/world/entity/Entity$RemovalReason;
+         4: ifnull        19
+         7: aload_0
+         8: getfield      #2714               // Field removalReason:Lnet/minecraft/world/entity/Entity$RemovalReason;
+        11: invokevirtual #2717               // Method net/minecraft/world/entity/Entity$RemovalReason.shouldSave:()Z
+        14: ifne          19
+        17: iconst_0
+        18: ireturn
+        19: aload_0
+        20: invokevirtual #756                // Method isPassenger:()Z
+        23: ifeq          28
+        26: iconst_0
+        27: ireturn
+        28: aload_0
+        29: invokevirtual #750                // Method isVehicle:()Z
+        32: ifeq          42
+        35: aload_0
+        36: invokevirtual #4764               // Method hasExactlyOnePlayerPassenger:()Z
+        39: ifne          46
+        42: iconst_1
+        43: goto          47
+        46: iconst_0
+        47: ireturn
+
+  public boolean isAlwaysTicking();
+    Code:
+         0: iconst_0
+         1: ireturn
+
+  public boolean mayInteract(net.minecraft.server.level.ServerLevel, net.minecraft.core.BlockPos);
+    Code:
+         0: iconst_1
+         1: ireturn
+
+  public boolean isFlyingVehicle();
+    Code:
+         0: iconst_0
+         1: ireturn
+
+  public net.minecraft.world.level.Level level();
+    Code:
+         0: aload_0
+         1: getfield      #567                // Field level:Lnet/minecraft/world/level/Level;
+         4: areturn
+
+  protected void setLevel(net.minecraft.world.level.Level);
+    Code:
+         0: aload_0
+         1: aload_1
+         2: putfield      #567                // Field level:Lnet/minecraft/world/level/Level;
+         5: return
+
+  public net.minecraft.world.damagesource.DamageSources damageSources();
+    Code:
+         0: aload_0
+         1: invokevirtual #672                // Method level:()Lnet/minecraft/world/level/Level;
+         4: invokevirtual #4771               // Method net/minecraft/world/level/Level.damageSources:()Lnet/minecraft/world/damagesource/DamageSources;
+         7: areturn
+
+  public net.minecraft.core.RegistryAccess registryAccess();
+    Code:
+         0: aload_0
+         1: invokevirtual #672                // Method level:()Lnet/minecraft/world/level/Level;
+         4: invokevirtual #4772               // Method net/minecraft/world/level/Level.registryAccess:()Lnet/minecraft/core/RegistryAccess;
+         7: areturn
+
+  protected void lerpPositionAndRotationStep(int, double, double, double, double, double);
+    Code:
+         0: dconst_1
+         1: iload_1
+         2: i2d
+         3: ddiv
+         4: dstore        12
+         6: dload         12
+         8: aload_0
+         9: invokevirtual #880                // Method getX:()D
+        12: dload_2
+        13: invokestatic  #1431               // Method net/minecraft/util/Mth.lerp:(DDD)D
+        16: dstore        14
+        18: dload         12
+        20: aload_0
+        21: invokevirtual #883                // Method getY:()D
+        24: dload         4
+        26: invokestatic  #1431               // Method net/minecraft/util/Mth.lerp:(DDD)D
+        29: dstore        16
+        31: dload         12
+        33: aload_0
+        34: invokevirtual #886                // Method getZ:()D
+        37: dload         6
+        39: invokestatic  #1431               // Method net/minecraft/util/Mth.lerp:(DDD)D
+        42: dstore        18
+        44: dload         12
+        46: aload_0
+        47: invokevirtual #945                // Method getYRot:()F
+        50: f2d
+        51: dload         8
+        53: invokestatic  #4782               // Method net/minecraft/util/Mth.rotLerp:(DDD)D
+        56: d2f
+        57: fstore        20
+        59: dload         12
+        61: aload_0
+        62: invokevirtual #942                // Method getXRot:()F
+        65: f2d
+        66: dload         10
+        68: invokestatic  #1431               // Method net/minecraft/util/Mth.lerp:(DDD)D
+        71: d2f
+        72: fstore        21
+        74: aload_0
+        75: dload         14
+        77: dload         16
+        79: dload         18
+        81: invokevirtual #655                // Method setPos:(DDD)V
+        84: aload_0
+        85: fload         20
+        87: fload         21
+        89: invokevirtual #2932               // Method setRot:(FF)V
+        92: return
+
+  public net.minecraft.util.RandomSource getRandom();
+    Code:
+         0: aload_0
+         1: getfield      #461                // Field random:Lnet/minecraft/util/RandomSource;
+         4: areturn
+
+  public net.minecraft.world.phys.Vec3 getKnownMovement();
+    Code:
+         0: aload_0
+         1: invokevirtual #2141               // Method getControllingPassenger:()Lnet/minecraft/world/entity/LivingEntity;
+         4: astore_2
+         5: aload_2
+         6: instanceof    #3076               // class net/minecraft/world/entity/player/Player
+         9: ifeq          29
+        12: aload_2
+        13: checkcast     #3076               // class net/minecraft/world/entity/player/Player
+        16: astore_1
+        17: aload_0
+        18: invokevirtual #741                // Method isAlive:()Z
+        21: ifeq          29
+        24: aload_1
+        25: invokevirtual #4785               // Method net/minecraft/world/entity/player/Player.getKnownMovement:()Lnet/minecraft/world/phys/Vec3;
+        28: areturn
+        29: aload_0
+        30: invokevirtual #1369               // Method getDeltaMovement:()Lnet/minecraft/world/phys/Vec3;
+        33: areturn
+
+  public net.minecraft.world.phys.Vec3 getKnownSpeed();
+    Code:
+         0: aload_0
+         1: invokevirtual #2141               // Method getControllingPassenger:()Lnet/minecraft/world/entity/LivingEntity;
+         4: astore_2
+         5: aload_2
+         6: instanceof    #3076               // class net/minecraft/world/entity/player/Player
+         9: ifeq          29
+        12: aload_2
+        13: checkcast     #3076               // class net/minecraft/world/entity/player/Player
+        16: astore_1
+        17: aload_0
+        18: invokevirtual #741                // Method isAlive:()Z
+        21: ifeq          29
+        24: aload_1
+        25: invokevirtual #4788               // Method net/minecraft/world/entity/player/Player.getKnownSpeed:()Lnet/minecraft/world/phys/Vec3;
+        28: areturn
+        29: aload_0
+        30: getfield      #534                // Field lastKnownSpeed:Lnet/minecraft/world/phys/Vec3;
+        33: areturn
+
+  public net.minecraft.world.item.ItemStack getWeaponItem();
+    Code:
+         0: aconst_null
+         1: areturn
+
+  public java.util.Optional<net.minecraft.resources.ResourceKey<net.minecraft.world.level.storage.loot.LootTable>> getLootTable();
+    Code:
+         0: aload_0
+         1: getfield      #565                // Field type:Lnet/minecraft/world/entity/EntityType;
+         4: invokevirtual #4794               // Method net/minecraft/world/entity/EntityType.getDefaultLootTable:()Ljava/util/Optional;
+         7: areturn
+
+  protected void applyImplicitComponents(net.minecraft.core.component.DataComponentGetter);
+    Code:
+         0: aload_0
+         1: aload_1
+         2: getstatic     #4803               // Field net/minecraft/core/component/DataComponents.CUSTOM_NAME:Lnet/minecraft/core/component/DataComponentType;
+         5: invokevirtual #4807               // Method applyImplicitComponentIfPresent:(Lnet/minecraft/core/component/DataComponentGetter;Lnet/minecraft/core/component/DataComponentType;)Z
+         8: pop
+         9: aload_0
+        10: aload_1
+        11: getstatic     #4810               // Field net/minecraft/core/component/DataComponents.CUSTOM_DATA:Lnet/minecraft/core/component/DataComponentType;
+        14: invokevirtual #4807               // Method applyImplicitComponentIfPresent:(Lnet/minecraft/core/component/DataComponentGetter;Lnet/minecraft/core/component/DataComponentType;)Z
+        17: pop
+        18: return
+
+  public final void applyComponentsFromItemStack(net.minecraft.world.item.ItemStack);
+    Code:
+         0: aload_0
+         1: aload_1
+         2: invokevirtual #4818               // Method net/minecraft/world/item/ItemStack.getComponents:()Lnet/minecraft/core/component/DataComponentMap;
+         5: invokevirtual #4820               // Method applyImplicitComponents:(Lnet/minecraft/core/component/DataComponentGetter;)V
+         8: return
+
+  public <T> T get(net.minecraft.core.component.DataComponentType<? extends T>);
+    Code:
+         0: aload_1
+         1: getstatic     #4803               // Field net/minecraft/core/component/DataComponents.CUSTOM_NAME:Lnet/minecraft/core/component/DataComponentType;
+         4: if_acmpne     16
+         7: aload_1
+         8: aload_0
+         9: invokevirtual #2783               // Method getCustomName:()Lnet/minecraft/network/chat/Component;
+        12: invokestatic  #4826               // Method castComponentValue:(Lnet/minecraft/core/component/DataComponentType;Ljava/lang/Object;)Ljava/lang/Object;
+        15: areturn
+        16: aload_1
+        17: getstatic     #4810               // Field net/minecraft/core/component/DataComponents.CUSTOM_DATA:Lnet/minecraft/core/component/DataComponentType;
+        20: if_acmpne     32
+        23: aload_1
+        24: aload_0
+        25: getfield      #563                // Field customData:Lnet/minecraft/world/item/component/CustomData;
+        28: invokestatic  #4826               // Method castComponentValue:(Lnet/minecraft/core/component/DataComponentType;Ljava/lang/Object;)Ljava/lang/Object;
+        31: areturn
+        32: aload_0
+        33: invokevirtual #2980               // Method typeHolder:()Lnet/minecraft/core/Holder;
+        36: invokeinterface #4828,  1         // InterfaceMethod net/minecraft/core/Holder.components:()Lnet/minecraft/core/component/DataComponentMap;
+        41: aload_1
+        42: invokeinterface #4832,  2         // InterfaceMethod net/minecraft/core/component/DataComponentMap.get:(Lnet/minecraft/core/component/DataComponentType;)Ljava/lang/Object;
+        47: areturn
+
+  protected static <T> T castComponentValue(net.minecraft.core.component.DataComponentType<T>, java.lang.Object);
+    Code:
+         0: aload_1
+         1: areturn
+
+  public <T> void setComponent(net.minecraft.core.component.DataComponentType<T>, T);
+    Code:
+         0: aload_0
+         1: aload_1
+         2: aload_2
+         3: invokevirtual #4844               // Method applyImplicitComponent:(Lnet/minecraft/core/component/DataComponentType;Ljava/lang/Object;)Z
+         6: pop
+         7: return
+
+  protected <T> boolean applyImplicitComponent(net.minecraft.core.component.DataComponentType<T>, T);
+    Code:
+         0: aload_1
+         1: getstatic     #4803               // Field net/minecraft/core/component/DataComponents.CUSTOM_NAME:Lnet/minecraft/core/component/DataComponentType;
+         4: if_acmpne     23
+         7: aload_0
+         8: getstatic     #4803               // Field net/minecraft/core/component/DataComponents.CUSTOM_NAME:Lnet/minecraft/core/component/DataComponentType;
+        11: aload_2
+        12: invokestatic  #4826               // Method castComponentValue:(Lnet/minecraft/core/component/DataComponentType;Ljava/lang/Object;)Ljava/lang/Object;
+        15: checkcast     #2934               // class net/minecraft/network/chat/Component
+        18: invokevirtual #2938               // Method setCustomName:(Lnet/minecraft/network/chat/Component;)V
+        21: iconst_1
+        22: ireturn
+        23: aload_1
+        24: getstatic     #4810               // Field net/minecraft/core/component/DataComponents.CUSTOM_DATA:Lnet/minecraft/core/component/DataComponentType;
+        27: if_acmpne     46
+        30: aload_0
+        31: getstatic     #4810               // Field net/minecraft/core/component/DataComponents.CUSTOM_DATA:Lnet/minecraft/core/component/DataComponentType;
+        34: aload_2
+        35: invokestatic  #4826               // Method castComponentValue:(Lnet/minecraft/core/component/DataComponentType;Ljava/lang/Object;)Ljava/lang/Object;
+        38: checkcast     #558                // class net/minecraft/world/item/component/CustomData
+        41: putfield      #563                // Field customData:Lnet/minecraft/world/item/component/CustomData;
+        44: iconst_1
+        45: ireturn
+        46: iconst_0
+        47: ireturn
+
+  protected <T> boolean applyImplicitComponentIfPresent(net.minecraft.core.component.DataComponentGetter, net.minecraft.core.component.DataComponentType<T>);
+    Code:
+         0: aload_1
+         1: aload_2
+         2: invokeinterface #4848,  2         // InterfaceMethod net/minecraft/core/component/DataComponentGetter.get:(Lnet/minecraft/core/component/DataComponentType;)Ljava/lang/Object;
+         7: astore_3
+         8: aload_3
+         9: ifnull        19
+        12: aload_0
+        13: aload_2
+        14: aload_3
+        15: invokevirtual #4844               // Method applyImplicitComponent:(Lnet/minecraft/core/component/DataComponentType;Ljava/lang/Object;)Z
+        18: ireturn
+        19: iconst_0
+        20: ireturn
+
+  public net.minecraft.util.ProblemReporter$PathElement problemPath();
+    Code:
+         0: new           #36                 // class net/minecraft/world/entity/Entity$EntityPathElement
+         3: dup
+         4: aload_0
+         5: invokespecial #4850               // Method net/minecraft/world/entity/Entity$EntityPathElement."<init>":(Lnet/minecraft/world/entity/Entity;)V
+         8: areturn
+
+  public void registerDebugValues(net.minecraft.server.level.ServerLevel, net.minecraft.util.debug.DebugValueSource$Registration);
+    Code:
+         0: return
+
+  public net.minecraft.world.phys.AABB getFluidInteractionBox();
+    Code:
+         0: ldc2_w        #4856               // double 0.001d
+         3: dstore_1
+         4: aload_0
+         5: invokevirtual #693                // Method getBoundingBox:()Lnet/minecraft/world/phys/AABB;
+         8: ldc2_w        #4856               // double 0.001d
+        11: invokevirtual #1967               // Method net/minecraft/world/phys/AABB.deflate:(D)Lnet/minecraft/world/phys/AABB;
+        14: astore_3
+        15: aload_0
+        16: invokevirtual #987                // Method getVehicle:()Lnet/minecraft/world/entity/Entity;
+        19: astore        4
+        21: aload         4
+        23: ifnull        33
+        26: aload         4
+        28: aload_3
+        29: invokevirtual #4861               // Method modifyPassengerFluidInteractionBox:(Lnet/minecraft/world/phys/AABB;)Lnet/minecraft/world/phys/AABB;
+        32: astore_3
+        33: aload_3
+        34: areturn
+
+  protected net.minecraft.world.phys.AABB modifyPassengerFluidInteractionBox(net.minecraft.world.phys.AABB);
+    Code:
+         0: aload_1
+         1: areturn
+
+  private static boolean lambda$countPlayerPassengers$0(net.minecraft.world.entity.Entity);
+    Code:
+         0: aload_0
+         1: instanceof    #3076               // class net/minecraft/world/entity/player/Player
+         4: ireturn
+
+  private java.util.Iterator lambda$getIndirectPassengers$0();
+    Code:
+         0: aload_0
+         1: invokevirtual #3332               // Method getIndirectPassengersStream:()Ljava/util/stream/Stream;
+         4: invokeinterface #4865,  1         // InterfaceMethod java/util/stream/Stream.iterator:()Ljava/util/Iterator;
+         9: areturn
+
+  private static void lambda$teleportPassengers$0(net.minecraft.world.entity.Entity);
+    Code:
+         0: aload_0
+         1: getfield      #438                // Field passengers:Lcom/google/common/collect/ImmutableList;
+         4: invokevirtual #1923               // Method com/google/common/collect/ImmutableList.iterator:()Lcom/google/common/collect/UnmodifiableIterator;
+         7: astore_1
+         8: aload_1
+         9: invokeinterface #1827,  1         // InterfaceMethod java/util/Iterator.hasNext:()Z
+        14: ifeq          40
+        17: aload_1
+        18: invokeinterface #1830,  1         // InterfaceMethod java/util/Iterator.next:()Ljava/lang/Object;
+        23: checkcast     #2                  // class net/minecraft/world/entity/Entity
+        26: astore_2
+        27: aload_0
+        28: aload_2
+        29: invokedynamic #4867,  0           // InvokeDynamic #26:accept:()Lnet/minecraft/world/entity/Entity$MoveFunction;
+        34: invokevirtual #3252               // Method positionRider:(Lnet/minecraft/world/entity/Entity;Lnet/minecraft/world/entity/Entity$MoveFunction;)V
+        37: goto          8
+        40: return
+
+  private net.minecraft.network.chat.Style lambda$getDisplayName$0(net.minecraft.network.chat.Style);
+    Code:
+         0: aload_1
+         1: aload_0
+         2: invokevirtual #4871               // Method createHoverEvent:()Lnet/minecraft/network/chat/HoverEvent;
+         5: invokevirtual #4875               // Method net/minecraft/network/chat/Style.withHoverEvent:(Lnet/minecraft/network/chat/HoverEvent;)Lnet/minecraft/network/chat/Style;
+         8: aload_0
+         9: invokevirtual #4877               // Method getStringUUID:()Ljava/lang/String;
+        12: invokevirtual #4881               // Method net/minecraft/network/chat/Style.withInsertion:(Ljava/lang/String;)Lnet/minecraft/network/chat/Style;
+        15: areturn
+
+  private java.lang.String lambda$fillCrashReportCategory$3() throws java.lang.Exception;
+    Code:
+         0: aload_0
+         1: invokevirtual #987                // Method getVehicle:()Lnet/minecraft/world/entity/Entity;
+         4: invokestatic  #4887               // Method java/lang/String.valueOf:(Ljava/lang/Object;)Ljava/lang/String;
+         7: areturn
+
+  private java.lang.String lambda$fillCrashReportCategory$2() throws java.lang.Exception;
+    Code:
+         0: aload_0
+         1: invokevirtual #2307               // Method getPassengers:()Ljava/util/List;
+         4: invokeinterface #4888,  1         // InterfaceMethod java/util/List.toString:()Ljava/lang/String;
+         9: areturn
+
+  private java.lang.String lambda$fillCrashReportCategory$1() throws java.lang.Exception;
+    Code:
+         0: aload_0
+         1: invokevirtual #3871               // Method getPlainTextName:()Ljava/lang/String;
+         4: areturn
+
+  private java.lang.String lambda$fillCrashReportCategory$0() throws java.lang.Exception;
+    Code:
+         0: aload_0
+         1: invokevirtual #2980               // Method typeHolder:()Lnet/minecraft/core/Holder;
+         4: invokeinterface #4891,  1         // InterfaceMethod net/minecraft/core/Holder.getRegisteredName:()Ljava/lang/String;
+         9: aload_0
+        10: invokevirtual #3863               // Method java/lang/Object.getClass:()Ljava/lang/Class;
+        13: invokevirtual #4894               // Method java/lang/Class.getCanonicalName:()Ljava/lang/String;
+        16: invokedynamic #4899,  0           // InvokeDynamic #27:makeConcatWithConstants:(Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;
+        21: areturn
+
+  private void lambda$moveOrInterpolateTo$1(java.lang.Float);
+    Code:
+         0: aload_0
+         1: aload_1
+         2: invokevirtual #2358               // Method java/lang/Float.floatValue:()F
+         5: ldc_w         #900                // float 360.0f
+         8: frem
+         9: invokevirtual #907                // Method setXRot:(F)V
+        12: return
+
+  private void lambda$moveOrInterpolateTo$0(java.lang.Float);
+    Code:
+         0: aload_0
+         1: aload_1
+         2: invokevirtual #2358               // Method java/lang/Float.floatValue:()F
+         5: ldc_w         #900                // float 360.0f
+         8: frem
+         9: invokevirtual #904                // Method setYRot:(F)V
+        12: return
+
+  private static boolean lambda$removePassenger$0(net.minecraft.world.entity.Entity, net.minecraft.world.entity.Entity);
+    Code:
+         0: aload_1
+         1: aload_0
+         2: if_acmpeq     9
+         5: iconst_1
+         6: goto          10
+         9: iconst_0
+        10: ireturn
+
+  private static void lambda$startRiding$1(net.minecraft.world.entity.Entity);
+    Code:
+         0: getstatic     #4905               // Field net/minecraft/advancements/triggers/CriteriaTriggers.START_RIDING_TRIGGER:Lnet/minecraft/advancements/triggers/StartRidingTrigger;
+         3: aload_0
+         4: checkcast     #2680               // class net/minecraft/server/level/ServerPlayer
+         7: invokevirtual #4909               // Method net/minecraft/advancements/triggers/StartRidingTrigger.trigger:(Lnet/minecraft/server/level/ServerPlayer;)V
+        10: return
+
+  private static boolean lambda$startRiding$0(net.minecraft.world.entity.Entity);
+    Code:
+         0: aload_0
+         1: instanceof    #2680               // class net/minecraft/server/level/ServerPlayer
+         4: ireturn
+
+  private static boolean lambda$interact$0(net.minecraft.world.entity.player.Player, net.minecraft.world.entity.Leashable);
+    Code:
+         0: aload_1
+         1: invokeinterface #3163,  1         // InterfaceMethod net/minecraft/world/entity/Leashable.getLeashHolder:()Lnet/minecraft/world/entity/Entity;
+         6: aload_0
+         7: if_acmpne     14
+        10: iconst_1
+        11: goto          15
+        14: iconst_0
+        15: ireturn
+
+  private boolean lambda$isInWall$0(net.minecraft.world.phys.AABB, net.minecraft.core.BlockPos);
+    Code:
+         0: aload_0
+         1: invokevirtual #672                // Method level:()Lnet/minecraft/world/level/Level;
+         4: aload_2
+         5: invokevirtual #1339               // Method net/minecraft/world/level/Level.getBlockState:(Lnet/minecraft/core/BlockPos;)Lnet/minecraft/world/level/block/state/BlockState;
+         8: astore_3
+         9: aload_3
+        10: invokevirtual #1481               // Method net/minecraft/world/level/block/state/BlockState.isAir:()Z
+        13: ifne          58
+        16: aload_3
+        17: aload_0
+        18: invokevirtual #672                // Method level:()Lnet/minecraft/world/level/Level;
+        21: aload_2
+        22: invokevirtual #4913               // Method net/minecraft/world/level/block/state/BlockState.isSuffocating:(Lnet/minecraft/world/level/BlockGetter;Lnet/minecraft/core/BlockPos;)Z
+        25: ifeq          58
+        28: aload_3
+        29: aload_0
+        30: invokevirtual #672                // Method level:()Lnet/minecraft/world/level/Level;
+        33: aload_2
+        34: invokevirtual #4916               // Method net/minecraft/world/level/block/state/BlockState.getCollisionShape:(Lnet/minecraft/world/level/BlockGetter;Lnet/minecraft/core/BlockPos;)Lnet/minecraft/world/phys/shapes/VoxelShape;
+        37: aload_2
+        38: invokevirtual #689                // Method net/minecraft/world/phys/shapes/VoxelShape.move:(Lnet/minecraft/core/Vec3i;)Lnet/minecraft/world/phys/shapes/VoxelShape;
+        41: aload_1
+        42: invokestatic  #698                // Method net/minecraft/world/phys/shapes/Shapes.create:(Lnet/minecraft/world/phys/AABB;)Lnet/minecraft/world/phys/shapes/VoxelShape;
+        45: getstatic     #704                // Field net/minecraft/world/phys/shapes/BooleanOp.AND:Lnet/minecraft/world/phys/shapes/BooleanOp;
+        48: invokestatic  #708                // Method net/minecraft/world/phys/shapes/Shapes.joinIsNotEmpty:(Lnet/minecraft/world/phys/shapes/VoxelShape;Lnet/minecraft/world/phys/shapes/VoxelShape;Lnet/minecraft/world/phys/shapes/BooleanOp;)Z
+        51: ifeq          58
+        54: iconst_1
+        55: goto          59
+        58: iconst_0
+        59: ireturn
+
+  private static java.lang.IllegalStateException lambda$getEncodeId$0();
+    Code:
+         0: new           #789                // class java/lang/IllegalStateException
+         3: dup
+         4: ldc_w         #4918               // String Unregistered entity
+         7: invokespecial #794                // Method java/lang/IllegalStateException."<init>":(Ljava/lang/String;)V
+        10: areturn
+
+  private void lambda$load$0(java.util.UUID);
+    Code:
+         0: aload_0
+         1: aload_1
+         2: putfield      #504                // Field uuid:Ljava/util/UUID;
+         5: aload_0
+         6: aload_0
+         7: getfield      #504                // Field uuid:Ljava/util/UUID;
+        10: invokevirtual #510                // Method java/util/UUID.toString:()Ljava/lang/String;
+        13: putfield      #512                // Field stringUUID:Ljava/lang/String;
+        16: return
+
+  private net.minecraft.world.level.block.state.BlockState lambda$checkFallDamage$0(net.minecraft.core.BlockPos);
+    Code:
+         0: aload_0
+         1: invokevirtual #672                // Method level:()Lnet/minecraft/world/level/Level;
+         4: aload_1
+         5: invokevirtual #1339               // Method net/minecraft/world/level/Level.getBlockState:(Lnet/minecraft/core/BlockPos;)Lnet/minecraft/world/level/block/state/BlockState;
+         8: areturn
+
+  private boolean lambda$checkInsideBlocks$0(int, java.util.concurrent.atomic.AtomicInteger, boolean, net.minecraft.world.phys.Vec3, net.minecraft.world.phys.Vec3, it.unimi.dsi.fastutil.longs.LongSet, boolean, net.minecraft.world.phys.AABB, net.minecraft.world.entity.InsideBlockEffectApplier$StepBasedCollector, net.minecraft.core.BlockPos, int);
+    Code:
+         0: aload_0
+         1: invokevirtual #741                // Method isAlive:()Z
+         4: ifne          9
+         7: iconst_0
+         8: ireturn
+         9: iload         11
+        11: iload_1
+        12: if_icmplt     17
+        15: iconst_0
+        16: ireturn
+        17: aload_2
+        18: iload         11
+        20: invokevirtual #4920               // Method java/util/concurrent/atomic/AtomicInteger.set:(I)V
+        23: aload_0
+        24: invokevirtual #672                // Method level:()Lnet/minecraft/world/level/Level;
+        27: aload         10
+        29: invokevirtual #1339               // Method net/minecraft/world/level/Level.getBlockState:(Lnet/minecraft/core/BlockPos;)Lnet/minecraft/world/level/block/state/BlockState;
+        32: astore        12
+        34: aload         12
+        36: invokevirtual #1481               // Method net/minecraft/world/level/block/state/BlockState.isAir:()Z
+        39: ifeq          66
+        42: iload_3
+        43: ifeq          64
+        46: aload_0
+        47: aload_0
+        48: invokevirtual #672                // Method level:()Lnet/minecraft/world/level/Level;
+        51: checkcast     #1016               // class net/minecraft/server/level/ServerLevel
+        54: aload         10
+        56: invokevirtual #3533               // Method net/minecraft/core/BlockPos.immutable:()Lnet/minecraft/core/BlockPos;
+        59: iconst_0
+        60: iconst_0
+        61: invokevirtual #4922               // Method debugBlockIntersection:(Lnet/minecraft/server/level/ServerLevel;Lnet/minecraft/core/BlockPos;ZZ)V
+        64: iconst_1
+        65: ireturn
+        66: aload         12
+        68: aload_0
+        69: invokevirtual #672                // Method level:()Lnet/minecraft/world/level/Level;
+        72: aload         10
+        74: aload_0
+        75: invokevirtual #4926               // Method net/minecraft/world/level/block/state/BlockState.getEntityInsideCollisionShape:(Lnet/minecraft/world/level/BlockGetter;Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/entity/Entity;)Lnet/minecraft/world/phys/shapes/VoxelShape;
+        78: astore        13
+        80: aload         13
+        82: invokestatic  #4928               // Method net/minecraft/world/phys/shapes/Shapes.block:()Lnet/minecraft/world/phys/shapes/VoxelShape;
+        85: if_acmpeq     116
+        88: aload_0
+        89: aload         4
+        91: aload         5
+        93: aload         13
+        95: new           #440                // class net/minecraft/world/phys/Vec3
+        98: dup
+        99: aload         10
+       101: invokespecial #4931               // Method net/minecraft/world/phys/Vec3."<init>":(Lnet/minecraft/core/Vec3i;)V
+       104: invokevirtual #4934               // Method net/minecraft/world/phys/shapes/VoxelShape.move:(Lnet/minecraft/world/phys/Vec3;)Lnet/minecraft/world/phys/shapes/VoxelShape;
+       107: invokevirtual #4937               // Method net/minecraft/world/phys/shapes/VoxelShape.toAabbs:()Ljava/util/List;
+       110: invokevirtual #2063               // Method collidedWithShapeMovingFrom:(Lnet/minecraft/world/phys/Vec3;Lnet/minecraft/world/phys/Vec3;Ljava/util/List;)Z
+       113: ifeq          120
+       116: iconst_1
+       117: goto          121
+       120: iconst_0
+       121: istore        14
+       123: aload_0
+       124: aload         12
+       126: invokevirtual #4940               // Method net/minecraft/world/level/block/state/BlockState.getFluidState:()Lnet/minecraft/world/level/material/FluidState;
+       129: aload         10
+       131: aload         4
+       133: aload         5
+       135: invokevirtual #4942               // Method collidedWithFluid:(Lnet/minecraft/world/level/material/FluidState;Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/phys/Vec3;Lnet/minecraft/world/phys/Vec3;)Z
+       138: istore        15
+       140: iload         14
+       142: ifne          150
+       145: iload         15
+       147: ifeq          165
+       150: aload         6
+       152: aload         10
+       154: invokevirtual #4945               // Method net/minecraft/core/BlockPos.asLong:()J
+       157: invokeinterface #4948,  3         // InterfaceMethod it/unimi/dsi/fastutil/longs/LongSet.add:(J)Z
+       162: ifne          167
+       165: iconst_1
+       166: ireturn
+       167: iload         14
+       169: ifeq          287
+       172: iload         7
+       174: ifne          187
+       177: aload         8
+       179: aload         10
+       181: invokevirtual #4951               // Method net/minecraft/world/phys/AABB.intersects:(Lnet/minecraft/core/BlockPos;)Z
+       184: ifeq          191
+       187: iconst_1
+       188: goto          192
+       191: iconst_0
+       192: istore        16
+       194: aload         9
+       196: iload         11
+       198: invokevirtual #4954               // Method net/minecraft/world/entity/InsideBlockEffectApplier$StepBasedCollector.advanceStep:(I)V
+       201: aload         12
+       203: aload_0
+       204: invokevirtual #672                // Method level:()Lnet/minecraft/world/level/Level;
+       207: aload         10
+       209: aload_0
+       210: aload         9
+       212: iload         16
+       214: invokevirtual #4958               // Method net/minecraft/world/level/block/state/BlockState.entityInside:(Lnet/minecraft/world/level/Level;Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/entity/Entity;Lnet/minecraft/world/entity/InsideBlockEffectApplier;Z)V
+       217: aload_0
+       218: aload         12
+       220: invokevirtual #4960               // Method onInsideBlock:(Lnet/minecraft/world/level/block/state/BlockState;)V
+       223: goto          287
+       226: astore        16
+       228: aload         16
+       230: ldc_w         #4962               // String Colliding entity with block
+       233: invokestatic  #2836               // Method net/minecraft/CrashReport.forThrowable:(Ljava/lang/Throwable;Ljava/lang/String;)Lnet/minecraft/CrashReport;
+       236: astore        17
+       238: aload         17
+       240: ldc_w         #4964               // String Block being collided with
+       243: invokevirtual #2842               // Method net/minecraft/CrashReport.addCategory:(Ljava/lang/String;)Lnet/minecraft/CrashReportCategory;
+       246: astore        18
+       248: aload         18
+       250: aload_0
+       251: invokevirtual #672                // Method level:()Lnet/minecraft/world/level/Level;
+       254: aload         10
+       256: aload         12
+       258: invokestatic  #4968               // Method net/minecraft/CrashReportCategory.populateBlockDetails:(Lnet/minecraft/CrashReportCategory;Lnet/minecraft/world/level/LevelHeightAccessor;Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/level/block/state/BlockState;)V
+       261: aload         17
+       263: ldc_w         #4970               // String Entity being checked for collision
+       266: invokevirtual #2842               // Method net/minecraft/CrashReport.addCategory:(Ljava/lang/String;)Lnet/minecraft/CrashReportCategory;
+       269: astore        19
+       271: aload_0
+       272: aload         19
+       274: invokevirtual #2846               // Method fillCrashReportCategory:(Lnet/minecraft/CrashReportCategory;)V
+       277: new           #2848               // class net/minecraft/ReportedException
+       280: dup
+       281: aload         17
+       283: invokespecial #2851               // Method net/minecraft/ReportedException."<init>":(Lnet/minecraft/CrashReport;)V
+       286: athrow
+       287: iload         15
+       289: ifeq          316
+       292: aload         9
+       294: iload         11
+       296: invokevirtual #4954               // Method net/minecraft/world/entity/InsideBlockEffectApplier$StepBasedCollector.advanceStep:(I)V
+       299: aload         12
+       301: invokevirtual #4940               // Method net/minecraft/world/level/block/state/BlockState.getFluidState:()Lnet/minecraft/world/level/material/FluidState;
+       304: aload_0
+       305: invokevirtual #672                // Method level:()Lnet/minecraft/world/level/Level;
+       308: aload         10
+       310: aload_0
+       311: aload         9
+       313: invokevirtual #4973               // Method net/minecraft/world/level/material/FluidState.entityInside:(Lnet/minecraft/world/level/Level;Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/entity/Entity;Lnet/minecraft/world/entity/InsideBlockEffectApplier;)V
+       316: iload_3
+       317: ifeq          340
+       320: aload_0
+       321: aload_0
+       322: invokevirtual #672                // Method level:()Lnet/minecraft/world/level/Level;
+       325: checkcast     #1016               // class net/minecraft/server/level/ServerLevel
+       328: aload         10
+       330: invokevirtual #3533               // Method net/minecraft/core/BlockPos.immutable:()Lnet/minecraft/core/BlockPos;
+       333: iload         14
+       335: iload         15
+       337: invokevirtual #4922               // Method debugBlockIntersection:(Lnet/minecraft/server/level/ServerLevel;Lnet/minecraft/core/BlockPos;ZZ)V
+       340: iconst_1
+       341: ireturn
+      Exception table:
+         from    to  target type
+           172   223   226   Class java/lang/Throwable
+
+  static {};
+    Code:
+         0: invokestatic  #4985               // Method com/mojang/logging/LogUtils.getLogger:()Lorg/slf4j/Logger;
+         3: putstatic     #3913               // Field LOGGER:Lorg/slf4j/Logger;
+         6: getstatic     #4991               // Field com/mojang/serialization/Codec.STRING:Lcom/mojang/serialization/codecs/PrimitiveCodec;
+         9: sipush        1024
+        12: invokeinterface #4997,  2         // InterfaceMethod com/mojang/serialization/codecs/PrimitiveCodec.sizeLimitedListOf:(I)Lcom/mojang/serialization/Codec;
+        17: putstatic     #2805               // Field TAG_LIST_CODEC:Lcom/mojang/serialization/Codec;
+        20: new           #1163               // class net/minecraft/world/phys/AABB
+        23: dup
+        24: dconst_0
+        25: dconst_0
+        26: dconst_0
+        27: dconst_0
+        28: dconst_0
+        29: dconst_0
+        30: invokespecial #1215               // Method net/minecraft/world/phys/AABB."<init>":(DDDDDD)V
+        33: putstatic     #447                // Field INITIAL_AABB:Lnet/minecraft/world/phys/AABB;
+        36: dconst_1
+        37: putstatic     #2709               // Field viewScale:D
+        40: ldc           #2                  // class net/minecraft/world/entity/Entity
+        42: getstatic     #5003               // Field net/minecraft/network/syncher/EntityDataSerializers.BYTE:Lnet/minecraft/network/syncher/EntityDataSerializer;
+        45: invokestatic  #5007               // Method net/minecraft/network/syncher/SynchedEntityData.defineId:(Ljava/lang/Class;Lnet/minecraft/network/syncher/EntityDataSerializer;)Lnet/minecraft/network/syncher/EntityDataAccessor;
+        48: putstatic     #598                // Field DATA_SHARED_FLAGS_ID:Lnet/minecraft/network/syncher/EntityDataAccessor;
+        51: ldc           #2                  // class net/minecraft/world/entity/Entity
+        53: getstatic     #5010               // Field net/minecraft/network/syncher/EntityDataSerializers.INT:Lnet/minecraft/network/syncher/EntityDataSerializer;
+        56: invokestatic  #5007               // Method net/minecraft/network/syncher/SynchedEntityData.defineId:(Ljava/lang/Class;Lnet/minecraft/network/syncher/EntityDataSerializer;)Lnet/minecraft/network/syncher/EntityDataAccessor;
+        59: putstatic     #610                // Field DATA_AIR_SUPPLY_ID:Lnet/minecraft/network/syncher/EntityDataAccessor;
+        62: ldc           #2                  // class net/minecraft/world/entity/Entity
+        64: getstatic     #5013               // Field net/minecraft/network/syncher/EntityDataSerializers.OPTIONAL_COMPONENT:Lnet/minecraft/network/syncher/EntityDataSerializer;
+        67: invokestatic  #5007               // Method net/minecraft/network/syncher/SynchedEntityData.defineId:(Ljava/lang/Class;Lnet/minecraft/network/syncher/EntityDataSerializer;)Lnet/minecraft/network/syncher/EntityDataAccessor;
+        70: putstatic     #627                // Field DATA_CUSTOM_NAME:Lnet/minecraft/network/syncher/EntityDataAccessor;
+        73: ldc           #2                  // class net/minecraft/world/entity/Entity
+        75: getstatic     #5016               // Field net/minecraft/network/syncher/EntityDataSerializers.BOOLEAN:Lnet/minecraft/network/syncher/EntityDataSerializer;
+        78: invokestatic  #5007               // Method net/minecraft/network/syncher/SynchedEntityData.defineId:(Ljava/lang/Class;Lnet/minecraft/network/syncher/EntityDataSerializer;)Lnet/minecraft/network/syncher/EntityDataAccessor;
+        81: putstatic     #620                // Field DATA_CUSTOM_NAME_VISIBLE:Lnet/minecraft/network/syncher/EntityDataAccessor;
+        84: ldc           #2                  // class net/minecraft/world/entity/Entity
+        86: getstatic     #5016               // Field net/minecraft/network/syncher/EntityDataSerializers.BOOLEAN:Lnet/minecraft/network/syncher/EntityDataSerializer;
+        89: invokestatic  #5007               // Method net/minecraft/network/syncher/SynchedEntityData.defineId:(Ljava/lang/Class;Lnet/minecraft/network/syncher/EntityDataSerializer;)Lnet/minecraft/network/syncher/EntityDataAccessor;
+        92: putstatic     #629                // Field DATA_SILENT:Lnet/minecraft/network/syncher/EntityDataAccessor;
+        95: ldc           #2                  // class net/minecraft/world/entity/Entity
+        97: getstatic     #5016               // Field net/minecraft/network/syncher/EntityDataSerializers.BOOLEAN:Lnet/minecraft/network/syncher/EntityDataSerializer;
+       100: invokestatic  #5007               // Method net/minecraft/network/syncher/SynchedEntityData.defineId:(Ljava/lang/Class;Lnet/minecraft/network/syncher/EntityDataSerializer;)Lnet/minecraft/network/syncher/EntityDataAccessor;
+       103: putstatic     #631                // Field DATA_NO_GRAVITY:Lnet/minecraft/network/syncher/EntityDataAccessor;
+       106: ldc           #2                  // class net/minecraft/world/entity/Entity
+       108: getstatic     #5019               // Field net/minecraft/network/syncher/EntityDataSerializers.POSE:Lnet/minecraft/network/syncher/EntityDataSerializer;
+       111: invokestatic  #5007               // Method net/minecraft/network/syncher/SynchedEntityData.defineId:(Ljava/lang/Class;Lnet/minecraft/network/syncher/EntityDataSerializer;)Lnet/minecraft/network/syncher/EntityDataAccessor;
+       114: putstatic     #633                // Field DATA_POSE:Lnet/minecraft/network/syncher/EntityDataAccessor;
+       117: ldc           #2                  // class net/minecraft/world/entity/Entity
+       119: getstatic     #5010               // Field net/minecraft/network/syncher/EntityDataSerializers.INT:Lnet/minecraft/network/syncher/EntityDataSerializer;
+       122: invokestatic  #5007               // Method net/minecraft/network/syncher/SynchedEntityData.defineId:(Ljava/lang/Class;Lnet/minecraft/network/syncher/EntityDataSerializer;)Lnet/minecraft/network/syncher/EntityDataAccessor;
+       125: putstatic     #641                // Field DATA_TICKS_FROZEN:Lnet/minecraft/network/syncher/EntityDataAccessor;
+       128: return
+}

--- a/fabric/src/main/java/dev/vox/lss/networking/client/FarPlayerMountLadder.java
+++ b/fabric/src/main/java/dev/vox/lss/networking/client/FarPlayerMountLadder.java
@@ -92,7 +92,11 @@ final class FarPlayerMountLadder {
                 return null;
             }
             return entity;
-        } catch (Exception e) {
+        } catch (Throwable e) {
+            // Throwable, not Exception (issue-#160 review MINOR-3): EntityType.create
+            // first-loads the modded class here, and a client-side NoClassDefFoundError
+            // (server-oriented mod internals absent on the client) must latch the TYPE,
+            // not escape to the whole-pass latch.
             latchWarn(typeIdentity, "creation failed (" + e + ")");
             return null;
         }
@@ -106,7 +110,7 @@ final class FarPlayerMountLadder {
      *  submit threw is latched like a creation failure — its riders render unmounted
      *  from the next frame, and the GLOBAL crash latch never fires for a per-type
      *  problem. */
-    void latchRenderFailure(String typeIdentity, Exception e) {
+    void latchRenderFailure(String typeIdentity, Throwable e) {
         latchWarn(typeIdentity, "rendering failed (" + e + ")");
     }
 

--- a/fabric/src/main/java/dev/vox/lss/networking/client/FarPlayerRenderer.java
+++ b/fabric/src/main/java/dev/vox/lss/networking/client/FarPlayerRenderer.java
@@ -132,13 +132,24 @@ public final class FarPlayerRenderer {
     }
 
     /** The ENTITY_LOAD edge trigger: a REAL player entity appearing kills its proxy
-     *  the same frame (crossfade guard — never render both). Main client thread. */
+     *  the same frame (crossfade guard — never render both). Main client thread.
+     *  CONTAINED (issue-#160 review MAJOR-1): this fires from ClientLevel's entity-add
+     *  path during PACKET HANDLING with no latch above it, and stopRiding dispatches
+     *  virtually into the modded vehicle class (Create's removePassenger reads
+     *  contraption state a bare client-created instance does not have) — an escaping
+     *  throw here crashed the client on the COMMON approach-a-mounted-far-player path.
+     *  The proxy is already removed either way; a stuck link dies with it. */
     static void onRealPlayerLoad(UUID uuid) {
         var r = instance;
         if (r != null) {
             var removed = r.proxies.remove(uuid);
             if (removed != null && removed.isPassenger()) {
-                removed.stopRiding(); // m2: never leave the link on the live mount
+                try {
+                    removed.stopRiding(); // m2: never leave the link on the live mount
+                } catch (Throwable t) {
+                    // Modded removePassenger threw on half-initialized state — the
+                    // proxy is dropped regardless; nothing renders it again.
+                }
             }
         }
     }
@@ -152,8 +163,12 @@ public final class FarPlayerRenderer {
         for (var mount : vehicles.values()) {
             try {
                 mount.entity.ejectPassengers();
-            } catch (Exception ignored) {
-                // The maps drop either way; a stuck link dies with the instance.
+            } catch (Throwable ignored) {
+                // Throwable, not Exception (issue-#160 review MINOR-3): clear() runs
+                // INSIDE the whole-pass catch, so a LinkageError from a modded
+                // removePassenger here would escape render() entirely — the one
+                // remaining render-thread crash window. The maps drop either way; a
+                // stuck link dies with the instance.
             }
         }
         proxies.clear();
@@ -243,9 +258,35 @@ public final class FarPlayerRenderer {
                             : current);
             boolean allowWalk = config.farPlayersMaxAnimationDistanceBlocks > 0
                     && distance <= config.farPlayersMaxAnimationDistanceBlocks;
-            proxy.apply(tracked, sample, position, config.farPlayersNameTags,
-                    maxRender > 0 ? maxRender : 16384, allowWalk, animationTick,
-                    itemCache);
+            // Rider-while-seated attribution (issue-#160 review MINOR-1): from frame 2
+            // of a ride the proxy IS a passenger, and apply's snapTo/setPose reach
+            // makeBoundingBox — which Create-class mixins wrap with vehicle-state
+            // reads (getSeatPos on a bare client-created contraption is the literal
+            // issue-#160 NPE). Seated, that throw must latch the VEHICLE's type and
+            // re-apply unmounted — not fall through to the whole-pass latch and kill
+            // the feature for the session.
+            if (proxy.isPassenger()) {
+                try {
+                    proxy.apply(tracked, sample, position, config.farPlayersNameTags,
+                            maxRender > 0 ? maxRender : 16384, allowWalk, animationTick,
+                            itemCache);
+                } catch (Throwable t) {
+                    latchSeatedFailure(tracked, proxy, t);
+                    // Unmounted, the vehicle-state mixin path is inert — one retry.
+                    // Guarded: if even the link-break threw (latchSeatedFailure dropped
+                    // the proxy), a still-seated retry would re-throw into the
+                    // whole-pass latch — skip this rider this frame instead.
+                    if (!proxy.isPassenger()) {
+                        proxy.apply(tracked, sample, position, config.farPlayersNameTags,
+                                maxRender > 0 ? maxRender : 16384, allowWalk,
+                                animationTick, itemCache);
+                    }
+                }
+            } else {
+                proxy.apply(tracked, sample, position, config.farPlayersNameTags,
+                        maxRender > 0 ? maxRender : 16384, allowWalk, animationTick,
+                        itemCache);
+            }
             active.add(tracked.uuid());
 
             // R-10 v1.3 mounts: the rider renders at its OWN wire position (the
@@ -262,24 +303,54 @@ public final class FarPlayerRenderer {
                 try {
                     renderMount(wireVehicle, tracked, proxy, level, now, animationTick,
                             dispatcher, partialTick, cameraPosition, poseStack, context);
-                } catch (Exception e) {
+                } catch (Throwable e) {
+                    // Throwable, not Exception (MINOR-3): a LinkageError from a modded
+                    // entity class init must latch the TYPE, not the whole feature.
                     mountLadder.latchRenderFailure(wireVehicle.typeIdentity(), e);
                     vehicles.remove(wireVehicle.uuid());
-                    if (proxy.isPassenger()) proxy.stopRiding();
+                    stopRidingContained(proxy); // MINOR-2: a throwing removePassenger
+                    // here escaped this catch to the whole-pass latch — same frame,
+                    // whole feature off where the type was already latched.
                 }
             } else if (proxy.isPassenger()) {
-                proxy.stopRiding(); // dismount edge
+                // Dismount edge (MINOR-2): the wire says unmounted, the local link may
+                // sit on a broken modded vehicle. A throwing dismount drops the proxy
+                // wholesale (fresh unmounted proxy next frame) instead of feature-off.
+                if (!stopRidingContained(proxy)) {
+                    proxies.remove(tracked.uuid());
+                    active.remove(tracked.uuid());
+                    continue;
+                }
             }
 
-            var renderState = dispatcher.extractEntity(proxy, partialTick);
-            dispatcher.submit(
-                    renderState,
-                    context.levelState().cameraRenderState,
-                    position.x - cameraPosition.x,
-                    position.y - cameraPosition.y,
-                    position.z - cameraPosition.z,
-                    poseStack,
-                    context.submitNodeCollector());
+            // Rider extraction while seated runs extraction mixins against the vehicle
+            // (MINOR-1's second half): attribute a seated throw to the vehicle type and
+            // skip this rider this frame — it renders unmounted next frame.
+            if (proxy.isPassenger()) {
+                try {
+                    var renderState = dispatcher.extractEntity(proxy, partialTick);
+                    dispatcher.submit(
+                            renderState,
+                            context.levelState().cameraRenderState,
+                            position.x - cameraPosition.x,
+                            position.y - cameraPosition.y,
+                            position.z - cameraPosition.z,
+                            poseStack,
+                            context.submitNodeCollector());
+                } catch (Throwable t) {
+                    latchSeatedFailure(tracked, proxy, t);
+                }
+            } else {
+                var renderState = dispatcher.extractEntity(proxy, partialTick);
+                dispatcher.submit(
+                        renderState,
+                        context.levelState().cameraRenderState,
+                        position.x - cameraPosition.x,
+                        position.y - cameraPosition.y,
+                        position.z - cameraPosition.z,
+                        poseStack,
+                        context.submitNodeCollector());
+            }
         }
         // Prune with the ride link BROKEN (E3 review m2): a proxy dropped while
         // riding otherwise stays in the mount's passenger list — no ghost render
@@ -289,8 +360,8 @@ public final class FarPlayerRenderer {
         while (proxyIt.hasNext()) {
             var entry = proxyIt.next();
             if (!active.contains(entry.getKey())) {
-                if (entry.getValue().isPassenger()) entry.getValue().stopRiding();
-                proxyIt.remove();
+                if (entry.getValue().isPassenger()) stopRidingContained(entry.getValue());
+                proxyIt.remove(); // dropped either way — a stuck link dies with it
             }
         }
         // Vehicle lifecycle (R-10): evict instances no rider referenced this frame
@@ -298,6 +369,36 @@ public final class FarPlayerRenderer {
         vehicles.keySet().removeIf(uuid -> !activeVehicles.contains(uuid));
         activeVehicles.clear();
         submittedVehicles.clear();
+    }
+
+    /** Contained dismount: modded removePassenger overrides can throw on the same
+     *  half-initialized state that motivated the type latch (issue-#160 review
+     *  MINOR-2). Returns false when the link could not be cleanly broken — the caller
+     *  drops the proxy so a broken link never persists. */
+    private static boolean stopRidingContained(Proxy proxy) {
+        try {
+            proxy.stopRiding();
+            return true;
+        } catch (Throwable t) {
+            return false;
+        }
+    }
+
+    /** Attributes a rider-while-seated throw (apply/extract reaching vehicle-state
+     *  mixins — the literal issue-#160 stack) to the VEHICLE's type: latch it, drop
+     *  the mount instance, break the link (contained), so the rider continues
+     *  unmounted and the feature keeps working for every other type (MINOR-1). */
+    private void latchSeatedFailure(FarPlayerClientTracker.TrackedFarPlayer tracked,
+                                    Proxy proxy, Throwable t) {
+        var wireVehicle = tracked.latest().vehicle();
+        String type = wireVehicle != null ? wireVehicle.typeIdentity()
+                : String.valueOf(proxy.getVehicle() == null ? null
+                        : proxy.getVehicle().getType());
+        mountLadder.latchRenderFailure(type, t);
+        if (wireVehicle != null) vehicles.remove(wireVehicle.uuid());
+        if (!stopRidingContained(proxy)) {
+            proxies.remove(tracked.uuid());
+        }
     }
 
     /** The per-rider mount pass: resolve/create/link/submit. Throws propagate to the


### PR DESCRIPTION
Targeted safe-degradation review of our far-players feature against the crash class in #160 (the NeoForge port's Create Big Cannons NPE). Our render-pass latch already prevented the literal crash; this PR closes the one reachable crash path (the uncontained ENTITY_LOAD dismount) and upgrades whole-feature-off degradations to per-vehicle-type latching, per the review's findings. Details in the commit message.

Gates: full T1 both platforms + T2 (72 gametests) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)