### PR TITLE
Pre-release review round: main-side sweep

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Supports **Fabric** clients, and **Fabric**, **NeoForge**, **Paper**, **Purpur**
 
 https://github.com/user-attachments/assets/721fb344-890e-4e03-ab36-539444427f7b
 
-**Try it live:** join `lod-server-support.modrinth.gg` with [Voxy](https://modrinth.com/mod/voxy) and this mod installed. The server runs Minecraft 26.2, but clients on **any supported version** — 26.2, 26.1.x, or 1.21.11 — can join and get full LOD streaming (cross-version columns, with ViaVersion bridging the Minecraft protocol).
+**Try it live:** join `lod-server-support.modrinth.gg` with [Voxy](https://modrinth.com/mod/voxy) and this mod installed. The server runs Minecraft 26.2, but clients on **any supported version** — 26.2, 26.1.x, 1.21.11, or 1.21.1 — can join and get full LOD streaming (cross-version columns, with ViaVersion bridging the Minecraft protocol).
 
 ## Installation
 
@@ -29,8 +29,9 @@ Each Minecraft version has its own build, versioned `v<x.y.z>+mc<version>`; only
 | Minecraft | LSS Version | Fabric | NeoForge | Paper | Folia | Voxy | Java |
 |---|---|---|---|---|---|---|---|
 | **26.2** | v0.11.0+mc26.2 | ✅ | ✅ (server) | ✅ | ✅ | 0.2.17-alpha+ | 25+ |
-| **26.1.x** | v0.11.0+mc26.1 | ✅ | — | ✅ | ✅ | 0.2.14-alpha+ | 25+ |
-| **1.21.11** | v0.11.0+mc1.21.11 | ✅ | — | ✅ | ✅ | 0.2.15-beta+ | 21+ |
+| **26.1.x** | v0.11.0+mc26.1 | ✅ | ✅ (server) | ✅ | ✅ | 0.2.14-alpha+ | 25+ |
+| **1.21.11** | v0.11.0+mc1.21.11 | ✅ | ✅ (server) | ✅ | ✅ | 0.2.15-beta+ | 21+ |
+| **1.21.1** | v0.11.0+mc1.21.1 | ✅ | ✅ (server) | ✅ | — | community fork | 21+ |
 
 > [!IMPORTANT]
 > **Mixed versions are fine back to v0.4.x.** LSS translates between protocol versions in both directions, so old clients keep working against new servers and vice versa. Against anything older — or with the compat layers turned off — you simply get vanilla render distance and no error.

--- a/docs/planning/port-runbook.md
+++ b/docs/planning/port-runbook.md
@@ -62,8 +62,14 @@ docs/planning/per-version-surfaces.md; this doc is the ORDER and the rules.
    the line's own MC artifact; contract-test flavors re-derived; hand rows recorded
    in the port PR description.
 8. **Harness retarget**: test-server.sh's LINE DATA block (MC/CDN URLs, legacy LSS
-   pin); soak.sh needs NOTHING for the base-world guard since V-1/T3a (the
-   mc-version marker is data-driven from gradle.properties).
+   pin, the Java gate) AND the CI workflows (build.yml/release.yml carry per-line
+   java-version + task-set deltas — the 1.21.1 cut missed both and CI was red by
+   construction, review 2026-08-15); fabric/build.gradle's localRuntime compat-arm
+   Modrinth IDs are per-line too. soak.sh: the BASE-WORLD GUARD needs nothing
+   (V-1/T3a — the mc-version marker is data-driven), but the WORLD-STAGING LAYOUT
+   is per-line forever: 1.21.x Bukkit uses split world_nether/world_the_end dirs
+   and needs the world* glob flavor at all four staging sites (the v0.11 delta-port
+   read "needs NOTHING" as covering this and lost the v0.10 flavor — same review).
 9. **Validation**: Tier 1+2 local, `CI=true` release build + `release_check
    --version`, CI green incl. Tier 3 where the line has it, per-line soak smokes.
    **Rehearse the release pipeline** with the workflow_dispatch dry-run on the

--- a/docs/planning/release-tag-v0.11.0.txt
+++ b/docs/planning/release-tag-v0.11.0.txt
@@ -13,7 +13,6 @@
 
 ### Configuration
 
-- **`lodDistanceChunks` default 512 → 300** — a mid-range default; the automatic timestamp-cache sizing follows it. Raise it freely on capable servers.
 - **`dirtyBroadcastIntervalSeconds: 0` now disables dirty broadcasts** — previously 0 clamped to the fastest cadence. With 0, connected clients pick up terrain edits only on rejoin or their own re-requests; server-side freshness bookkeeping keeps running, so rejoins always see current terrain.
 - **`maxConcurrentDiskReads`** — new key (default auto): caps concurrent expensive region-file reads so server CPU stays bounded independently of bandwidth. Store-served LODs never consume its capacity; auto = half the reader pool with the LOD store on, no limit with it off. Applies on all platforms including Folia (experimental).
 - **Far-player keys** — server: `farPlayers`, `farPlayersUpdateIntervalTicks`, `farPlayersMaxDistanceBlocks` (default 2048), `farPlayersMinDistanceBlocks`, `farPlayersSendSpectators`, `farPlayersExclude`. Client: the Sodium "Far Players" page carries enable, "Share My Position", name tags, and the render-distance cap; the animation-distance cap and visibility-ring overrides live in `lss-client-config.json`.

