### PR TITLE
docs: v0.12.0 Phase D-prep record + panel-folded release notes

### DIFF
--- a/docs/planning/v0.12.0-release-notes/main.md
+++ b/docs/planning/v0.12.0-release-notes/main.md
@@ -1,19 +1,23 @@
 ### New Features
 
-- **Region summaries: warm rejoins no longer re-download the world** — When you reconnect to a server you've explored, the server now sends a compact freshness summary of each region (a few KB), and your client validates its cached terrain against it instead of re-requesting every chunk. A converged rejoin that used to re-transfer gigabytes now costs kilobytes.
-- **Stamped up-to-date responses** — The server timestamps its "your copy is current" answers, so terrain verified on one session stays verified on the next. This closes the loop where the same regions were re-checked on every single rejoin forever.
-- **Far lighter client memory** — The client's terrain-tracking state moved to a compact section-leaf layout: roughly 6-10× less memory at high LOD distances, and smoother scanning with fewer render-thread hitches when teleporting or changing dimensions.
+- **Warm rejoins stop re-downloading terrain you already have** — Before reading or re-sending a column, the server now checks the region file's on-disk freshness (and, with the LOD store on, the store's own acquisition stamps) and answers "still current" instead. A rejoin whose freshness cache has aged out no longer re-streams gigabytes. This half is server-side: every client benefits, including ones still on v0.11.
+- **Region summaries: one small frame replaces a million re-checks** — With client and server both on v0.12.0, entering a dimension now costs one compact frame (a few KB) listing which regions are unchanged; the client validates the clean bulk of its cached terrain from it instead of re-declaring every column over several minutes. Verify with `/lsslod diag`'s new `Summary:` line.
+- **Stamped up-to-date responses** — The server timestamps its "your copy is current" answers, so terrain verified in one session stays verified in the next. This closes the loop where the same regions were re-checked on every single rejoin forever. (On servers with the LOD store enabled, the stickiness lands one session later — the store's honest, older stamps take one extra verified rejoin to ratchet forward.)
+
+### Performance
+
+- **Far lighter client memory** — The client's terrain-tracking state moves to a compact section-leaf layout: roughly 6-10× smaller at the default 512-chunk LOD distance, with smoother scanning and fewer render-thread hitches when teleporting or changing dimensions.
 
 ### Bug Fixes
 
-- **Exotic dimension no longer able to break server startup** — A dimension whose identity lookup throws could previously escape the safety net during service start. It now degrades only that dimension's freshness tracking.
-- **Server shutdown hardened against mid-session jar swaps** — Diagnostic telemetry no longer loads classes during shutdown, which could abort the final world save if the mod jar had been replaced while the server ran.
+- **Replacing the mod jar on a running server no longer risks an unclean shutdown (Fabric)** — An internal diagnostics class could load for the first time during shutdown and fail if the jar had been swapped underneath, aborting the orderly stop and the final world save. It now loads only when that diagnostic is actually enabled.
 
 ### Configuration
 
-- **`enableRegionSummaries`** (server, default on) and **`enableRegionSummarySync`** (client, default on) — kill switches for the new summary exchange.
-- **`enableQuadtreeScan`** (client, default on) — the new fast ring-scan path; disable to restore the per-position walk.
+- **`enableRegionSummaries`** (server, default on) and **`enableRegionSummarySync`** (client, in `lss-client-config.json`, default on) — kill switches for the new summary exchange.
+- **`enableQuadtreeScan`** (client, in `lss-client-config.json`, default on) — the new fast ring-scan path; disable to restore the per-position walk.
 
 ### Compatibility
 
-- **The new behaviors need BOTH halves on v0.12.0** — the summary exchange and stamped verification only run when client and server both carry this version. Mixed versions are fully compatible: a v0.12.0 client on an older server (or the reverse) simply doesn't exchange the new messages and behaves like v0.11. Folia support remains **experimental**.
+- **The summary exchange needs BOTH halves on v0.12.0** — Mixed versions are fully compatible and quiet: a v0.12.0 client on an older server gets no answer and falls back to per-column revalidation, and an older client on a v0.12.0 server still gets the server-side freshness checks above — it just never asks for a summary.
+- Folia support remains **experimental**.

--- a/docs/planning/v0.12.0-release-notes/mc1.21.1.md
+++ b/docs/planning/v0.12.0-release-notes/mc1.21.1.md
@@ -1,19 +1,27 @@
 ### New Features
 
-- **Region summaries: warm rejoins no longer re-download the world** — When you reconnect to a server you've explored, the server now sends a compact freshness summary of each region (a few KB), and your client validates its cached terrain against it instead of re-requesting every chunk. A converged rejoin that used to re-transfer gigabytes now costs kilobytes.
-- **Stamped up-to-date responses** — The server timestamps its "your copy is current" answers, so terrain verified on one session stays verified on the next. This closes the loop where the same regions were re-checked on every single rejoin forever.
-- **Far lighter client memory** — The client's terrain-tracking state moved to a compact section-leaf layout: roughly 6-10× less memory at high LOD distances, and smoother scanning with fewer render-thread hitches when teleporting or changing dimensions.
+- **Warm rejoins stop re-downloading terrain you already have** — Before reading or re-sending a column, the server now checks the region file's on-disk freshness (and, with the LOD store on, the store's own acquisition stamps) and answers "still current" instead. A rejoin whose freshness cache has aged out no longer re-streams gigabytes. This half is server-side: every client benefits, including ones still on v0.11.
+- **Region summaries: one small frame replaces a million re-checks** — With client and server both on v0.12.0, entering a dimension now costs one compact frame (a few KB) listing which regions are unchanged; the client validates the clean bulk of its cached terrain from it instead of re-declaring every column over several minutes. Verify with `/lsslod diag`'s new `Summary:` line.
+- **Stamped up-to-date responses** — The server timestamps its "your copy is current" answers, so terrain verified in one session stays verified in the next. This closes the loop where the same regions were re-checked on every single rejoin forever. (On servers with the LOD store enabled, the stickiness lands one session later — the store's honest, older stamps take one extra verified rejoin to ratchet forward.)
+
+### Performance
+
+- **Far lighter client memory** — The client's terrain-tracking state moves to a compact section-leaf layout: roughly 6-10× smaller at the default 512-chunk LOD distance, with smoother scanning and fewer render-thread hitches when teleporting or changing dimensions.
 
 ### Bug Fixes
 
-- **Exotic dimension no longer able to break server startup** — A dimension whose identity lookup throws could previously escape the safety net during service start. It now degrades only that dimension's freshness tracking.
-- **Server shutdown hardened against mid-session jar swaps** — Diagnostic telemetry no longer loads classes during shutdown, which could abort the final world save if the mod jar had been replaced while the server ran.
+- **Replacing the mod jar on a running server no longer risks an unclean shutdown (Fabric)** — An internal diagnostics class could load for the first time during shutdown and fail if the jar had been swapped underneath, aborting the orderly stop and the final world save. It now loads only when that diagnostic is actually enabled.
 
 ### Configuration
 
-- **`enableRegionSummaries`** (server, default on) and **`enableRegionSummarySync`** (client, default on) — kill switches for the new summary exchange.
-- **`enableQuadtreeScan`** (client, default on) — the new fast ring-scan path; disable to restore the per-position walk.
+- **`enableRegionSummaries`** (server, default on) and **`enableRegionSummarySync`** (client, in `lss-client-config.json`, default on) — kill switches for the new summary exchange.
+- **`enableQuadtreeScan`** (client, in `lss-client-config.json`, default on) — the new fast ring-scan path; disable to restore the per-position walk.
 
 ### Compatibility
 
-- **The new behaviors need BOTH halves on v0.12.0** — the summary exchange and stamped verification only run when client and server both carry this version. Mixed versions are fully compatible: a v0.12.0 client on an older server (or the reverse) simply doesn't exchange the new messages and behaves like v0.11. Folia support remains **experimental**. This line (including NeoForge) is supported at the best-effort tier.
+- **The summary exchange needs BOTH halves on v0.12.0** — Mixed versions are fully compatible and quiet: a v0.12.0 client on an older server gets no answer and falls back to per-column revalidation, and an older client on a v0.12.0 server still gets the server-side freshness checks above — it just never asks for a summary.
+
+### NeoForge notes
+
+- This line (including the NeoForge build) is supported at the best-effort tier. No features were cut in this release.
+- The NeoForge build carries the client half of the new behaviors too — region summaries and stamped verification work on NeoForge clients exactly as on Fabric.

--- a/docs/planning/v0.12.0-release-notes/mc1.21.11.md
+++ b/docs/planning/v0.12.0-release-notes/mc1.21.11.md
@@ -1,19 +1,24 @@
 ### New Features
 
-- **Region summaries: warm rejoins no longer re-download the world** — When you reconnect to a server you've explored, the server now sends a compact freshness summary of each region (a few KB), and your client validates its cached terrain against it instead of re-requesting every chunk. A converged rejoin that used to re-transfer gigabytes now costs kilobytes.
-- **Stamped up-to-date responses** — The server timestamps its "your copy is current" answers, so terrain verified on one session stays verified on the next. This closes the loop where the same regions were re-checked on every single rejoin forever.
-- **Far lighter client memory** — The client's terrain-tracking state moved to a compact section-leaf layout: roughly 6-10× less memory at high LOD distances, and smoother scanning with fewer render-thread hitches when teleporting or changing dimensions.
+- **Warm rejoins stop re-downloading terrain you already have** — Before reading or re-sending a column, the server now checks the region file's on-disk freshness (and, with the LOD store on, the store's own acquisition stamps) and answers "still current" instead. A rejoin whose freshness cache has aged out no longer re-streams gigabytes. This half is server-side: every client benefits, including ones still on v0.11.
+- **Region summaries: one small frame replaces a million re-checks** — With client and server both on v0.12.0, entering a dimension now costs one compact frame (a few KB) listing which regions are unchanged; the client validates the clean bulk of its cached terrain from it instead of re-declaring every column over several minutes. Verify with `/lsslod diag`'s new `Summary:` line.
+- **Stamped up-to-date responses** — The server timestamps its "your copy is current" answers, so terrain verified in one session stays verified in the next. This closes the loop where the same regions were re-checked on every single rejoin forever. (On servers with the LOD store enabled, the stickiness lands one session later — the store's honest, older stamps take one extra verified rejoin to ratchet forward.)
+
+### Performance
+
+- **Far lighter client memory** — The client's terrain-tracking state moves to a compact section-leaf layout: roughly 6-10× smaller at the default 512-chunk LOD distance, with smoother scanning and fewer render-thread hitches when teleporting or changing dimensions.
 
 ### Bug Fixes
 
-- **Exotic dimension no longer able to break server startup** — A dimension whose identity lookup throws could previously escape the safety net during service start. It now degrades only that dimension's freshness tracking.
-- **Server shutdown hardened against mid-session jar swaps** — Diagnostic telemetry no longer loads classes during shutdown, which could abort the final world save if the mod jar had been replaced while the server ran.
+- **Replacing the mod jar on a running server no longer risks an unclean shutdown (Fabric)** — An internal diagnostics class could load for the first time during shutdown and fail if the jar had been swapped underneath, aborting the orderly stop and the final world save. It now loads only when that diagnostic is actually enabled.
 
 ### Configuration
 
-- **`enableRegionSummaries`** (server, default on) and **`enableRegionSummarySync`** (client, default on) — kill switches for the new summary exchange.
-- **`enableQuadtreeScan`** (client, default on) — the new fast ring-scan path; disable to restore the per-position walk.
+- **`enableRegionSummaries`** (server, default on) and **`enableRegionSummarySync`** (client, in `lss-client-config.json`, default on) — kill switches for the new summary exchange.
+- **`enableQuadtreeScan`** (client, in `lss-client-config.json`, default on) — the new fast ring-scan path; disable to restore the per-position walk.
 
 ### Compatibility
 
-- **The new behaviors need BOTH halves on v0.12.0** — the summary exchange and stamped verification only run when client and server both carry this version. Mixed versions are fully compatible: a v0.12.0 client on an older server (or the reverse) simply doesn't exchange the new messages and behaves like v0.11. Folia support remains **experimental**. This line is supported at the "correct, not perfect" tier.
+- **The summary exchange needs BOTH halves on v0.12.0** — Mixed versions are fully compatible and quiet: a v0.12.0 client on an older server gets no answer and falls back to per-column revalidation, and an older client on a v0.12.0 server still gets the server-side freshness checks above — it just never asks for a summary.
+- Folia support remains **experimental**.
+- This line is supported at the "correct, not perfect" tier.

--- a/docs/planning/v0.12.0-release-notes/mc26.1.md
+++ b/docs/planning/v0.12.0-release-notes/mc26.1.md
@@ -1,19 +1,24 @@
 ### New Features
 
-- **Region summaries: warm rejoins no longer re-download the world** — When you reconnect to a server you've explored, the server now sends a compact freshness summary of each region (a few KB), and your client validates its cached terrain against it instead of re-requesting every chunk. A converged rejoin that used to re-transfer gigabytes now costs kilobytes.
-- **Stamped up-to-date responses** — The server timestamps its "your copy is current" answers, so terrain verified on one session stays verified on the next. This closes the loop where the same regions were re-checked on every single rejoin forever.
-- **Far lighter client memory** — The client's terrain-tracking state moved to a compact section-leaf layout: roughly 6-10× less memory at high LOD distances, and smoother scanning with fewer render-thread hitches when teleporting or changing dimensions.
+- **Warm rejoins stop re-downloading terrain you already have** — Before reading or re-sending a column, the server now checks the region file's on-disk freshness (and, with the LOD store on, the store's own acquisition stamps) and answers "still current" instead. A rejoin whose freshness cache has aged out no longer re-streams gigabytes. This half is server-side: every client benefits, including ones still on v0.11.
+- **Region summaries: one small frame replaces a million re-checks** — With client and server both on v0.12.0, entering a dimension now costs one compact frame (a few KB) listing which regions are unchanged; the client validates the clean bulk of its cached terrain from it instead of re-declaring every column over several minutes. Verify with `/lsslod diag`'s new `Summary:` line.
+- **Stamped up-to-date responses** — The server timestamps its "your copy is current" answers, so terrain verified in one session stays verified in the next. This closes the loop where the same regions were re-checked on every single rejoin forever. (On servers with the LOD store enabled, the stickiness lands one session later — the store's honest, older stamps take one extra verified rejoin to ratchet forward.)
+
+### Performance
+
+- **Far lighter client memory** — The client's terrain-tracking state moves to a compact section-leaf layout: roughly 6-10× smaller at the default 512-chunk LOD distance, with smoother scanning and fewer render-thread hitches when teleporting or changing dimensions.
 
 ### Bug Fixes
 
-- **Exotic dimension no longer able to break server startup** — A dimension whose identity lookup throws could previously escape the safety net during service start. It now degrades only that dimension's freshness tracking.
-- **Server shutdown hardened against mid-session jar swaps** — Diagnostic telemetry no longer loads classes during shutdown, which could abort the final world save if the mod jar had been replaced while the server ran.
+- **Replacing the mod jar on a running server no longer risks an unclean shutdown (Fabric)** — An internal diagnostics class could load for the first time during shutdown and fail if the jar had been swapped underneath, aborting the orderly stop and the final world save. It now loads only when that diagnostic is actually enabled.
 
 ### Configuration
 
-- **`enableRegionSummaries`** (server, default on) and **`enableRegionSummarySync`** (client, default on) — kill switches for the new summary exchange.
-- **`enableQuadtreeScan`** (client, default on) — the new fast ring-scan path; disable to restore the per-position walk.
+- **`enableRegionSummaries`** (server, default on) and **`enableRegionSummarySync`** (client, in `lss-client-config.json`, default on) — kill switches for the new summary exchange.
+- **`enableQuadtreeScan`** (client, in `lss-client-config.json`, default on) — the new fast ring-scan path; disable to restore the per-position walk.
 
 ### Compatibility
 
-- **The new behaviors need BOTH halves on v0.12.0** — the summary exchange and stamped verification only run when client and server both carry this version. Mixed versions are fully compatible: a v0.12.0 client on an older server (or the reverse) simply doesn't exchange the new messages and behaves like v0.11. Folia support remains **experimental**. This line is supported at the "correct, not perfect" tier.
+- **The summary exchange needs BOTH halves on v0.12.0** — Mixed versions are fully compatible and quiet: a v0.12.0 client on an older server gets no answer and falls back to per-column revalidation, and an older client on a v0.12.0 server still gets the server-side freshness checks above — it just never asks for a summary.
+- Folia support remains **experimental**.
+- This line is supported at the "correct, not perfect" tier.

--- a/docs/planning/v0.12.0-release-plan.md
+++ b/docs/planning/v0.12.0-release-plan.md
@@ -493,7 +493,7 @@ support/mc1.21.1 @ 1374e6a1 — CI green on final tips (see 11.11).
 ### 11.2 Gates (all green at folded tips)
 - 26.1: :fabric:build -x runClientGameTest (T1+T2) + :paper:test + :neoforge:build 3m05s;
   local T3 (:fabric:runClientGameTest) BUILD SUCCESSFUL (the line CI runs T3 on push).
-- 1.21.11: same set 2m58s; local T3 pending at draft time.
+- 1.21.11: same set 2m58s; local T3 green (and again on final-tip CI run 32478394943).
 - 1.21.1: :fabric:build (no T3 task on this line) + :paper:test + :neoforge:build green
   as a unit (T2 72/72 — the 71 + regionFreshnessServesRealRegionHeaders). One
   environmental T2 red catalogued (dedupe-convergence A=0 B=0 under 8-agent box load;
@@ -546,7 +546,10 @@ support/mc1.21.1 @ 1374e6a1 — CI green on final tips (see 11.11).
   stamps 1618 emitted AND applied — the doctrine shape REPRODUCED on a second
   line, independent confirmation it is geometry, not a port artifact),
   store-second-join PASS.
-- 1.21.1: pending (wrs fabric + wrs paper + :neoforge:runGameTestServer smoke).
+- 1.21.1 (closed in 11.8/11.10): wrs fabric PASS (isolated re-run; one catalogued near-floor red),
+  wrs paper PASS first-attempt (1313/15 — 26.x-typical), store-second-join PASS,
+  stamp-heal chain PASS on repeat (catalogued), dirty-while-offline-summary PASS,
+  :neoforge:runGameTestServer 8/8 after the 11.8 repair.
 
 ### 11.6 Environmental discipline invocations
 - 1.21.1 T2 dedupe-convergence red: box contention (8 concurrent review agents);
@@ -649,3 +652,73 @@ support/mc1.21.1 @ 1374e6a1 — CI green on final tips (see 11.11).
   instrument; 26.1 soak.sh world* glob alignment (pre-existing, outside the
   pick range); the RegionSummaryServiceTest 60 s deadline escalation rule
   (fires only on a second CI timeout).
+
+## 12. Phase D-prep as-built record (2026-08-21) — THE HARD STOP
+
+Steps D.2-D.4 are DONE; D.5-D.7 (tags, VSS publish, closure) are the USER'S GATE.
+
+### 12.1 Pre-flights (D.2)
+All four trees: `./gradlew clean` first (verified: zero pre-run files under any
+build/), the line-correct release build at `-Pmod_version=0.12.0` under CI=true,
+`release_check.py --version 0.12.0` OK (re-run independently by the closing
+panel; also MUTATION-TESTED — deleting a required jar family fails it, both
+SHIP_NEOFORGE arms). T2 73/73/73/72; T1 1836-1844/0 per tree.
+
+### 12.2 CI on the release commits (D.3)
+Line tips 24e7440b / 7f77a42f / 1374e6a1: full runs green INCLUDING the
+Client GameTests job where the line has one (verified real: client logs show
+the gametest consumers + the ingest-failure loop). Main: last Build run green
+at 7159eaf8 incl. T3; the tip above it (dbf9fd2a) is DOCS-ONLY (5 .md files —
+build.yml paths-ignore skips by design), so the release commit itself has NO
+run; the delta is provably non-product. STATE THIS at tag time rather than
+ticking D.3 silently.
+
+### 12.3 Notes (D.4)
+docs/planning/v0.12.0-release-notes/{main,mc26.1,mc1.21.11,mc1.21.1}.md —
+rewritten under the notes panel: the GB-class win re-attributed to the
+server-side freshness rungs (v0.11 clients benefit too; summaries are the
+both-halves feature), the never-shipped exotic-dimension "fix" deleted, the
+1.21.1 Folia claim deleted (line.env has no folia), Performance section,
+Fabric qualifier on the shutdown fix, client-config key labels, the
+store-armed one-session-later caveat on the stamped bullet, 1.21.1
+NeoForge-notes section (best-effort tier, no cuts, client half present).
+NOTE FOR D.5: the notes exist on MAIN only — tag from the line worktrees with
+`git show main:docs/planning/v0.12.0-release-notes/<line>.md > /tmp/notes.md`
+(or an absolute path into the main checkout) before `git tag -a -F`.
+
+### 12.4 Closing panel (3 Opus)
+Notes lens: 3 MAJOR + 9 minor, all folded (above). Completeness lens: no
+findings; steps verified with evidence. Last-line adversarial lens: verdict
+SAFE-TO-TAG once user gates clear; re-proved release_check (mutation),
+Paper-soak reality, T3 reality, the repaired NeoForge smoke alive on the final
+tip, wire-parity claim trail (five shared sources sha256-identical across all
+four trees; 13-channel censuses green everywhere), and no v0.12* tag exists
+anywhere.
+
+### 12.5 Carried to v0.13 (additive to 10.4/11.11)
+- Generalize the NeoForge-smoke `ran_some_tests` CI guard to main/26.1/1.21.11
+  build.yml (their smokes are verified ALIVE today — latent only) and tighten
+  its regex to `[1-9][0-9]*` (currently admits "0 required tests").
+- Reframe follow-up: 1.21.1 Fabric wrs runs LOW in both samples (11/649 red,
+  13/985 pass) vs every sibling sample (15/1313-1377 incl. the line's own
+  Paper) — "n=2, both below every sibling", not "variance"; catalog entry
+  updated accordingly.
+- README documents no client config keys at all (pre-existing gap; the notes
+  name two).
+
+### 12.6 User actions (the gate)
+1. B.5 acceptance: warm-rejoin observation on the rig + Prism client. NO
+   REDEPLOY NEEDED — the deployed Phase-B jar (sha256 00f750fa…, e8408674) is
+   product-identical to the release tip (zero src/main diff since; verified).
+2. MODRINTH_PAT renewal (blocks the VSS publish D.6 only, not the tags). The
+   CI MODRINTH_TOKEN secret is healthy (updated 2026-03-18; all four v0.11.1
+   publishes succeeded with it).
+3. Tag sequence per D.5 (annotated, --cleanup=verbatim, verify headers before
+   push; notes from MAIN per 12.3; v0.12.0 on main first, then the three line
+   tags, watching each; never re-run a partially-published release).
+4. VSS publish per vss-publish-discipline (6 files on 1.21.1 — the NeoForge
+   VSS pair ships there — 4 elsewhere).
+5. Post-release closure per D.7 (rig/Prism re-point needs the archon session
+   token — renewed 2026-08-19, ~14-day window — and possibly a manual panel
+   Start after an RCON stop), PLUS: delete feat/region-summary-sync (local +
+   origin, ac60ec84) only after ALL FOUR tags are pushed.


### PR DESCRIPTION
Docs only: the §12 D-prep as-built record (pre-flight and CI evidence, the three-reviewer closing panel's folds and SAFE-TO-TAG verdict, v0.13 carries, and the user-gate checklist) plus the four release-notes drafts rewritten under the notes panel's findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)