### PR TITLE
feat: port-isolation round 2 — machinery invariance + derivations

### DIFF
--- a/.github/line.env
+++ b/.github/line.env
@@ -25,6 +25,9 @@ LINE_NEOFORGE_NAME=NeoForge (MC 26.2, server-side)
 # 1.21.1 line (the one line with a working client pairing — the community Voxy
 # port). false = the module still builds/tests in CI, but release.yml skips its
 # build + assets + Modrinth step and release_check does not require its families.
-# Flip release_check.py's SHIP_NEOFORGE together with this value —
-# ReleaseWorkflowContractTest cross-pins the pair.
+# release_check.py DERIVES its SHIP_NEOFORGE from this value (R2-5) — one edit
+# here is the whole flip.
 LINE_SHIP_NEOFORGE=false
+# Fabric jar manifest mapping namespace (release_check derives): official on the
+# 26.x/1.21.11 toolchains; intermediary under loom-remap lines.
+LINE_FABRIC_MAPPING_NAMESPACE=official

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,10 +16,15 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
+      # Line identity comes from .github/line.env (R2-2 — build.yml used to hardcode
+      # the Java version and went red-by-construction on the Java-21 line).
+      - name: Source line env
+        run: grep -vE '^\s*(#|$)' .github/line.env >> "$GITHUB_ENV"
+
       - uses: actions/setup-java@v5
         with:
           distribution: temurin
-          java-version: 25
+          java-version: ${{ env.LINE_JAVA_VERSION }}
 
       - uses: gradle/actions/setup-gradle@v5
 
@@ -145,10 +150,15 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
+      # Line identity comes from .github/line.env (R2-2 — build.yml used to hardcode
+      # the Java version and went red-by-construction on the Java-21 line).
+      - name: Source line env
+        run: grep -vE '^\s*(#|$)' .github/line.env >> "$GITHUB_ENV"
+
       - uses: actions/setup-java@v5
         with:
           distribution: temurin
-          java-version: 25
+          java-version: ${{ env.LINE_JAVA_VERSION }}
 
       - uses: gradle/actions/setup-gradle@v5
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,6 +101,14 @@ jobs:
           expand GV_PAPER "${LINE_GAME_VERSIONS_PAPER}"
           expand GV_NEOFORGE "${LINE_GAME_VERSIONS_NEOFORGE}"
           expand PAPER_LOADERS "${LINE_PAPER_LOADERS}"
