### PR TITLE
chore: bump mod_version to 0.11.1

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -16,7 +16,7 @@ loader_version=0.19.3
 loom_version=1.17.13
 
 # Mod Properties
-mod_version=0.9.1
+mod_version=0.11.1
 maven_group=dev.vox
 archives_base_name=lod-server-support-fabric
 


### PR DESCRIPTION
One-liner: dev builds were stamping the stale 0.9.1 banner (the release flow overrides via -Pmod_version, so this is cosmetic — but it becomes the v0.11.1 release commit on main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)