--- a/docs/planning/v0.11.0-progress.md
+++ b/docs/planning/v0.11.0-progress.md
@@ -66,6 +66,34 @@ Single source of stage status; updated in each stage's merge commit.
 
 ## Decisions log
 
+- 2026-08-15 — **Pre-release 6-Opus review round (2 lenses × 3 support branches):
+  6 MAJORs dispositioned (5 fixed, 1 refuted), ~20 minors swept.** Fixed: (1)
+  1.21.11 far-player render event `AFTER_ENTITIES`→`BEFORE_ENTITIES` (on 1.21.11
+  AFTER fires post-drain-and-clear of the submit storage — proxies drew in the
+  particles pass; bytecode-diagnosed); (2) the Paper store sweep now re-roots
+  region dirs PER LEVEL via `getWorld().getWorldFolder()` on both 1.21.x branches
+  (split world dirs — the 26.x code's own BACKPORT CAVEAT; the unified-root resolve
+  fail-safe-dropped every non-Overworld dim's rows each sweep); (3) the 1.21.1
+  workflows carried the dead `-x runClientGameTest` + `java-version: 25` (CI red by
+  construction; release would have died pre-publish); (4) the 1.21.1 test-server.sh
+  LINE DATA was never retargeted (26.2 servers + a Java gate rejecting the line's
+  own JDK); (5) the 1.21.1 CLAUDE.md banner named two cuts the line did not take
+  (far-player render + Sodium screen are LIVE on Fabric; only Tier 3 was cut).
+  REFUTED: "MoonriseReadCompat targets a class absent on 1.21.1" — the reviewer
+  checked Paper's dev bundle (`RegionFileIOThread`, Paper's own fork), but
+  Moonrise-Fabric 0.1.0-beta.15+1.21.1 ships `MoonriseRegionFileIO` with the exact
+  7-arg overload/CHUNK_DATA/LOW (jar-verified); the two platforms genuinely differ
+  on this line and both flavors were already correct. NEW LINE FACT found during the
+  fixes: **Folia has NO 1.21.1 build** (its 1.21 family starts at 1.21.4) — the
+  1.21.1 branch now pins `folia-supported` ABSENT (plugin.yml + inverted
+  PluginYmlContractTest/release_check pins + loaders list drops folia), the
+  surfaces-row-7 re-derivation the fresh cut had skipped.
+- 2026-08-15 — **`fabricloader >=0.18.4` KEPT on the 1.21.1 line** (review M7
+  raised lowering toward the 0.16.x install base as the 1.21.8 line once did):
+  the fresh cut compiled and gated against 0.18.4 and no one has verified the
+  loader-API floor below it; a floor lowered without that verification trades a
+  visible "update your loader" refusal for a possible runtime break. Revisit only
+  with a real compatibility pass.
 - 2026-08-15 — **V-3/T2 scope extension (the §6.2 pair — plan §T2 carries the
   back-pointer): the gametest position helper is a RECORD (`TestPositions.ChunkAt`)
   and also concentrates the chunk-hold ticket calls.** Two deltas from the plan's

--- a/fabric/src/test/java/dev/vox/lss/common/wire/NativeSectionShapeTest.java
+++ b/fabric/src/test/java/dev/vox/lss/common/wire/NativeSectionShapeTest.java
@@ -105,6 +105,31 @@ class NativeSectionShapeTest {
                         + "code (javadoc may NAME the constants it disclaims)");
     }
 
+
+    @Test
+    void longArrayPrefixReferencesAreAlwaysNativeGated() throws Exception {
+        // Scope hygiene for the FOURTH descriptor axis (review 2026-08-15, the M8 gap):
+        // NATIVE_LONG_ARRAY_PREFIXED is a NATIVE-layout fact. V20 is prefix-free on
+        // every line by wire spec, so a cursor site that consults the flag without a
+        // layout == Layout.NATIVE guard would fork the never-tiered wire on prefixed
+        // lines — and both ends of that line would agree, exactly the failure the
+        // V20_* literal pin above guards. Every reference must sit in a conjunction
+        // with the NATIVE-layout test on the same line.
+        Path cursor = locate("common/src/main/java/dev/vox/lss/common/wire/WireSectionCursor.java");
+        String source = Files.readString(cursor);
+        int refs = 0;
+        for (String line : source.split("\n")) {
+            if (!line.contains("NATIVE_LONG_ARRAY_PREFIXED")) continue;
+            if (line.strip().startsWith("//") || line.strip().startsWith("*")) continue;
+            refs++;
+            assertTrue(line.contains("layout == Layout.NATIVE &&"),
+                    "un-gated NATIVE_LONG_ARRAY_PREFIXED reference (V20 must stay"
+                            + " prefix-free — wire spec): " + line.strip());
+        }
+        assertTrue(refs >= 4, "expected the four gated cursor sites, found " + refs
+                + " — if sites moved, re-derive this pin with them");
+    }
+
     private static Path locate(String repoRelative) {
         Path dir = Path.of("").toAbsolutePath();
         for (int i = 0; i < 6 && dir != null; i++, dir = dir.getParent()) {


### PR DESCRIPTION
Main's share of the 6-Opus support-branch review round (branch fixes pushed directly to the three support branches): release-notes correction (the 512→300 item described an unshipped change), README table truth (NeoForge columns + the 1.21.1 row), the port-runbook step-8 lessons (workflows + compat-arm IDs are per-line; the soak world-staging layout is per-line forever), the fourth-axis scope-hygiene pin, and the decisions-log record of the round.

🤖 Generated with [Claude Code](https://claude.com/claude-code)