### PR TITLE
Stage-G back-flow: port-found hardening

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,6 @@ benchmark-compare-results/
 # Store gate harness output (JFR profiles are huge)
 store-gate-results/
 CLAUDE.local.md
+
+# Tier-3/gametest client cache droppings (the .lss gameDir convention)
+fabric/.lss/

--- a/docs/planning/port-runbook.md
+++ b/docs/planning/port-runbook.md
@@ -34,8 +34,14 @@ docs/planning/per-version-surfaces.md; this doc is the ORDER and the rules.
 3. **Line identity commit**: `.github/line.env` (~10 values: tag suffix, three MC
    tokens, three game-version lists, paper loaders, NeoForge name prose ≤64 chars
    resolved, make_latest=false, Java version) + `gradle.properties`
-   (`minecraft_version`, `minecraft_dependency`, dep pins) + per-line build.gradle
-   pins. `ReleaseWorkflowContractTest` + `ToolchainContractTest` follow the data
+   (`minecraft_version`, `minecraft_dependency`, `fabric_api_dependency`,
+   `neoforge_version`, dep pins) + per-line build.gradle pins. NeoForge module
+   line rows (found at the v0.11 ports): `java.toolchain.languageVersion`, the
+   `lss.neoforge.mixins.json` compatibilityLevel, and the toml loader
+   versionRange (LINE DATA marker). **Merge trap, hit twice**: a file main
+   DELETED then RESTORED byte-identically (branding/vss/icon.png) nets to
+   no-change on main's side, so a branch that also deleted it silently keeps the
+   delete — `ls branding/vss/` after every delta-port merge. `ReleaseWorkflowContractTest` + `ToolchainContractTest` follow the data
    automatically; `FabricModJsonContractTest`/`PluginYmlContractTest` keep small
    per-line FORM constants.
 4. **Toolchain retarget**: loom(-remap) plugin, mappings namespace