+          # Paper Modrinth display prose derives from the same loader list (R2-7) —
+          # release.yml carries ZERO per-line name tokens.
+          display=""
+          for l in ${LINE_PAPER_LOADERS}; do
+            cap="$(tr '[:lower:]' '[:upper:]' <<< "${l:0:1}")${l:1}"
+            display="${display:+$display/}$cap"
+          done
+          echo "LINE_PAPER_DISPLAY=$display" >> "$GITHUB_ENV"
           # Release-asset list is line data: NeoForge ships only where
           # LINE_SHIP_NEOFORGE=true (v0.11.0 scope, user decision 2026-08-15).
           {
@@ -232,7 +240,7 @@ jobs:
           modrinth-id: lKiXKLvv
           modrinth-token: ${{ secrets.MODRINTH_TOKEN }}
           files: paper/build/libs/lod-server-support-paper-*.jar
-          name: v${{ env.MOD_VERSION }} - Paper/Purpur/Folia (MC ${{ env.LINE_MC_PAPER }})
+          name: v${{ env.MOD_VERSION }} - ${{ env.LINE_PAPER_DISPLAY }} (MC ${{ env.LINE_MC_PAPER }})
           version: v${{ env.MOD_VERSION }}+paper+mc${{ env.LINE_MC_PAPER }}
           version-type: release
           # The loader list is per-line data (Folia's presence has flipped per line —

--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -61,8 +61,8 @@ dependencies {
     storeDeps "com.github.luben:zstd-jni:1.5.7-3"
     localRuntime "org.xerial:sqlite-jdbc:3.49.1.0"
     localRuntime "com.github.luben:zstd-jni:1.5.7-3"
-    compileOnly "maven.modrinth:sodium:mc26.2-0.9.1-beta.3-fabric"
-    compileOnly "maven.modrinth:modmenu:20.0.0-beta.4"
+    compileOnly "maven.modrinth:sodium:${sodium_version}"
+    compileOnly "maven.modrinth:modmenu:${modmenu_version}"
     // Compat validation arm: -Pbenchmark.moonrise=true puts Moonrise on the dev runtime
     // (the same Modrinth version issue #69 was reported against), so the soak harness can
     // drive the full dirty pipeline — the SerializableChunkData.copyOf hook, broadcast,
@@ -70,7 +70,7 @@ dependencies {
     // (SOAK_EXTRA_GRADLE_ARGS="-Pbenchmark.moonrise=true" ./scripts/soak.sh dirty-broadcast).
     // Runtime-only: release jars and normal builds are unaffected.
     if ((findProperty('benchmark.moonrise') ?: 'false').toString() == 'true') {
-        localRuntime "maven.modrinth:moonrise-opt:W0HImEBl"
+        localRuntime "maven.modrinth:moonrise-opt:${moonrise_modrinth_version}"
     }
     // Same arm for C2ME (the Modrinth version test-server.sh installs), doing double duty:
     // the disk-read profile measures the chunk-IO-overhaul fallback path (adaptive read
@@ -78,7 +78,7 @@ dependencies {
     // hook is validated through C2ME's rewritten save paths — the old ChunkMap.save hook
     // silently never fired there. Runtime-only: release jars and normal builds are unaffected.
     if ((findProperty('benchmark.c2me') ?: 'false').toString() == 'true') {
-        localRuntime "maven.modrinth:c2me-fabric:nvOkOiyi"
+        localRuntime "maven.modrinth:c2me-fabric:${c2me_modrinth_version}"
     }
 }
 
@@ -113,13 +113,49 @@ sourceSets {
     }
 }
 
+// LINE DATA (port-isolation-round-2-plan.md R2-1): Tier 3 (client gametests) per
+// line — true on 26.x/1.21.11, false on 1.21.1 (no fabric-client-gametest-api in
+// that line's fabric-api; pre-authorized-cuts.md). This boolean is the ONLY build
+// edit a Tier-3 cut needs: it flips the loom wiring, registers a poison-pill
+// runClientGameTest stub (so every `-x runClientGameTest` across the machinery
+// stays line-invariant and a direct invocation reds with an explanation), excludes
+// the client gametest class from compilation, and filters its entrypoint out of
+// the gametest fabric.mod.json (a compile-exclude without the resource edit breaks
+// Tier 2 at entrypoint resolution). The source tree and source fabric.mod.json
+// stay IDENTICAL across lines — GameTestEntrypointContractTest compares source to
+// source, so it is line-neutral by construction.
+def tier3 = true
+
 fabricApi {
     configureTests {
         createSourceSet = true
         modId = "lss-test"
         enableGameTests = true
-        enableClientGameTests = true
+        enableClientGameTests = tier3
         eula = true
+    }
+}
+
+if (!tier3) {
+    tasks.register('runClientGameTest') {
+        group = 'verification'
+        description = 'Poison pill: Tier 3 is cut on this line (pre-authorized-cuts.md).'
+        doFirst {
+            throw new GradleException('Tier 3 (client gametests) is CUT on this line — '
+                    + 'see docs/planning/pre-authorized-cuts.md. -x runClientGameTest is '
+                    + 'a no-op here by design; do not invoke the task directly.')
+        }
+    }
+    afterEvaluate {
+        sourceSets.gametest.java.exclude 'dev/vox/lss/test/LSSClientGameTests.java'
+        tasks.named('processGametestResources') {
+            doLast {
+                def f = new File(it.destinationDir, 'fabric.mod.json')
+                def json = new groovy.json.JsonSlurper().parse(f)
+                json.entrypoints.remove('fabric-client-gametest')
+                f.text = groovy.json.JsonOutput.prettyPrint(groovy.json.JsonOutput.toJson(json))
+            }
+        }
     }
 }
 
@@ -222,6 +258,8 @@ processResources {
     inputs.property "version", project.version
     inputs.property "minecraft_dependency", project.minecraft_dependency
     inputs.property "fabric_api_dependency", project.fabric_api_dependency
+    inputs.property "suggests_sodium", project.suggests_sodium
+    inputs.property "suggests_voxy", project.suggests_voxy
 
     filesMatching("fabric.mod.json") {
         // V-1/P3 (+ the G back-flow): the MC and fabric-api depends ranges are
@@ -229,7 +267,9 @@ processResources {
         // this resource.
         expand "version": inputs.properties.version,
                "minecraft_dependency": inputs.properties.minecraft_dependency,
-               "fabric_api_dependency": inputs.properties.fabric_api_dependency
+               "fabric_api_dependency": inputs.properties.fabric_api_dependency,
+               "suggests_sodium": inputs.properties.suggests_sodium,
+               "suggests_voxy": inputs.properties.suggests_voxy
     }
 }
 

--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -46,8 +46,8 @@
     "fabric-api": "${fabric_api_dependency}"
   },
   "suggests": {
-    "sodium": ">=0.9.0",
+    "sodium": "${suggests_sodium}",
     "modmenu": "*",
-    "voxy": ">=0.2.17-alpha"
+    "voxy": "${suggests_voxy}"
   }
 }

--- a/fabric/src/test/java/dev/vox/lss/FabricModJsonContractTest.java
+++ b/fabric/src/test/java/dev/vox/lss/FabricModJsonContractTest.java
@@ -54,6 +54,29 @@ class FabricModJsonContractTest {
     }
 
     @Test
+    void suggestsRangesAreTemplatedAndBackedByProperties() {
+        // R2-6: the suggests ranges are gradle.properties data expanded at build time —
+        // stale hand copies shipped on all three v0.11 ports. The source must carry the
+        // placeholders and the properties must expand them non-empty.
+        var suggests = modJson.getAsJsonObject("suggests");
+        org.junit.jupiter.api.Assertions.assertEquals("${suggests_sodium}",
+                suggests.get("sodium").getAsString(),
+                "suggests.sodium must be the processResources placeholder");
+        org.junit.jupiter.api.Assertions.assertEquals("${suggests_voxy}",
+                suggests.get("voxy").getAsString(),
+                "suggests.voxy must be the processResources placeholder");
+        for (String key : new String[]{"suggests_sodium", "suggests_voxy",
+                "sodium_version", "modmenu_version",
+                "moonrise_modrinth_version", "c2me_modrinth_version"}) {
+            String v = gradleProps.getProperty(key);
+            org.junit.jupiter.api.Assertions.assertNotNull(v,
+                    key + " missing from gradle.properties (R2-6 line data)");
+            org.junit.jupiter.api.Assertions.assertFalse(v.isBlank(),
+                    key + " must expand non-empty");
+        }
+    }
+
+    @Test
     void dependsMinecraftPinsThisLineBothWays() {
         // V-1/P3: the SOURCE resource carries the template token — the actual range is
         // per-line DATA in gradle.properties (minecraft_dependency), pinned by FORM here

--- a/gradle.properties
+++ b/gradle.properties
@@ -25,3 +25,13 @@ fabric_version=0.154.0+26.2
 
 # NeoForge (stage N — neoforge-support-plan.md; non-beta 26.2 build, spike-verified)
 neoforge_version=26.2.0.59
+
+# Third-party coordinates as LINE DATA (R2-6) — consumed by fabric/build.gradle
+# (compileOnly + the compat localRuntime arms) and templated into fabric.mod.json's
+# suggests. Stale copies of these shipped on all three v0.11 ports; one source now.
+sodium_version=mc26.2-0.9.1-beta.3-fabric
+modmenu_version=20.0.0-beta.4
+moonrise_modrinth_version=W0HImEBl
+c2me_modrinth_version=nvOkOiyi
+suggests_sodium=>=0.9.0
+suggests_voxy=>=0.2.17-alpha

--- a/neoforge/build.gradle
+++ b/neoforge/build.gradle
@@ -137,9 +137,13 @@ dependencies {
 }
 
 processResources {
+    // R2-6: the toml's loader floor derives from neoforge_version (first two
+    // components) — one gradle.properties edit retargets compile AND descriptor.
+    def neoforgeFloor = project.neoforge_version.tokenize('.').take(2).join('.')
     def props = [mod_version    : project.mod_version,
                  minecraft_version: project.minecraft_version,
-                 neoforge_version : project.neoforge_version]
+                 neoforge_version : project.neoforge_version,
+                 neoforge_floor  : neoforgeFloor]
     inputs.properties props
     filesMatching('META-INF/neoforge.mods.toml') {
         expand props

--- a/neoforge/src/main/resources/META-INF/neoforge.mods.toml
+++ b/neoforge/src/main/resources/META-INF/neoforge.mods.toml
@@ -17,9 +17,9 @@ config="lss.neoforge.mixins.json"
 [[dependencies.lss]]
     modId="neoforge"
     type="required"
-    # LINE DATA: per-line NeoForge loader floor (round-3 review NIT — the MC dep
-    # above is templated from gradle.properties; this row is hand-edited per line)
-    versionRange="[26.2,)"
+    # DERIVED (R2-6): the loader floor is neoforge_version's first two components
+    # (26.2.0.59 -> [26.2,)) — the hand row churned on all three v0.11 ports.
+    versionRange="[${neoforge_floor},)"
     ordering="NONE"
     side="BOTH"
 

--- a/paper/build.gradle
+++ b/paper/build.gradle
@@ -55,13 +55,27 @@ test {
             .withPathSensitivity(PathSensitivity.RELATIVE)
 }
 
+// R2-5: folia-supported derives from line.env (single per-line source; the same
+// datum release_check.py and PluginYmlContractTest read, so the three cannot drift).
+def lineEnv = [:]
+rootProject.file('.github/line.env').eachLine { l ->
+    def t = l.trim()
+    if (t && !t.startsWith('#') && t.contains('=')) {
+        def i = t.indexOf('=')
+        lineEnv[t.substring(0, i)] = t.substring(i + 1)
+    }
+}
+def foliaSupported = (lineEnv['LINE_PAPER_LOADERS'] ?: '').tokenize().contains('folia')
+
 processResources {
     inputs.property "version", project.version
     inputs.property "api_version", project.minecraft_version
+    inputs.property "folia_supported", foliaSupported
     filesMatching("plugin.yml") {
         // V-1/P3: api-version equals gradle.properties' minecraft_version on every
         // recorded line — templated so a support cut never edits this resource.
-        expand "version": project.version, "api_version": project.minecraft_version
+        expand "version": project.version, "api_version": project.minecraft_version,
+                "folia_supported": foliaSupported
     }
 }
 

--- a/paper/src/main/resources/plugin.yml
+++ b/paper/src/main/resources/plugin.yml
@@ -2,12 +2,13 @@ name: LodServerSupport
 version: '${version}'
 main: dev.vox.lss.paper.LSSPaperPlugin
 api-version: '${api_version}'
-# Re-declared 2026-08-01: Folia published its first MC 26.2 build (26.2-1, channel BETA,
-# 2026-07-28), so the flag no longer auto-loads onto a nonexistent platform. Folia support
-# remains EXPERIMENTAL on this line exactly as on 1.21.8/1.21.11/26.1.x — single-player soak
-# validated; concurrent multi-region ingress untested. Do NOT treat the flag's presence as a
-# claim that SOAK_PLATFORM=folia has passed on 26.2.
-folia-supported: true
+# DERIVED (R2-5): the value expands from `folia` membership in line.env's
+# LINE_PAPER_LOADERS — the one per-line judgment ("does Folia exist upstream for
+# THIS line?") lives there, beside the other line identity rows a fresh cut must
+# touch anyway. Where true, Folia support is EXPERIMENTAL (single-player soak
+# validated; concurrent multi-region ingress untested) — the flag is a loads-at-all
+# statement, never a claim that SOAK_PLATFORM=folia has passed on this line.
+folia-supported: ${folia_supported}
 # C5 (XVER §7): the Via mismatch guard reflectively reads ViaVersion's API when the
 # plugin is present. softdepend keeps Spigot's classloader from logging the one-time
 # "loaded class ... which is not a depend/softdepend" warning on the first handshake —

--- a/paper/src/test/java/dev/vox/lss/paper/PluginYmlContractTest.java
+++ b/paper/src/test/java/dev/vox/lss/paper/PluginYmlContractTest.java
@@ -127,20 +127,34 @@ class PluginYmlContractTest {
     }
 
     @Test
-    void foliaSupportedIsDeclaredNowThatFolia262Exists() {
-        // Third flip. Absent 2026-07-19..2026-08-01 because Folia had no MC 26.2 build at
-        // all, so declaring it would have auto-loaded release jars onto a platform that did
-        // not exist yet. Folia published 26.2-1 (channel BETA) on 2026-07-28, so the flag is
-        // back — putting this line on the same experimental footing as 1.21.8/1.21.11/26.1.x
-        // rather than ahead of them. FoliaWiringContractTest still pins the wiring
-        // (no legacy scheduler, lifecycle through the mailbox).
-        assertTrue(yml.contains("folia-supported"),
-                "folia-supported must be declared now that Folia ships a 26.2 build — the"
-                        + " single jar serves Paper and Folia");
-        assertTrue(yml.getBoolean("folia-supported"),
-                "...and it must be true; a false/absent flag makes Folia refuse the jar");
-        assertTrue(rawText.contains("folia-supported: true"),
-                "release_check.py greps the RAW line, so the source must carry that exact form");
+    void foliaSupportedDerivesFromLineEnv() throws Exception {
+        // R2-5: the flag's direction is line.env's judgment (folia membership in
+        // LINE_PAPER_LOADERS) — the source carries the placeholder, processResources
+        // expands it, and this pin asserts BOTH polarities agree with the datum. The
+        // pre-R2-5 history (three hand flips, one shipped wrong by inheritance) is
+        // exactly what the derivation ends. FoliaWiringContractTest still pins the
+        // wiring (no legacy scheduler, lifecycle through the mailbox).
+        assertTrue(rawText.contains("folia-supported: ${folia_supported}"),
+                "the SOURCE plugin.yml must carry the processResources placeholder");
+        boolean expected = java.util.Arrays.asList(
+                lineEnv("LINE_PAPER_LOADERS").split("\\s+")).contains("folia");
+        String expanded;
+        try (var in = LSSPaperPlugin.class.getResourceAsStream("/plugin.yml")) {
+            assertNotNull(in, "expanded plugin.yml must be on the test classpath");
+            expanded = new String(in.readAllBytes(), java.nio.charset.StandardCharsets.UTF_8);
+        }
+        assertTrue(expanded.contains("folia-supported: " + expected),
+                "the EXPANDED plugin.yml must agree with line.env LINE_PAPER_LOADERS ("
+                        + expected + ") — the wrong polarity either refuses Folia or "
+                        + "auto-loads onto a platform this line does not publish for");
+    }
+
+    private static String lineEnv(String key) throws java.io.IOException {
+        for (String line : Files.readAllLines(locate(".github/line.env"))) {
+            String t = line.trim();
+            if (t.startsWith(key + "=")) return t.substring(key.length() + 1);
+        }
+        throw new IllegalStateException(key + " not found in .github/line.env");
     }
 
     @Test

--- a/paper/src/test/java/dev/vox/lss/paper/ReleaseWorkflowContractTest.java
+++ b/paper/src/test/java/dev/vox/lss/paper/ReleaseWorkflowContractTest.java
@@ -76,6 +76,37 @@ class ReleaseWorkflowContractTest {
         isMainline = env("LINE_TAG_SUFFIX").isEmpty();
     }
 
+    @org.junit.jupiter.api.Test
+    void buildYmlDerivesJavaVersionFromLineEnv() throws java.io.IOException {
+        // R2-2 (port-isolation round 2): build.yml hardcoded java-version went red by
+        // construction on the Java-21 line, twice. Both jobs must source line.env and
+        // derive; a literal value is the regression.
+        String buildYml = Files.readString(locate(".github/workflows/build.yml"));
+        assertFalse(buildYml.matches("(?s).*java-version:\\s*\\d.*"),
+                "build.yml must not hardcode java-version — derive from LINE_JAVA_VERSION");
+        assertEquals(2, count(buildYml, "java-version: ${{ env.LINE_JAVA_VERSION }}"),
+                "both build.yml jobs must derive java-version from line.env");
+        assertEquals(2, count(buildYml, "grep -vE '^\\s*(#|$)' .github/line.env >> \"$GITHUB_ENV\""),
+                "both build.yml jobs must source line.env before setup-java");
+    }
+
+    @org.junit.jupiter.api.Test
+    void releaseYmlDerivesPaperDisplayProse() throws java.io.IOException {
+        // R2-7: the Paper Modrinth display name composes from LINE_PAPER_LOADERS —
+        // a hardcoded "Paper/Purpur..." literal is the last per-line name token class.
+        String releaseYml = Files.readString(locate(".github/workflows/release.yml"));
+        assertFalse(releaseYml.contains("Paper/Purpur"),
+                "release.yml must not hardcode loader display prose (LINE_PAPER_DISPLAY derives it)");
+        assertTrue(releaseYml.contains("${{ env.LINE_PAPER_DISPLAY }}"),
+                "the Paper Modrinth name must compose from LINE_PAPER_DISPLAY");
+    }
+
+    private static int count(String haystack, String needle) {
+        int n = 0;
+        for (int i = haystack.indexOf(needle); i >= 0; i = haystack.indexOf(needle, i + 1)) n++;
+        return n;
+    }
+
     private static String env(String key) {
         assertTrue(lineEnv.containsKey(key), "line.env must define " + key);
         return lineEnv.get(key);
@@ -287,17 +318,14 @@ class ReleaseWorkflowContractTest {
         assertTrue(stepBlock("- name: Upload NeoForge to Modrinth")
                         .contains("env.LINE_SHIP_NEOFORGE == 'true'"),
                 "the NeoForge Modrinth step must be flag-gated");
-        // The two-file coupling the message above promises (review MAJOR M1): the
-        // release_check.py mirror has no other automated pin, and the drift vector is
-        // the recurring main->support forward merge on a file already hand-resolved
-        // per line — a desync toward False silently un-gates the shipping line's
-        // family requirements.
+        // R2-5 retired the hand mirror: release_check.py DERIVES SHIP_NEOFORGE from
+        // line.env, so the forward-merge drift vector is gone by construction. Pin the
+        // derivation itself so a revert to a hand constant reds here.
         try {
             String rc = Files.readString(locate("scripts/release_check.py"));
-            assertTrue(rc.contains("\nSHIP_NEOFORGE = "
-                            + (env("LINE_SHIP_NEOFORGE").equals("true") ? "True" : "False") + "\n"),
-                    "release_check.py SHIP_NEOFORGE must mirror line.env LINE_SHIP_NEOFORGE"
-                            + " — flip both together, consciously");
+            assertTrue(rc.contains("SHIP_NEOFORGE = _LINE_ENV.get(\"LINE_SHIP_NEOFORGE\") == \"true\""),
+                    "release_check.py must DERIVE SHIP_NEOFORGE from line.env (R2-5) — "
+                            + "a hand constant re-opens the forward-merge drift vector");
         } catch (java.io.IOException e) {
             throw new java.io.UncheckedIOException(e);
         }

--- a/scripts/release_check.py
+++ b/scripts/release_check.py
@@ -58,7 +58,27 @@ COMMON_FORBIDDEN = ("dev/vox/lss/common/soak/", "dev/vox/lss/common/benchmark/")
 # gets the full jar checks below; only the SHIPPING requirements (family presence,
 # version pin, release globs) are gated. Mirrors .github/line.env
 # LINE_SHIP_NEOFORGE; flip BOTH together.
-SHIP_NEOFORGE = False
+def _line_env():
+    """Parse .github/line.env (the single per-line data source, R2-5) — release_check
+    stops carrying hand-mirrored copies of line data; the contract tests pin the
+    line.env VALUES per line, and everything here derives."""
+    out = {}
+    here = os.path.dirname(os.path.abspath(__file__))
+    with open(os.path.join(here, "..", ".github", "line.env")) as f:
+        for line in f:
+            line = line.strip()
+            if line and not line.startswith("#") and "=" in line:
+                k, _, v = line.partition("=")
+                out[k] = v
+    return out
+
+
+_LINE_ENV = _line_env()
+# Derived (R2-5, retiring the v1.1 hand mirror + its drift vector): NeoForge family
+# requirements follow the line's shipping decision directly.
+SHIP_NEOFORGE = _LINE_ENV.get("LINE_SHIP_NEOFORGE") == "true"
+# Derived: does this line declare folia support? (plugin.yml expands the same datum.)
+FOLIA_SUPPORTED = "folia" in _LINE_ENV.get("LINE_PAPER_LOADERS", "").split()
 RELEASE_GLOBS = ("lod-server-support-fabric-*.jar", "lod-server-support-paper-*.jar",
                  "voxy-server-side-fabric-*.jar", "voxy-server-side-paper-*.jar") + ((
                  "lod-server-support-neoforge-*.jar",
@@ -68,7 +88,7 @@ CI_NAME_SUFFIX = "0.4.0+26.1.2.jar"  # a representative CI filename for glob rou
 # jars; 1.21.x fabric-loom-remap ships intermediary. A forward merge swapping the loom
 # plugin produces a right-named, gate-green jar in the WRONG namespace — unloadable on any
 # real server of this line — so the manifest attribute is pinned like Paper's namespace.
-FABRIC_MAPPING_NAMESPACE = "official"
+FABRIC_MAPPING_NAMESPACE = _LINE_ENV.get("LINE_FABRIC_MAPPING_NAMESPACE", "official")
 SOAK_JAR_PREFIX = "lss-paper-soak"
 
 
@@ -193,9 +213,12 @@ def check_paper_jar(jar, problems):
         # LOSES the flag silently stops loading on Folia servers, which is the failure this
         # now guards (the previous inversion guarded the opposite risk, when no 26.2 Folia
         # existed to load onto).
-        if not re.search(r"^folia-supported:\s*true\s*$", ymltext, re.MULTILINE):
-            problems.append(f"{base}: plugin.yml lost folia-supported: true — Folia servers "
-                            "will refuse this jar")
+        want_folia = "true" if FOLIA_SUPPORTED else "false"
+        if not re.search(r"^folia-supported:\s*" + want_folia + r"\s*$", ymltext, re.MULTILINE):
+            problems.append(f"{base}: plugin.yml folia-supported must be {want_folia} "
+                            "(derived from line.env LINE_PAPER_LOADERS) — the wrong "
+                            "polarity either refuses Folia or auto-loads onto a "
+                            "platform this line does not publish for")
     if not any(n.startswith("dev/vox/lss/common/") and n.endswith(".class") for n in names):
         problems.append(f"{base}: shaded jar missing the shared common/ classes")
     if "paperweight-mappings-namespace: mojang" not in _manifest(jar):

--- a/scripts/soak.sh
+++ b/scripts/soak.sh
@@ -19,9 +19,9 @@ set -euo pipefail
 # SOAK_PLATFORM=paper runs the identical scenario against a real Paper server
 # (:paper:runSoakServer + PaperSoakScenarioDriver) with the UNCHANGED Fabric soak
 # client and checker. Paper keeps its own base-world snapshot (soak-worlds/base-paper);
-# on MC 26.1.2 Paper uses the vanilla unified layout (world/dimensions/minecraft/<dim>,
-# no split world_nether/world_the_end dirs), so the snapshot carries every dimension —
-# including the End — exactly like Fabric's.
+# the staging's world* glob is LINE-INVARIANT (R2-3): on unified-layout lines it
+# matches only world/; on split-layout lines (1.21.x Bukkit) it also carries
+# world_nether/world_the_end — every dimension, including the End, on every line.
 #
 # SOAK_PLATFORM=folia runs the Paper scenario set against a real Folia server
 # (:paper:runFolia downloads the jar; base world soak-worlds/base-folia). Same plugin,
@@ -337,11 +337,12 @@ mkdir -p "$RUN_RESULTS_DIR"
 
 # Step 5a: Stage world. Fresh-world scenarios start from nothing (generation paths);
 # only fresh-backfill SAVES its world as the reusable base afterwards (Step 13).
-# Both platforms keep all dimensions inside world/ (Paper on MC 26.1.2 uses the vanilla
-# unified world/dimensions/minecraft/<dim> layout, not the legacy split
-# world_nether/world_the_end dirs), so clearing/copying world/ covers the End too.
+# The world* glob + split-dir rm are LINE-INVARIANT (R2-3): a strict superset on
+# unified-layout lines (the glob matches only world/, the extra rms hit nothing)
+# and exactly the split-layout flavor on 1.21.x Bukkit — the per-line staging
+# flavor stops existing (it was lost once in a delta-port; review 2026-08-15).
 echo "[soak] Staging world for scenario: $SCENARIO"
-rm -rf "$SERVER_RUN_DIR/world"
+rm -rf "$SERVER_RUN_DIR"/world "$SERVER_RUN_DIR"/world_nether "$SERVER_RUN_DIR"/world_the_end
 if [[ -n "${SOAK_WORLD_FROM:-}" ]]; then
     # Multi-phase orchestrators (scripts/store_offline_edit.sh) carry a prior phase's
     # world forward instead of restaging the base. The dir must contain world/.
@@ -350,9 +351,9 @@ if [[ -n "${SOAK_WORLD_FROM:-}" ]]; then
         exit 1
     fi
     echo "[soak] Staging world from SOAK_WORLD_FROM=$SOAK_WORLD_FROM"
-    cp -r "$SOAK_WORLD_FROM/world" "$SERVER_RUN_DIR/world"
+    cp -r "$SOAK_WORLD_FROM"/world* "$SERVER_RUN_DIR"/
 elif [[ " $FRESH_WORLD_SCENARIOS " != *" $SCENARIO "* ]]; then
-    cp -r "$BASE_WORLD_DIR/world" "$SERVER_RUN_DIR/world"
+    cp -r "$BASE_WORLD_DIR"/world* "$SERVER_RUN_DIR"/
 fi
 
 # Step 5b: Stage client column cache. warm-rejoin clears too: its run 1 IS the
@@ -568,8 +569,8 @@ cp "$SCENARIO_JSON" "$RUN_RESULTS_DIR/"
 if [[ "$SCENARIO" == "fresh-backfill" && -d "$SERVER_RUN_DIR/world" ]]; then
     echo "[soak] Saving world to $BASE_WORLD_DIR/ for reuse"
     mkdir -p "$BASE_WORLD_DIR"
-    rm -rf "$BASE_WORLD_DIR/world"
-    cp -r "$SERVER_RUN_DIR/world" "$BASE_WORLD_DIR/world"
+    rm -rf "$BASE_WORLD_DIR"/world "$BASE_WORLD_DIR"/world_nether "$BASE_WORLD_DIR"/world_the_end
+    cp -r "$SERVER_RUN_DIR"/world* "$BASE_WORLD_DIR"/
     printf '%s' "$MC_LINE_VERSION" > "$WORLD_VERSION_MARKER"
     # Stage D: collect from whichever root the client actually used this run — a
     # fresh run dir writes .lss/cache while a legacy dir adopts config/lss/cache;

--- a/test-server.sh
+++ b/test-server.sh
@@ -20,18 +20,29 @@ NEOFORGE_DIR="$SCRIPT_DIR/test-server/neoforge"
 LEGACY_DIR="$SCRIPT_DIR/test-server/fabric-legacy"
 
 # ======================= LINE DATA (per-MC-line values) =======================
-# The port runbook's step 8 edits exactly this block (MC versions, CDN URLs, the
-# legacy LSS pin below) — nothing else in this script is per-line.
+# SHRUNK by R2-6: the MC versions and the Java gate now DERIVE (gradle.properties
+# minecraft_version + line.env LINE_JAVA_VERSION — the same data the build itself
+# consumes, so the rig can never drift from the compile target). Only the CDN URLs
+# + the legacy LSS pin below remain genuine LINE DATA, and the startup self-check
+# reds loudly when a kept URL disagrees with the derived data.
+MC_LINE_VERSION="$(sed -n 's/^minecraft_version=//p' "$SCRIPT_DIR/gradle.properties" | tr -d '\r')"
+if [ -z "$MC_LINE_VERSION" ]; then
+    echo "ERROR: could not read minecraft_version from gradle.properties" >&2
+    exit 1
+fi
+LINE_JAVA_VERSION="$(sed -n 's/^LINE_JAVA_VERSION=//p' "$SCRIPT_DIR/.github/line.env" | tr -d '\r')"
+if [ -z "$LINE_JAVA_VERSION" ]; then
+    echo "ERROR: could not read LINE_JAVA_VERSION from .github/line.env" >&2
+    exit 1
+fi
 # --- Fabric versions ---
-# NOTE: the Java-version gate below (JAVA_MAJOR check) is ALSO per-line data —
-#       a Java-21 line port must retarget it (round-3 review NIT).
-FABRIC_MC_VERSION="26.2"
+FABRIC_MC_VERSION="$MC_LINE_VERSION"
 FABRIC_LOADER_VERSION="0.19.3"
 FABRIC_INSTALLER_VERSION="1.1.1"
 
 # --- Paper/Folia versions ---
-PAPER_MC_VERSION="26.2"
-FOLIA_MC_VERSION="26.2"
+PAPER_MC_VERSION="$MC_LINE_VERSION"
+FOLIA_MC_VERSION="$MC_LINE_VERSION"
 
 # --- NeoForge version ---
 # Pinned to the version the neoforge module BUILDS AGAINST (gradle.properties
@@ -66,13 +77,31 @@ LEGACY_LSS_VERSION="0.6.2"
 LEGACY_LSS_MC="26.2"
 LEGACY_LSS_FABRIC_URL="https://github.com/VoX/lod-server-support/releases/download/v${LEGACY_LSS_VERSION}/lod-server-support-fabric-${LEGACY_LSS_VERSION}%2B${LEGACY_LSS_MC}.jar"
 
-# --- Java version check ---
+# --- Java version check (derived from line.env, R2-6) ---
 JAVA_MAJOR=$(java -version 2>&1 | head -1 | sed 's/.*"\([0-9]\+\).*/\1/')
-if [ "$JAVA_MAJOR" -lt 25 ] 2>/dev/null; then
-    echo "ERROR: Java 25+ required for MC 26.2. Found: Java $JAVA_MAJOR" >&2
-    echo "  Set JAVA_HOME to a JDK 25+ installation." >&2
+if [ "$JAVA_MAJOR" -lt "$LINE_JAVA_VERSION" ] 2>/dev/null; then
+    echo "ERROR: Java ${LINE_JAVA_VERSION}+ required for MC ${MC_LINE_VERSION}. Found: Java $JAVA_MAJOR" >&2
+    echo "  Set JAVA_HOME to a JDK ${LINE_JAVA_VERSION}+ installation." >&2
     exit 1
 fi
+
+# --- LINE DATA self-check (R2-6): the kept hand URLs must agree with the derived
+# data — an inherited URL from another line reds HERE, not as a mid-run 404/mixin
+# crash. C2ME's Modrinth version ID also lives in gradle.properties; the URL must
+# embed the same ID or the two drift internally.
+case "$FABRIC_API_URL" in *"${MC_LINE_VERSION}"*) : ;; *)
+    echo "ERROR: FABRIC_API_URL does not mention MC ${MC_LINE_VERSION} — stale line data" >&2
+    exit 1 ;;
+esac
+case "$C2ME_URL" in *"mc${MC_LINE_VERSION}"*) : ;; *)
+    echo "ERROR: C2ME_URL does not mention mc${MC_LINE_VERSION} — stale line data" >&2
+    exit 1 ;;
+esac
+C2ME_MODRINTH_ID="$(sed -n 's/^c2me_modrinth_version=//p' "$SCRIPT_DIR/gradle.properties" | tr -d '\r')"
+case "$C2ME_URL" in *"/${C2ME_MODRINTH_ID}/"*) : ;; *)
+    echo "ERROR: C2ME_URL version ID disagrees with gradle.properties c2me_modrinth_version (${C2ME_MODRINTH_ID})" >&2
+    exit 1 ;;
+esac
 
 # --- Settings ---
 SERVER_RAM="${SERVER_RAM:-2G}"


### PR DESCRIPTION
R2-1/2/3/5/6/7 per the v1.2 plan: the Tier-3 cut boolean with its poison-pill stub, build.yml java-version from line.env, line-invariant soak world staging, folia-supported + SHIP_NEOFORGE + mapping-namespace derived from line.env (the hand mirror retired), third-party coordinates as data, and the composed Paper display name. All M3 byte-diff gates pass (only planned comment rewords); full local gates green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)