### PR TITLE
P-1 answered: sqlite module collision on 1.21.1 NeoForge

### DIFF
--- a/docs/planning/v0.11.0-progress.md
+++ b/docs/planning/v0.11.0-progress.md
@@ -66,6 +66,25 @@ Single source of stage status; updated in each stage's merge commit.
 
 ## Decisions log
 
+- 2026-08-15 — **Stage-N review P-1 is ANSWERED, live: the flat unrelocated sqlite
+  shading HARD-FAILS module resolution against the community Voxy NeoForge port on
+  1.21.1.** FML refuses to boot with `ResolutionException: Modules
+  org.xerial.sqlitejdbc and lss export package org.sqlite.core` — the j-shelfwood
+  voxy-neoforge fork jarJars sqlite-jdbc 3.49.1.0 while the LSS NeoForge jar
+  flat-shades org/sqlite (incl. the META-INF/versions/9 tree, which also counts
+  toward the module's package set). Consequence: on 1.21.1 the LSS NeoForge jar
+  and the community Voxy port — the exact client pairing that line's NeoForge
+  client exists to serve — are MUTUALLY EXCLUSIVE as shipped. Server-side installs
+  are unaffected (servers run no Voxy), and 26.x/1.21.11 NeoForge are unaffected
+  today (official Voxy's bundle carries no sqlite; Foxy extracts it as game
+  libraries). Test-rig workaround in place: the lss-test-neo-1.21.1 Prism instance
+  runs an instance-local client jar with org/sqlite stripped (safe —
+  `SqliteLodStore.createOrNull` catches Throwable and degrades store-less). REAL
+  fix = shadow-RELOCATE the shaded sqlite (and audit zstd-jni the same way) in the
+  neoforge shadowJar; needs its own round (native-library resource paths make
+  sqlite relocation non-trivial) and a G-4 decision: relocate before the release,
+  or ship with a release-notes caveat naming the incompatibility on 1.21.1.
+
 - 2026-08-15 — **Pre-release 6-Opus review round (2 lenses × 3 support branches):
   6 MAJORs dispositioned (5 fixed, 1 refuted), ~20 minors swept.** Fixed: (1)
   1.21.11 far-player render event `AFTER_ENTITIES`→`BEFORE_ENTITIES` (on 1.21.11


### PR DESCRIPTION
The stage-N uncharted risk is now charted live: LSS-NeoForge + the community Voxy 1.21.1 port cannot boot together (duplicate org.sqlite package export). Decisions-log entry with the rig workaround and the G-4 decision it forces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)