### PR TITLE
test(paper): B.0 wiring pins for the P1 header rung (v0.12.0 Phase B.0)

### DIFF
--- a/docs/planning/v0.12.0-release-plan.md
+++ b/docs/planning/v0.12.0-release-plan.md
@@ -7,10 +7,14 @@ error, re-aims Phase C's gates at the Paper half of the P1 work, and adds the
 parity-diff artifact that makes the per-line reviews mechanical where drift is
 zero.
 
-**Content:** v0.12.0 is exactly the unmerged two-PR stack — **PR #207**
-(section-leaf client state + quadtree ring fast path) and **PR #208** (region
-summary sync P1/P2 + stamped up_to_date, both panel folds applied) — **15
-commits, 117 files, ~12.3k insertions** (measured; #207 = 3, #208 = 12). main
+**Content:** v0.12.0 is exactly the two-PR stack — **PR #207** (section-leaf
+client state + quadtree ring fast path) and the summary half landed as **PR
+#209** (the continuation of #208, whose base deletion CLOSED it — a third
+GitHub behavior variant; recovery provably lossless, same head SHA): region
+summary sync P1/P2 + stamped up_to_date, both panel folds applied — **16
+commits, 118 files, ~12.6k insertions** (measured post-merge; #207 = 3,
+#209 = 13 incl. this plan doc, which RIDES the per-line pick range — do not
+exclude it). main
 is fully released at v0.11.1 (79e49951; the stutter-fix round already shipped
 in v0.11.1 on all four lines), so nothing else is pending. Headline
 user-facing features: the GB-class warm-rejoin re-download is closed
@@ -128,9 +132,13 @@ gate → review → fold**.
    per-line commit by precedent — the main bump is NOT in the pick range, and
    skipping it re-enters the stale-dev-banner state v0.11.1 paid to fix; the
    pre-flight's explicit `-Pmod_version` masks the gap, so nothing else reds).