--- a/docs/planning/v0.11.0-progress.md
+++ b/docs/planning/v0.11.0-progress.md
@@ -27,6 +27,30 @@ Single source of stage status; updated in each stage's merge commit.
 | V | Version-port isolation (mega plan v1.8; version-port-isolation-plan.md v1.1 normative, 3-Opus-reviewed — plan round: 2 research passes (port-delta forensics: true tag-relative port surface = 357 lines on 26.1 with the release pipeline at 50.4%, 995 on 1.21.11; the three-dot metric is 2-3× inflated by stale merge-bases) + plan + 3× MERGE WITH FIXES folded (S3 cut on evidence; two-field shape descriptor; jar-byte-identity phasing)) | **V-1 + V-2 merged; V-3 branch-first inside G** | 2026-08-14 | 2026-08-14 | 2026-08-14 (dc42206a) | [#175](https://github.com/VoX/lod-server-support/pull/175) (plan) [#176](https://github.com/VoX/lod-server-support/pull/176) (mega v1.8) [#177](https://github.com/VoX/lod-server-support/pull/177) (V-1) [#182](https://github.com/VoX/lod-server-support/pull/182) (V-2) | **V-1 COMPLETE**: release.yml branch-invariant off `.github/line.env` (suffix-equality guard post-checkout re-pin, mod_version/PREV_TAG shape adopted, push-gated publishes + refused non-dry dispatch); ReleaseWorkflowContractTest data-driven (IS_MAINLINE switch, no-hardcoded-MC-tokens, resolved-name 64-cap, single-row drift armor, three-link chain ending at the resolved MC artifact via new ToolchainContractTest twins); plugin.yml/fabric.mod.json metadata templated (minecraft_dependency data key); NativeCorpusRegenTool hoisted (byte-identical-no-op gate on main); soak.sh mc-version base-world guard; RegionFault either-label pin + CLAUDE.md flake-entry rewrite; line-neutral corpus wording; VersionVolatileFileListTest; per-version-surfaces.md + port-runbook.md + pre-authorized-cuts.md. GATES: **jar-byte-identity PROVEN (1419/1419 entries across the three LSS jars — no F-gate re-arm, pause undisturbed)**, full suites green, release_check 68-case selftest + real OK, review round 2× grouped-lens (pipeline MERGE — resolved-value walk + both-direction merge-clobber simulation; tooling MERGE WITH FIXES — all applied), CI green, **post-merge workflow_dispatch dry-run rehearsal SUCCESS (run 31856082310): three builds + six-family release gate at 0.0.0-dryrun, all four publish steps skipped)**. **V-2 EXECUTED 2026-08-14** (post user continue-directive, before G port work — branch feat/v0.11.0-stage-v2): S5 ScopedCarrier per-loader twins (Java21 exclusion list EMPTY, twin byte-identity pinned), S7 ASM copyOf census green on real 26.2 bytecode, S3-replacement TicketType constants (values verified 0L/2), S2 SectionConstruction family helpers + zero-ctor-sites pin, S1 NativeSectionShape descriptor (cursor + both serializers + 3 relationship tests derived; folds throw on 2-short lines; scope-hygiene pins) — all golden suites green WITHOUT regeneration (byte-identity proof); gates green (full T1 both platforms, T2, T3, neoforge, release_check, fresh-backfill soak PASS 33/0); review round 2x grouped-lens — wire lens verified the dormant 1-short arm against the recorded support/mc1.21.11 branch and caught 2 MAJORs (the cursor's LINE-level fold the two-field descriptor couldn't express; emitV20Direct unwired) + pre-size literals, all folded with tests realigned to FOLD semantics; seam lens clean (extraction fidelity mechanical, every pin verified non-vacuous against compiled bytes) — merged 2026-08-15 (60592682); V-3 (S4/T2) branch-first inside G |
 | G | delta-ports (both `-v0.11` lines = full tree incl. FARP, R-7 v1.4; + the FRESH `support/mc1.21.1` line — fabric+neoforge+paper, v1.7) + the four-line × three-loader SIMULTANEOUS release | pending | — | — | — | — | — |
 
+## Stage G status (live)
+
+- **G-1 (26.1 delta-port): COMPLETE, pushed** — `support/mc26.1-v0.11` (merge
+  ef07d7c3 + flavors, anchor main @ 9cb32ade). 19 conflicts (5 take-main
+  branch-invariant, 7 provably-unflavored take-main, 7 per-line data). FIVE hand
+  rows total (VoxyCompat rebuild, camera accessor, EntityType constants,
+  fabric-api floor, icon trap). Gates: fabric T1/T2/T3 green (descriptor-derived
+  corpus suite UNFLAVORED), paper 422/0, neoforge build + 8/8 smoke vs real
+  26.1.2.95, release_check six families, fresh-backfill soaks PASS (fabric 32w +
+  paper 40w, 0 violations).
+- **G-2 (1.21.11 delta-port): COMPLETE, pushed** — `support/mc1.21.11-v0.11`
+  (merge b4acf918 + flavors 2fe76e0a, same anchor). 32 conflicts, 25 take-main
+  (the V-1/V-2 payoff). The line's count-short flavor lives ENTIRELY in
+  NativeSectionShape (=1 + three folds) — **the committed line goldens passed
+  WITHOUT regeneration**, proving the descriptor's dormant fold arm reproduces
+  the recorded bytes. ScopedCarrier pass-through swap (S5). A FOURTH
+  relationship site (convertIndexed fuzz) found + derived, back-flowed to main.
+  Gates: T1/T2/T3 (Java 21), paper 422/0, neoforge build + 8/8 smoke vs real
+  21.11.45 (line rows: toolchain 21, mixin JAVA_21, toml [21.11,)),
+  release_check, both fresh-backfill soaks PASS.
+- **G-3 (1.21.1 fresh line): NOT STARTED** — next; spike + pre-authorized-cuts
+  are the recipe; ships Fabric+Paper+NeoForge with the recorded drop list.
+- **G-4 (release round): BLOCKED on user tag sign-off.**
+
 ## Decisions log
 
 - 2026-08-14 — **Round-3 review P-1: the flat unrelocated sqlite/zstd shading is

--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -221,12 +221,15 @@ afterEvaluate {
 processResources {
     inputs.property "version", project.version
     inputs.property "minecraft_dependency", project.minecraft_dependency
+    inputs.property "fabric_api_dependency", project.fabric_api_dependency
 
     filesMatching("fabric.mod.json") {
-        // V-1/P3: the MC depends range is per-line DATA (gradle.properties
-        // minecraft_dependency) — a support cut edits the data, never this resource.
+        // V-1/P3 (+ the G back-flow): the MC and fabric-api depends ranges are
+        // per-line DATA (gradle.properties) — a support cut edits the data, never
+        // this resource.
         expand "version": inputs.properties.version,
-               "minecraft_dependency": inputs.properties.minecraft_dependency
+               "minecraft_dependency": inputs.properties.minecraft_dependency,
+               "fabric_api_dependency": inputs.properties.fabric_api_dependency
     }
 }
 

--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -43,7 +43,7 @@
   "depends": {
     "minecraft": "${minecraft_dependency}",
     "fabricloader": ">=0.18.4",
-    "fabric-api": ">=0.152.1"
+    "fabric-api": "${fabric_api_dependency}"
   },
   "suggests": {
     "sodium": ">=0.9.0",

--- a/fabric/src/test/java/dev/vox/lss/FabricModJsonContractTest.java
+++ b/fabric/src/test/java/dev/vox/lss/FabricModJsonContractTest.java
@@ -66,6 +66,14 @@ class FabricModJsonContractTest {
                 gradleProps.getProperty("minecraft_dependency", ""),
                 "gradle.properties minecraft_dependency must pin the line's range exactly — "
                         + "the upper bound is what keeps this jar off incompatible newer lines");
+        // The G back-flow's sibling key: the fabric-api floor is per-line data too
+        // (the 26.1 port found the literal floor naming a 26.2-family version no
+        // 26.1 install can satisfy — silently unresolvable at mod load).
+        assertEquals("${fabric_api_dependency}",
+                modJson.getAsJsonObject("depends").get("fabric-api").getAsString(),
+                "fabric.mod.json's fabric-api depends must stay templated from the data key");
+        assertTrue(!gradleProps.getProperty("fabric_api_dependency", "").isEmpty(),
+                "gradle.properties must carry the line's fabric_api_dependency floor");
     }
 
     @Test

--- a/fabric/src/test/java/dev/vox/lss/common/wire/NativeToV20TranslatorTest.java
+++ b/fabric/src/test/java/dev/vox/lss/common/wire/NativeToV20TranslatorTest.java
@@ -522,7 +522,17 @@ class NativeToV20TranslatorTest {
         var dict = new IdentityDictionary();
         var sections = new java.util.ArrayList<WireSection>();
         for (var s : shapes) {
-            sections.add(new WireSection(s.sectionY(), s.nonEmptyBlockCount(), s.fluidCount(),
+            // Derived (the emitV20Direct rule — the fourth relationship site, found at
+            // the 1.21.11 port): the translate side reads CURSOR-emitted native bytes,
+            // whose one-short line header carries the line fold — so the direct side
+            // must assemble (fold, 0) there to stay byte-identical (two-short lines,
+            // like this one, pass through — the ternary constant-folds).
+            int nonEmpty = NativeSectionShape.NATIVE_COUNT_SHORTS == 2
+                    ? s.nonEmptyBlockCount()
+                    : NativeSectionShape.foldedCountForNativeHeader(
+                            s.nonEmptyBlockCount(), s.fluidCount());
+            int fluid = NativeSectionShape.NATIVE_COUNT_SHORTS == 2 ? s.fluidCount() : 0;
+            sections.add(new WireSection(s.sectionY(), nonEmpty, fluid,
                     NativeToV20Translator.convertIndexed(s.blocks().bits(), s.blocks().palette(),
                             s.blocks().data(), true, dict, BLOCKS),
                     NativeToV20Translator.convertIndexed(s.biomes().bits(), s.biomes().palette(),

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,6 +9,9 @@ minecraft_version=26.2
 # '>=26.1 <26.2-', exact '1.21.11'), so it is explicit per-line data. Templated into
 # the resource by :fabric:processResources; FabricModJsonContractTest pins the FORM.
 minecraft_dependency=>=26.2 <26.3-
+# fabric_api_dependency joined at the G back-flow: the 26.1 port found the literal
+# floor naming a 26.2-family version — every line's floor is its own API family.
+fabric_api_dependency=>=0.152.1
 loader_version=0.19.3
 loom_version=1.17.13
 


### PR DESCRIPTION
The T3 back-flow rule: hardening invented on the G-1/G-2 port branches lands on main in the same round. fabric-api floor as per-line data (templated + pinned), the fourth descriptor-derived relationship site (found live on 1.21.11), the .lss gitignore, runbook trap notes, and the stage-G progress status.

🤖 Generated with [Claude Code](https://claude.com/claude-code)