### PR TITLE
fix: NeoForge mods-screen metadata parity (description + icon)

### DIFF
--- a/neoforge/build.gradle
+++ b/neoforge/build.gradle
@@ -144,6 +144,11 @@ processResources {
     filesMatching('META-INF/neoforge.mods.toml') {
         expand props
     }
+    // The mods-screen icon (logoFile in the TOML): derived from the fabric module's
+    // copy so git keeps a single source — the fabric/neoforge mod lists match.
+    from(rootProject.file('fabric/src/main/resources/assets/lss/icon.png')) {
+        into 'assets/lss'
+    }
 }
 
 // Native strip lists — zstd-jni only on this module (sqlite rides NESTED with all
@@ -259,11 +264,13 @@ tasks.register('vssJar') {
     description = 'Repackages the LSS NeoForge jar under the Voxy Server Side branding.'
     dependsOn 'shadowJar'
     def srcJar = tasks.named('shadowJar').flatMap { it.archiveFile }
+    def iconFile = rootProject.file('branding/vss/icon.png')
     def outName = providers.environmentVariable('CI').map { it == 'true' }.getOrElse(false)
             ? "voxy-server-side-neoforge-${project.mod_version}+${project.minecraft_version}.jar"
             : 'voxy-server-side-neoforge.jar'
     def outFile = layout.buildDirectory.file("libs/${outName}")
     inputs.file(srcJar)
+    inputs.file(iconFile)
     outputs.file(outFile)
     doLast {
         def src = srcJar.get().asFile
@@ -282,6 +289,8 @@ tasks.register('vssJar') {
                                 .replaceFirst(/(?m)^displayName=.*$/,
                                         'displayName="Voxy Server Side"')
                                 .replaceFirst(/(?m)^authors=.*$/, 'authors="Xantha, VoX"')
+                                .replaceFirst(/(?m)^logoFile=.*$/,
+                                        'logoFile="assets/lss/icon-vss.png"')
                                 .replaceFirst(/(?m)^issueTrackerURL=.*$/,
                                         'issueTrackerURL="https://modrinth.com/plugin/voxy-server-side"')
                                 .replaceFirst(/(?m)^description=.*$/,
@@ -307,6 +316,12 @@ tasks.register('vssJar') {
                         zos.closeEntry()
                     }
                 }
+                // The dedicated VSS icon rides as a NEW entry beside the LSS icon
+                // (the rewritten logoFile above points at it) — the fabric vssJar's
+                // exact pattern; nothing else in the jar changes.
+                zos.putNextEntry(new ZipEntry('assets/lss/icon-vss.png'))
+                zos.write(iconFile.bytes)
+                zos.closeEntry()
             }
         } finally {
             zf.close()

--- a/neoforge/src/main/resources/META-INF/neoforge.mods.toml
+++ b/neoforge/src/main/resources/META-INF/neoforge.mods.toml
@@ -8,7 +8,8 @@ modId="lss"
 version="${mod_version}"
 displayName="LOD Server Support"
 authors="VoX"
-description='''Distributes LOD chunk data from servers to clients for LOD rendering mods (Voxy API surface). Server-side works with any LSS/VSS client; the client half needs a community Voxy build for NeoForge.'''
+logoFile="assets/lss/icon.png"
+description='''Voxy multiplayer support (unofficial). Enables players with Voxy to see fully rendered terrain out to hundreds of chunks on multiplayer servers without needing to explore the world first. Server-side works with any LSS/VSS client; the client half needs a community Voxy build for NeoForge.'''
 
 [[mixins]]
 config="lss.neoforge.mixins.json"

--- a/scripts/release_check.py
+++ b/scripts/release_check.py
@@ -452,6 +452,14 @@ def check_neoforge_jar(jar, problems):
         if 'config="lss.neoforge.mixins.json"' not in toml:
             problems.append(f"{base}: neoforge.mods.toml lost the mixin config declaration "
                             "(accessors + save hook would silently never apply)")
+        import re as _re
+        logo = _re.search(r'(?m)^logoFile="([^"]+)"$', toml)
+        if not logo:
+            problems.append(f"{base}: neoforge.mods.toml has no logoFile — the mods "
+                            "screen shows a blank icon (must match the fabric jar)")
+        elif logo.group(1) not in names:
+            problems.append(f"{base}: logoFile points at {logo.group(1)!r} but that "
+                            "entry is not in the jar")
     for required, why in (("lss.neoforge.mixins.json", "mixin config"),
                           ("META-INF/accesstransformer.cfg", "access transformer"),
                           ("META-INF/services/dev.vox.lss.platform.LoaderServices",
@@ -556,7 +564,8 @@ def check_wire_identity_neoforge(lss_jar, vss_jar, problems):
                         "jar — the repackage must be a byte-copy rebrand (wire identity)")
 
 
-VSS_NEOFORGE_REBRAND_KEYS = ("displayName=", "authors=", "description=", "issueTrackerURL=")
+VSS_NEOFORGE_REBRAND_KEYS = ("displayName=", "authors=", "description=",
+                             "issueTrackerURL=", "logoFile=")
 
 
 def check_vss_pair_neoforge(lss_jar, vss_jar, problems):
@@ -1885,11 +1894,14 @@ def _selftest():
 
         TOML_LSS = ('modLoader="javafml"\nloaderVersion="[4,)"\nlicense="MIT"\n\n[[mods]]\n'
                     'modId="lss"\nversion="0.7.0"\ndisplayName="LOD Server Support"\n'
-                    'authors="VoX"\ndescription=\'\'\'LSS.\'\'\'\n\n'
+                    'authors="VoX"\nlogoFile="assets/lss/icon.png"\n'
+                    'description=\'\'\'LSS.\'\'\'\n\n'
                     '[[mixins]]\nconfig="lss.neoforge.mixins.json"\n')
         TOML_VSS = (TOML_LSS
                     .replace('displayName="LOD Server Support"', 'displayName="Voxy Server Side"')
-                    .replace('authors="VoX"', 'authors="Xantha, VoX"'))
+                    .replace('authors="VoX"', 'authors="Xantha, VoX"')
+                    .replace('logoFile="assets/lss/icon.png"',
+                             'logoFile="assets/lss/icon-vss.png"'))
 
         def _write_tree_neoforge(name, toml, brand, shared_class="x", extra=None, drop=(),
                                   store_entries=None):
@@ -1907,10 +1919,13 @@ def _selftest():
                 "dev/vox/lss/platform/NeoForgeClientLoaderServices.class": "x",
                 "dev/vox/lss/common/store/SqliteLodStore.class":
                     "ref org/sqlite/SQLiteDataSource ok",
+                "assets/lss/icon.png": "PNG",
                 "THIRD-PARTY-NOTICES": "sqlite-jdbc / zstd-jni notices " + "x" * 100,
             }
             entries.update(_store_neoforge_entries() if store_entries is None
                            else store_entries)
+            if brand == BRAND_VSS:
+                entries["assets/lss/icon-vss.png"] = "PNG"
             entries.update(extra or {})
             for d in drop:
                 entries.pop(d, None)
@@ -1933,6 +1948,16 @@ def _selftest():
         check_neoforge_jar(os.path.join(dneo, "lod-server-support-neoforge.jar"), p)
         check(any("LSSNeoMod" in m and "excluded from the shadow jar" in m for m in p),
               f"entrypoint-less neoforge jar not caught: {p}")
+        _write_tree_neoforge("lod-server-support-neoforge.jar", TOML_LSS, BRAND_LSS)
+
+        # a logoFile pointing at a missing icon entry must red (the mods-screen
+        # icon parity fix — fabric/neoforge lists must match)
+        _write_tree_neoforge("lod-server-support-neoforge.jar", TOML_LSS, BRAND_LSS,
+                             drop=("assets/lss/icon.png",))
+        p = []
+        check_neoforge_jar(os.path.join(dneo, "lod-server-support-neoforge.jar"), p)
+        check(any("logoFile points at" in m for m in p),
+              f"logoFile referencing a missing icon not caught: {p}")
         _write_tree_neoforge("lod-server-support-neoforge.jar", TOML_LSS, BRAND_LSS)
 
         # jarjar-shape negatives (neoforge-jarjar-sqlite-plan.md §4): metadata


### PR DESCRIPTION
NeoForge LSS/VSS jars had no mods-screen icon and a divergent description. Now matched to the fabric jars (caveat sentence kept per user decision), with the VSS variant carrying its own icon via the vssJar rewrite. release_check pins the shape (selftest 87). Same diff on all three support branches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)