-2. **Port**: cherry-pick the stack + B.0 range (`git log --oneline
-   main..<stack-tip>` at pick time is the completeness checklist — count it,
-   don't trust this doc). Non-mechanical resolutions get a note in the port
+2. **Port**: cherry-pick the stack + B.0 range. The stack is now IN main —
+   enumerate the pick list with `git log --oneline --no-merges
+   79e49951..main` at pick time and count it, don't trust this doc.
+   **Fetch origin FIRST and branch from the REMOTE v0.11 tips** (Phase A
+   review: the local support refs are stale by 7-8 commits — branching from
+   local refs silently drops the line's v0.11.1 port). 
+   Non-mechanical resolutions get a note in the port
    commit body. **Must-carry note:** commit 502dd13e (move-trace shutdown
    classload gate) rides the stack unrelated to any feature — it is NOT
    optional and nothing reds if dropped.

--- a/paper/src/main/java/dev/vox/lss/paper/PaperRequestProcessingService.java
+++ b/paper/src/main/java/dev/vox/lss/paper/PaperRequestProcessingService.java
@@ -483,34 +483,10 @@ public class PaperRequestProcessingService {
             }
         }
         // Region-dir resolver, HOISTED out of the store branch (region-summary-sync-plan.md
-        // §5 integration M2 — the Fabric twin's comment applies: the P1 header rung must
-        // work store-LESS, and the compiled store default is off).
-        // PER-LINE INVARIANT (surfaces row 17 — Bukkit world layout): Paper 26.x uses the
-        // vanilla UNIFIED layout, so the server worldRoot is the correct getStorageFolder
-        // root, same as Fabric. The 1.21.x lines use Bukkit's legacy SPLIT world dirs and
-        // re-root PER LEVEL via getWorld().getWorldFolder() — the two forms are NOT
-        // interchangeable: R2-9's live probe (2026-08-15) showed 26.2's getWorldFolder()
-        // returns the per-dimension SUBFOLDER (world/dimensions/minecraft/<dim>), so
-        // adopting the per-level form here would break this line's sweep the same way the
-        // unified form broke the 1.21.x port's. Walk row 17 on every port.
+        // §5 integration M2 — the P1 header rung must work store-LESS). The per-line
+        // layout invariant (surfaces row 17) lives on resolveRegionDirs below.
         var worldRoot = server.getWorldPath(LevelResource.ROOT).normalize();
-        var regionDirs = new java.util.HashMap<String, java.nio.file.Path>();
-        for (ServerLevel level : server.getAllLevels()) {
-            // Per-level belt: this loop now runs on STORE-LESS servers too, where the
-            // storage-folder API was never touched before — an exotic dimension key
-            // must degrade that one dimension to UNKNOWN (the table's designed
-            // fail-safe), never take down service start.
-            try {
-                regionDirs.put(level.dimension().identifier().toString(),
-                        net.minecraft.world.level.dimension.DimensionType
-                                .getStorageFolder(level.dimension(), worldRoot)
-                                .resolve("region").normalize());
-            } catch (Throwable t) {
-                LSSLogger.warn("Could not resolve the region directory for "
-                        + level.dimension().identifier() + " — region freshness there"
-                        + " falls through to full reads", t);
-            }
-        }
+        var regionDirs = resolveRegionDirs(server, worldRoot);
         var regionStamps = new dev.vox.lss.common.region.RegionStampTable(regionDirs::get);
         diskReader.attachRegionStamps(regionStamps);
         // Tracker + mark listener BEFORE the processor starts (the Fabric twin's
@@ -577,6 +553,43 @@ public class PaperRequestProcessingService {
         return new Wiring(players, diskReader, generationService, offThreadProcessor,
                 dirtyTracker, dirtyBroadcaster, lodStore, xrayMasks, wireCompressionLive,
                 regionStamps);
+    }
+
+    /** Region-dir resolution for the P1 freshness rungs (one call site in the wiring
+     *  builder above; extracted for the v0.12.0 B.0 wiring pin —
+     *  {@code PaperRegionFreshnessWiringTest} drives it with mocked levels). The
+     *  PER-LINE INVARIANT (surfaces row 17) lives HERE now, at the one swappable
+     *  site: Paper 26.x uses the vanilla UNIFIED layout ({@code getStorageFolder}
+     *  under the server worldRoot, same as Fabric); the 1.21.x lines use Bukkit's
+     *  legacy SPLIT world dirs and must re-root PER LEVEL via
+     *  {@code getWorld().getWorldFolder()} — the two forms are NOT interchangeable
+     *  (R2-9's live probe, 2026-08-15: 26.2's getWorldFolder() returns the
+     *  per-dimension SUBFOLDER, and the unified form broke the 1.21.x port's sweep
+     *  the same way). Ports adapt THIS method + the wiring test's expectations. */
+    static java.util.HashMap<String, java.nio.file.Path> resolveRegionDirs(
+            MinecraftServer server, java.nio.file.Path worldRoot) {
+        var regionDirs = new java.util.HashMap<String, java.nio.file.Path>();
+        for (ServerLevel level : server.getAllLevels()) {
+            // Per-level belt: this loop runs on STORE-LESS servers too — an exotic
+            // dimension key must degrade that one dimension to UNKNOWN (the table's
+            // designed fail-safe), never take down service start. The catch must not
+            // re-invoke anything throwable (B.0 pin finding: the old warn line called
+            // level.dimension() AGAIN, so a dimension whose accessor itself throws
+            // escaped the belt and killed start — capture the name first).
+            String dim = null;
+            try {
+                dim = level.dimension().identifier().toString();
+                regionDirs.put(dim,
+                        net.minecraft.world.level.dimension.DimensionType
+                                .getStorageFolder(level.dimension(), worldRoot)
+                                .resolve("region").normalize());
+            } catch (Throwable t) {
+                LSSLogger.warn("Could not resolve the region directory for "
+                        + (dim != null ? dim : "<unresolvable dimension>")
+                        + " — region freshness there falls through to full reads", t);
+            }
+        }
+        return regionDirs;
     }
 
     /** Registry identity for the LOD store meta guard (4-agent round R2-M3) — textual

--- a/paper/src/test/java/dev/vox/lss/paper/PaperRegionFreshnessWiringTest.java
+++ b/paper/src/test/java/dev/vox/lss/paper/PaperRegionFreshnessWiringTest.java
@@ -1,0 +1,130 @@
+package dev.vox.lss.paper;
+
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.level.Level;
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * The v0.12.0 B.0 wiring pins (v0.12.0-release-plan.md Phase B.0): the P1 header
+ * freshness rung's PAPER wiring had no gate on any support line while living in the
+ * single most-drifted file of the backport — a conflict resolution that drops the
+ * {@code attachRegionStamps} call or mis-roots the region-dir resolver ships a line
+ * where the headline warm-rejoin feature is silently dead (every doubt shape degrades
+ * fail-safe to NEVER_CLEAN — no crash, no log storm). The 1.21.1 line has ALREADY
+ * shipped the resolver half of that bug once (world/DIM-1 does not exist under the
+ * unified layout — its own port comment records it).
+ *
+ * <p>PORTS: the resolver pin's EXPECTATIONS are per-line (surfaces row 17): this
+ * line (26.x unified layout) expects {@code getStorageFolder} under the server
+ * worldRoot; the 1.21.x lines expect the per-level {@code getWorldFolder()} split
+ * roots. Adapt the expected paths WITH the resolver — a port that leaves either
+ * behind reds here.
+ */
+class PaperRegionFreshnessWiringTest {
+
+    @org.junit.jupiter.api.BeforeAll
+    static void setup() {
+        net.minecraft.SharedConstants.tryDetectVersion();
+        net.minecraft.server.Bootstrap.bootStrap();
+    }
+
+    private static ServerLevel level(ResourceKey<Level> key) {
+        var l = mock(ServerLevel.class);
+        when(l.dimension()).thenReturn(key);
+        return l;
+    }
+
+    @Test
+    void resolverMapsAllThreeVanillaDimensionsToTheirRegionDirs() throws Exception {
+        Path root = Files.createTempDirectory("lss-resolver-pin");
+        var server = mock(MinecraftServer.class);
+        var overworld = level(Level.OVERWORLD);
+        var nether = level(Level.NETHER);
+        var end = level(Level.END);
+        when(server.getAllLevels()).thenReturn(List.of(overworld, nether, end));
+
+        var dirs = PaperRequestProcessingService.resolveRegionDirs(server, root);
+
+        assertEquals(3, dirs.size(), "all three vanilla dimensions must resolve");
+        Path ow = dirs.get("minecraft:overworld");
+        Path ne = dirs.get("minecraft:the_nether");
+        Path en = dirs.get("minecraft:the_end");
+        assertNotNull(ow, "overworld resolved");
+        assertNotNull(ne, "nether resolved — the shipped-once failure shape was a"
+                + " nether/end dir that does not exist, silently degrading every"
+                + " non-overworld dim to NEVER_CLEAN");
+        assertNotNull(en, "end resolved");
+        // 26.x unified layout (row 17): EVERY dimension, overworld included, lives
+        // under dimensions/minecraft/<dim>/region (verified against the real
+        // getStorageFolder at pin-writing time — the classic root/region overworld is
+        // a PRE-26 shape). PORTS: on the 1.21.x split-dir lines these expectations
+        // change WITH the resolver form — see the class javadoc.
+        assertEquals(root.resolve("dimensions/minecraft/overworld/region").normalize(), ow,
+                "overworld = worldRoot/dimensions/minecraft/overworld/region on 26.x");
+        assertTrue(ne.toString().endsWith("region"), "nether path targets a region dir: " + ne);
+        assertTrue(en.toString().endsWith("region"), "end path targets a region dir: " + en);
+        assertEquals(3, java.util.Set.of(ow, ne, en).size(),
+                "the three dimensions' region dirs must be DISTINCT — a resolver that"
+                + " collapses them serves cross-dimension freshness claims");
+        // The vanilla storage-folder derivation must keep nether/end under the root
+        // (the unified layout's invariant — a resolver re-rooted per-level on this
+        // line would escape the worldRoot, the R2-9 probe's failure shape inverted).
+        assertTrue(ne.startsWith(root), "nether dir under the world root: " + ne);
+        assertTrue(en.startsWith(root), "end dir under the world root: " + en);
+    }
+
+    @Test
+    void exoticDimensionDegradesThatDimensionOnlyNeverServiceStart() {
+        var server = mock(MinecraftServer.class);
+        var overworld = level(Level.OVERWORLD);
+        var exotic = mock(ServerLevel.class);
+        when(exotic.dimension()).thenThrow(new IllegalStateException("exotic dimension"));
+        when(server.getAllLevels()).thenReturn(List.of(overworld, exotic));
+
+        var dirs = assertDoesNotThrow(() -> PaperRequestProcessingService
+                        .resolveRegionDirs(server, Path.of("root")),
+                "the per-level belt: one exotic dimension must never take down start");
+        assertNotNull(dirs.get("minecraft:overworld"), "the healthy dimension still resolves");
+    }
+
+    /** The ATTACH half (source-scan — the contract-test idiom; the production wiring
+     *  builder needs a full NMS server, and the test Wiring ctor deliberately
+     *  bypasses it): the stamp table must be constructed from the resolver and
+     *  attached to the disk reader UNCONDITIONALLY (outside any store branch — the
+     *  rung is load-bearing store-LESS), and the dirty tracker's mark listener must
+     *  bump the region latch. A port that drops any of the three lines ships the
+     *  silent-dead-feature shape this test exists for. */
+    @Test
+    void wiringSourceCarriesTheAttachAndTheMarkListenerBump() throws Exception {
+        Path src = Path.of("src/main/java/dev/vox/lss/paper/PaperRequestProcessingService.java");
+        if (!Files.exists(src)) {
+            src = Path.of("paper").resolve(src);
+        }
+        String body = Files.readString(src);
+
+        int resolve = body.indexOf("resolveRegionDirs(server, worldRoot)");
+        int attach = body.indexOf("diskReader.attachRegionStamps(regionStamps)");
+        int bump = body.indexOf(".bumpLiveSaveMark(");
+        int storeBranch = body.indexOf("if (storeMode != dev.vox.lss.common.store.LodStoreMode.OFF)");
+        assertTrue(resolve > 0, "the wiring builder must construct the region dirs via"
+                + " resolveRegionDirs (the extracted, per-line-swappable site)");
+        assertTrue(attach > 0, "the disk reader must get attachRegionStamps — without it"
+                + " the header rung is silently dead (disk.header_hits frozen at 0)");
+        assertTrue(bump > 0, "the mark listener must bump the region live-save latch");
+        assertTrue(storeBranch > 0, "census anchor: the store-mode branch exists");
+        assertTrue(attach < storeBranch, "attachRegionStamps must sit BEFORE (outside)"
+                + " the store branch — the rung is load-bearing on store-LESS servers"
+                + " (the compiled store default is off)");
+        assertTrue(bump < storeBranch, "the latch bump wiring must also be store-independent");
+    }
+}


### PR DESCRIPTION
Per docs/planning/v0.12.0-release-plan.md Phase B.0: the resolver behavioral pin (which corrected the 26.x layout expectation and found+fixed a latent belt bug — the catch re-invoked the throwing accessor), the extracted per-line-swappable resolveRegionDirs site, and the attach/mark-listener source-scan. Plus the Phase A review's plan-doc corrections.

🤖 Generated with [Claude Code](https://claude.com/claude-code)