### PR TITLE
docs: README final pass

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # LOD Server Support
 
-Enables players with [Voxy](https://modrinth.com/mod/voxy) to see fully rendered terrain out to hundreds of chunks on multiplayer servers without needing to explore the world first.
+Enables players with [Voxy](https://modrinth.com/mod/voxy) to see fully rendered terrain out to hundreds of chunks on multiplayer servers without needing to explore the world first. Also includes **Far Players**: players far beyond normal render distance appear in the LOD terrain with name tags, equipment, and mounts.
 
 **Try it live**: join `lod-server-support.modrinth.gg` with Voxy and this mod installed. Supports Minecraft 26.2, 26.1, 1.21.11, and 1.21.1.
 
@@ -17,7 +17,7 @@ Clients use the Fabric mod on every version. Supported servers:
 | 1.21.11 | ✅ | ✅ | ✅ (experimental) | - |
 | 1.21.1 | ✅ | ✅ | - | ✅ (server) |
 
-Compatible with [AntiXray](https://modrinth.com/mod/anti-xray), [Moonrise](https://modrinth.com/mod/moonrise-opt), [C2ME](https://modrinth.com/mod/c2me-fabric), [ViaVersion](https://modrinth.com/plugin/viaversion)/[ViaBackwards](https://modrinth.com/plugin/viabackwards), and most other mods. Can be run alongside Distant Horizons on the same server to support DH clients and Voxy clients simultaneously. Includes **Far Players**: players far beyond normal render distance appear in the LOD terrain as simple player models, with name tags, equipment, and mounts, and privacy controls on both the server and the client.
+Compatible with [AntiXray](https://modrinth.com/mod/anti-xray), [Moonrise](https://modrinth.com/mod/moonrise-opt), [C2ME](https://modrinth.com/mod/c2me-fabric), [ViaVersion](https://modrinth.com/plugin/viaversion)/[ViaBackwards](https://modrinth.com/plugin/viabackwards), and most other mods. Can be run alongside Distant Horizons on the same server to support DH clients and Voxy clients simultaneously. 
 
 LOD Server Support is backwards and forwards compatible from v0.4.0 through the current version. Server operators can freely update to take advantage of improvements without breaking clients on older versions, and clients can update without breaking compatibility with older servers.
 


### PR DESCRIPTION
Syncs the README with the approved Modrinth-page edit (Far Players description moved into the intro paragraph). Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)