### PR TITLE
fix(client): window-limited Row-4 bypass — the slow-start ramp completes on serve-rate-clocked loops

### DIFF
--- a/docs/planning/ramp-window-limited-credit-plan.md
+++ b/docs/planning/ramp-window-limited-credit-plan.md
@@ -165,13 +165,23 @@ uncredited interval, so the 10-credit exit could never fire on the fix's own
 headline rig. The streak reset gains one interval of forgiveness:
 
 - New field `rampUncreditedRun`. In the `finally`: a credited interval zeroes
-  it; a qualifying uncredited interval increments it, and only the SECOND
-  consecutive one resets `rampOpenStreak` (non-qualifying intervals remain
-  no-observations, as today).
-- Round-3 safety is preserved: the trickle cannot credit at all (§2 — credits
-  require desired > 4 MB/s), so forgiveness never manufactures streaks from
-  nothing; an alternating credited/uncredited link is delivering >4 MB/s growth
-  evidence half the time, which is honest OPEN material.
+  it; a qualifying uncredited interval that was WINDOW-LIMITED is forgiven once
+  (the run marks 1); any other uncredited qualifying interval — un-latched, or
+  the second consecutive miss — resets `rampOpenStreak` exactly as main did
+  (non-qualifying intervals remain no-observations, as today).
+- SCOPED TO THE LATCH (implementation-panel fold, governor MAJOR): an unscoped
+  forgiveness loosened the OPEN confirmation for every ramp session —
+  alternating credited/uncredited demand patterns could confirm at ~3/8 average
+  answered where main required 10 consecutive; and it silently forgave Row-1/2/3
+  holds (vanilla-behind included). Scoping costs the headline fix nothing: in
+  the stop-and-wait steady state EVERY interval latches, so the aliased miss is
+  always a latched interval.
+- Round-3 safety is preserved by demand geometry, not by a delivery claim (the
+  same fold corrected §3.4's earlier justification — `credited` measures the
+  governor's post-doubling desired, not delivered bytes): credits require
+  desired > 4 MB/s, which requires the walk to keep FILLING a ≥~170-350-column
+  governed budget with ≥¾ answered — sustained backfill demand no trickle or
+  alternating pattern produces, and un-latched misses now reset regardless.
 - Expected exit at the measured rig shape: ~12 intervals ≈ 24 s (10 credits
   with ~1-in-6 forgiven misses). A REAL degradation (two consecutive uncredited
   intervals) still resets exactly as before.
@@ -213,10 +223,15 @@ headline rig. The streak reset gains one interval of forgiveness:
    the fix: today's failure (permanent ramp park) costs every good-server
    session ~25-35% forever; the new failure lands in OPEN = v0.11 behavior with
    all its containment.
-3. **Genuinely slow serves stay parked.** At cycle > ~2 s (serve ≲ 180 col/s),
-   declare-bearing intervals fail `answeredAllAsked` (the answers drain into the
-   next interval) and drain-only intervals never latch — the ramp keeps holding,
-   which is protective there. Recorded as designed behavior.
+3. **Genuinely slow serves park via the double-miss reset (mechanism corrected
+   by the implementation panel).** Answers stream continuously, so a 1-declare
+   interval's answered ratio is ~2000 ms/cycle and `answeredAllAsked` holds up
+   to cycle ≈ 2.67 s: the 2.0-2.67 s band (≈130-180 col/s) reaches OPEN through
+   forgiven zero-declare intervals — an accepted landing (§4.2; OPEN is
+   self-paced there too). Past ~2.67 s the ratio itself falls under ¾, the
+   declare-bearing AND drain-only intervals are both uncredited, the run
+   reaches 2, and the reset parks the ramp — which is the protective outcome
+   for genuinely slow serves.
 4. **Partial answers never credit and never snap.** Window-limited + answered <
    ¾ declared → all rungs fail → HOLD (the new pre-snap guard). A server hiccup
    costs an interval, not the earned desired (mirrors
@@ -250,8 +265,11 @@ headline rig. The streak reset gains one interval of forgiveness:
   bypass is a Row-4 bypass, not a blanket pre-snap return (a wrong
   implementation early-returning on the latch before the snap must red here).
 - `windowLimitedSingleAliasedMissIsForgiven` / `twoConsecutiveMissesReset`
-  (§3.4): credited×5, one uncredited, credited×5 → OPEN; credited×9,
-  uncredited×2 → streak restarts.
+  (§3.4): credited×5, one latched uncredited, credited×5 → OPEN; credited×9,
+  latched uncredited×2 → streak restarts.
+- `unlatchedUncreditedIntervalStillResetsTheStreak` (the scoping pin): an
+  UN-latched miss after nine credits resets immediately — the alternating
+  pattern can never confirm.
 - `trickleThroughTinyBudgetSelfArrestsAndNeverCredits` (MAJOR-1(b) bound):
   latched intervals with small answered demand double desired only while the
   implied budget < demand, park below ENGAGE_BELOW, phase stays RAMP,
@@ -319,3 +337,28 @@ Findings and dispositions (all folded into the sections above):
   pre-snap guard's bit-identicality when unlatched, the tick-order attribution,
   the latch-clearing coverage (including the DISABLED-scan corner), the
   credited-streak accounting, and the pinned-decision inventory.
+
+## 9. The 3-Opus implementation panel fold (2026-08-21) — normative
+
+- **Wiring MAJOR (composition mismatch):** with `enableAdaptiveScanCadence`
+  false the scan's governed half is the FULL sustained rate while the latch
+  re-read burst = ceil(sustained/4) — manually-capped walks in
+  [ceil(sustained/4), sustained/2) latched as governor-window-limited. Folded:
+  `governedBurstCap()` is the ONE composition both sites read; pinned by
+  `manualBelowTheGovernedHalfNeverLatches` (cadence-off, manual 1 < sustained 2).
+- **Governor MAJOR (forgiveness scope):** folded as §3.4 now records — the
+  forgiveness is latch-scoped; un-latched uncredited intervals reset exactly as
+  main; pinned by `unlatchedUncreditedIntervalStillResetsTheStreak`. §3.4's
+  alternating-link justification was replaced (credited measures post-doubling
+  desired, not delivery); §4.3's slow-serve mechanism corrected (parks via the
+  double-miss reset past ~2.67 s cycles; the 2.0-2.67 s band reaches OPEN,
+  accepted).
+- Minors folded: the tiny-cap taper floor corner documented at the scanner
+  recording site (bounded by self-arrest; `burstCap == 1` always reads
+  cap-clamped under pressure); `lastBudgetCapClamped` cleared in
+  `SpiralScanner.reset()` for lifecycle symmetry; the duplicate truncation
+  accessor collapsed to one (`wasLastWalkTruncated`, production + tests);
+  `climbToCeiling`'s EWMA javadoc corrected (32K); the interval-scoped test's
+  vacuous desired-at-ceiling assertion pinned on PHASE over nine unlatched
+  twins; the manager test suite gained the cadence-off manual-binding arm the
+  original suite could not red on.

--- a/docs/planning/ramp-window-limited-credit-plan.md
+++ b/docs/planning/ramp-window-limited-credit-plan.md
@@ -1,0 +1,321 @@
+# Ramp window-limited credit — the Row-4 refinement (v1.1, 2026-08-21 — §8 is the 1-Fable fold, normative)
+
+Fixes the never-ending slow-start RAMP on healthy connections whose server serves
+slower than the ramp ceiling. Live-diagnosed 2026-08-21 on the Paper test rig
+(v0.12.0 client, default server config): `governed=ramp@8192 KB/s` frozen for the
+whole session, budget pinned at 353, ~25-35% throughput left on the table.
+
+## 1. The defect, mechanically
+
+The client's request loop is a **stop-and-wait window**: the adaptive-cadence fast
+trigger refuses to fire until ≤5% of the last batch is unanswered
+(`SpiralScanner.fastRescanDue`, the outstanding gate), so the scan cadence is
+clocked by the server's delivery time, not by the designed 4 Hz spacing-gate
+equilibrium. The server's delivery time for one governed burst window
+(`burst = desired/(4·EWMA)` columns) is set by the per-player RAW bandwidth
+allocation (default 25 MB/s → 1.25 MB/tick; send pacing floors at exactly that
+share), which on the measured rig yields a ~630 ms cycle → **1.6 Hz**.
+
+RAMP's Row 4 (`TransferRateGovernor.stepRamp`, the under-offer hold) requires
+`offered × 2 ≥ desired` before any growth rung is evaluated. Offered rate =
+`burst × cadence × EWMA` = `desired/4 × cadence`, so Row 4 needs **cadence ≥ 2 Hz**
+— unreachable at 1.6 Hz. Worse, the `finally` resets `rampOpenStreak` on every
+qualifying-but-uncredited interval, so the 10-interval RAMP→OPEN confirmation
+never accumulates. The `answeredAllAsked` growth rung — which fires at the
+measured 92% answered/declared — sits behind Row 4 and is unreachable.
+
+The compression ratio compounds it: the 8 MB/s **wire** ceiling assumed 2-3×
+compression ("≈ 16-24 MB/s raw ≈ the default per-player cap"); the measured
+terrain compresses ~5.5×, so the ceiling's raw-equivalent (~44 MB/s) is ~2× the
+default server cap — in wire terms a default-capped server can serve at most
+~4.5 MB/s at perfect duty against a `desired/2` threshold of 4.19 MB/s. With any
+duty-cycle loss the ramp exit is **structurally unreachable**, not timing-unlucky.
+
+Cost of the stuck state: the RAMP burst cap clamps the want-set budget to
+`desired/(4·EWMA)` (≈353 measured) instead of `WANT_SET_BUDGET` (800), costing
+~25-35% steady-state throughput; `/lss diag` reads `governed=ramp@…` forever; and
+every future session repeats it (the dimension-change ssthresh hint re-enters RAMP).
+
+## 2. Why Row 4 exists (the constraint the fix must keep)
+
+Round-3 review MAJOR: with growth evaluated first, a **converged client's
+one-column dirty-edit trickle** (offered a fraction of desired, trivially
+answered) satisfied `answeredAllAsked`, and ~17 sparse intervals walked a
+never-proven link to capless OPEN — non-qualifying gaps preserve both streaks.
+Row 4 makes under-offer the gate growth must pass. Pinned by
+`answeredTrickleUnderTheOfferFloorNeverRamps`.
+
+The defect is that Row 4 **conflates two under-offer causes**:
+- *demand-limited*: the walk had nothing more to declare (the trickle, the
+  converged client) — growth would be vacuous; HOLD is correct;
+- *window-limited*: the walk FILLED the clamped budget and was truncated with
+  demand left over — the offer shortfall is the stop-and-wait actuator's
+  arithmetic, not absent demand; the link/server is carrying the entire window
+  continuously.
+
+The discriminator is built from the scanner's `lastWalkTruncated` ("did the
+last walk stop early because the budget filled?") — but truncation ALONE is not
+the discriminator (1-Fable fold MAJOR-1): exact-fill demand truncates (the
+budget check precedes classify, so `truncated ⇔ count == budget` in practice),
+tiny early-ramp budgets (burst floors at 1 near INITIAL) let a 2-3-column
+trickle truncate, and the #71 pressure taper or the manual knob can be the
+binding clamp. The latch therefore requires **provenance**: truncated AND the
+governed burst cap was the binding, taper-free clamp (§3.2). The residual
+trickle escape through a tiny governed budget is **self-arresting**: each
+credit-free doubling doubles the burst budget, so a fixed small demand stops
+truncating within 1-3 doublings and parks — and CREDITS require desired >
+4 MB/s, i.e. a sustained ≥~170-350-column-per-scan demand with ≥¾ answered for
+ten forgiveness-bounded intervals, which no trickle produces. The bound is
+pinned by test, not assumed (§5).
+
+## 3. Design
+
+### 3.1 The latch (governor)
+
+New interval-scoped latch on `TransferRateGovernor`, mirroring `noteMovement()`:
+
+- `private boolean windowLimitedSeenThisInterval;`
+- `void noteWindowLimited()` sets it (main client thread, like every other input).
+- Cleared in `seedInterval(…)`, `hardReset()`, and `adoptFrom(…)` (interval
+  accumulator state — the adopt contract already reseeds the interval).
+  `setSlowStartEnabled`'s RAMP→OPEN demote deliberately does not clear it (OPEN
+  never reads it; RAMP re-entry passes through `hardReset`).
+
+### 3.2 The wiring (manager + scanner)
+
+- `SpiralScanner` gains two package-private accessors: `wasLastWalkTruncated()`
+  (the existing field) and `wasLastBudgetCapClamped()` — a NEW per-walk flag
+  recorded in `maybeScan`: true iff the burst-cap clamp set the final budget
+  (`burstCap > 0 && burstCap < WANT_SET_BUDGET` and the pressure taper did not
+  reduce it further, i.e. the final budget still equals the cap-clamped value).
+  A taper-reduced budget (MAJOR-1(c): the CPU-weak client at 25-99% of halt)
+  reads false and can never latch.
+- `LodRequestManager.sendRequests` returns `boolean` (true iff the batch send
+  succeeded — the same condition that bumps `declaredColumnsCumulative`).
+- `tickScanPhase` latches after a successful non-empty send of a walk truncated
+  by the GOVERNED cap:
+
+```java
+int governedBurst = this.governor.burstColumnsPerSecond();
+int manual = LSSClientConfig.CONFIG.lodColumnsPerSecondLimit;
+if (scanned > 0 && sent
+        && this.scanner.wasLastWalkTruncated()
+        && this.scanner.wasLastBudgetCapClamped()
+        && governedBurst > 0 && (manual <= 0 || governedBurst <= manual)) {
+    this.governor.noteWindowLimited();
+}
+```
+
+The last conjunct keeps the latch's meaning honest when the manual knob is the
+binding half of the min-compose (MAJOR-1(c) second shape): a manually-capped
+loop never claims to be governor-window-limited (in effect the min-compose
+keeps the manual cap binding either way; this is about meaning, not safety).
+A failed send latches nothing (nothing was offered); an untruncated or
+taper-clamped walk latches nothing. Tick order keeps
+attribution honest: `governor.tick()` (interval evaluation + reseed) runs BEFORE
+`tickScanPhase` in the manager, so a scan's latch lands in the interval its
+declaration counts toward.
+
+### 3.3 The Row-4 bypass (governor)
+
+In `stepRamp`, two edits, both inert while the latch is false:
+
+```java
+// Row 4 — under-offered HOLDs, UNLESS the interval was window-limited: the walk
+// filled the clamped budget and was truncated (demand exceeded the window), so
+// the offer shortfall is the stop-and-wait actuator's arithmetic — the window
+// drains at the serve rate and cadence is completion-clocked below the 2 Hz the
+// threshold implies. The trickle (round-3 MAJOR) cannot CREDIT through this
+// branch: the latch requires the governed cap as the binding clamp (provenance,
+// wiring side), a tiny-budget trickle self-arrests within a few doublings, and
+// credits require desired > ENGAGE_BELOW — see the plan's §2/§4.1.
+if (offered * 2L < this.desiredBytesPerSec
+        && !this.windowLimitedSeenThisInterval) {
+    return;
+}
+```
+
+and, gating the plateau snap (which today is only reachable offer-backed):
+
+```java
+// A window-limited under-offered interval whose growth rungs did not fire is
+// NOT offer-backed evidence — the ENGAGED path's freeze rule (MAJOR-1): HOLD,
+// never snap. Unreachable while the latch is false (the un-latched under-offer
+// case returned at Row 4), so the un-latched ladder is bit-identical.
+if (offered * 2L < this.desiredBytesPerSec) {
+    return;
+}
+```
+
+The growth rungs between the two are evaluated verbatim. In the bypass branch,
+`deliveredAllOffered` is structurally false (it requires `offered ≥ desired/2`)
+and `keptUp` is ~unreachable in steady state (measured ≤ offered + one in-flight
+window), so **the operative rung is `answeredAllAsked`** — the byte-free
+"position window saturated with timely service" rung, which is exactly the
+evidence a window-limited loop produces. Crediting, the ceiling clamp, and
+`openFromRamp()` are untouched.
+
+### 3.4 Streak forgiveness (1-Fable fold MAJOR-2)
+
+The 2 s interval aliases against the ~630 ms stop-and-wait cycle: a window
+containing 4 declarations carries the 4th batch's answers into the NEXT window,
+so `answeredAllAsked` fails roughly 1 interval in 6 under metronomic timing —
+and the current `finally` resets `rampOpenStreak` on EVERY qualifying
+uncredited interval, so the 10-credit exit could never fire on the fix's own
+headline rig. The streak reset gains one interval of forgiveness:
+
+- New field `rampUncreditedRun`. In the `finally`: a credited interval zeroes
+  it; a qualifying uncredited interval increments it, and only the SECOND
+  consecutive one resets `rampOpenStreak` (non-qualifying intervals remain
+  no-observations, as today).
+- Round-3 safety is preserved: the trickle cannot credit at all (§2 — credits
+  require desired > 4 MB/s), so forgiveness never manufactures streaks from
+  nothing; an alternating credited/uncredited link is delivering >4 MB/s growth
+  evidence half the time, which is honest OPEN material.
+- Expected exit at the measured rig shape: ~12 intervals ≈ 24 s (10 credits
+  with ~1-in-6 forgiven misses). A REAL degradation (two consecutive uncredited
+  intervals) still resets exactly as before.
+- Known adjacent dynamic, unchanged by this plan: at the alias boundary the
+  offered×2-vs-desired compare sits within ~1% of the threshold, so EWMA noise
+  can occasionally route a 4-declare window into the offer-backed plateau snap
+  (growth fails by a hair) — desired snaps toward measured and the ramp
+  re-climbs in seconds. Pre-existing containment behavior; the forgiveness
+  absorbs the streak cost of such an interval.
+
+### 3.4 What does NOT change
+
+- No new config. The kill switch remains `enableJoinSlowStart` (no RAMP at all).
+- ENGAGED/OPEN ladders untouched. Row 1 (engage), Row 2 (vanilla-behind),
+  Row 3 (movement hold) untouched and still precede the bypass.
+- Latch-false behavior is bit-identical by construction (both edits are
+  unreachable or no-ops when the latch is false).
+- The server side is untouched — pacing and the bandwidth limiter are behaving
+  as designed; they merely set the loop period the client must reason about.
+
+## 4. Safety argument (adversarial)
+
+1. **The round-3 trickle stays excluded, by geometry rather than by "never
+   truncates" (1-Fable fold).** A trickle CAN truncate a tiny early-ramp budget
+   and latch — but the escape is self-arresting (each doubling doubles the
+   budget past the fixed demand within 1-3 intervals) and can never CREDIT
+   (credits require desired > 4 MB/s = a sustained ≥~170-350-column answered
+   window, which is a backfill by definition). Taper-clamped and
+   manual-capped truncations never latch at all (provenance, §3.2). The pin
+   test stays green unmodified, and the bound gets its own wiring-level tests.
+2. **A slow-but-clean link (no bufferbloat) can now reach OPEN via the bypass.**
+   This is contained and is the pre-slow-start posture for every session:
+   (a) the actuator is completion-clocked in OPEN too — the 95% outstanding gate
+   means OPEN cannot outrun the serve rate; batches grow to 800 but remain
+   self-paced; (b) a bufferbloat link accumulates ping excess → RAMP Row 1 or
+   OPEN's engage conjunct → ENGAGED (byte-for-byte the pre-phase machinery;
+   the vanilla-behind cut is deliberately NOT claimed here — it is evaluated
+   only in RAMP/ENGAGED, per the constant's own comment). The asymmetry favors
+   the fix: today's failure (permanent ramp park) costs every good-server
+   session ~25-35% forever; the new failure lands in OPEN = v0.11 behavior with
+   all its containment.
+3. **Genuinely slow serves stay parked.** At cycle > ~2 s (serve ≲ 180 col/s),
+   declare-bearing intervals fail `answeredAllAsked` (the answers drain into the
+   next interval) and drain-only intervals never latch — the ramp keeps holding,
+   which is protective there. Recorded as designed behavior.
+4. **Partial answers never credit and never snap.** Window-limited + answered <
+   ¾ declared → all rungs fail → HOLD (the new pre-snap guard). A server hiccup
+   costs an interval, not the earned desired (mirrors
+   `partiallyAnsweredByteFreeIntervalHoldsInsteadOfSnapping`).
+5. **The exit is achievable under aliasing (re-derived, 1-Fable fold
+   MAJOR-2).** Without forgiveness the 1-in-6 aliased `answeredAllAsked` miss
+   recurs faster than the 10-streak and the exit never fires; with one-miss
+   forgiveness (§3.4) the expected exit is ~12 intervals ≈ 24 s at the measured
+   rig shape, and only two consecutive uncredited intervals (real degradation)
+   reset.
+
+## 5. Test plan (all Tier 1)
+
+`TransferRateGovernorTest` additions:
+- `windowLimitedStopAndWaitCompletesTheRamp` — the headline repro: desired at
+  the ceiling, offered < desired/2 every interval, answered ≥ ¾ declared, latch
+  set each interval → 10 intervals → `Phase.OPEN`, capless, and the un-fixed
+  shape (same ticks, no latch) stays RAMP (asserted in the same test as the
+  control arm).
+- `windowLimitedBypassStillRequiresAnswers` — latch set, answered < ¾ declared,
+  zero bytes → HOLD, desired unchanged, streak observably reset (a subsequent
+  credited run needs a fresh 10).
+- `windowLimitedUnderOfferNeverSnaps` — latch set, bytes moved (measured > 0),
+  growth fails → desired unchanged (the pre-snap guard; the ENGAGED-freeze
+  mirror).
+- `windowLimitedLatchIsIntervalScoped` — a latch in interval N does not leak
+  into N+1; `hardReset`/`adoptFrom` clear it.
+- `windowLimitedOfferBackedPlateauStillSnaps` (1-Fable fold minor-2): a
+  LATCHED interval that is offer-backed (offered×2 ≥ desired) with growth
+  failed and measured > 0 must still take the plateau snap — pins that the
+  bypass is a Row-4 bypass, not a blanket pre-snap return (a wrong
+  implementation early-returning on the latch before the snap must red here).
+- `windowLimitedSingleAliasedMissIsForgiven` / `twoConsecutiveMissesReset`
+  (§3.4): credited×5, one uncredited, credited×5 → OPEN; credited×9,
+  uncredited×2 → streak restarts.
+- `trickleThroughTinyBudgetSelfArrestsAndNeverCredits` (MAJOR-1(b) bound):
+  latched intervals with small answered demand double desired only while the
+  implied budget < demand, park below ENGAGE_BELOW, phase stays RAMP,
+  `rampOpenStreak` stays 0.
+- Existing pins run unmodified: `answeredTrickleUnderTheOfferFloorNeverRamps`,
+  `partiallyAnsweredByteFreeIntervalHoldsInsteadOfSnapping`,
+  `underOfferedIntervalHoldsAndPlateauSnapsWithoutRaising`,
+  `keptUpIntervalsDoubleToTheCeilingAndTenCreditedIntervalsOpen`.
+
+Manager/scanner wiring:
+- `LodRequestManager` test (the governor-wiring suite): a successful send of a
+  governed-cap-truncated walk latches the governor; a failed send does not; an
+  untruncated walk does not; a MANUAL-capped walk (manual < governed) does not.
+  (Seam: the existing injectable `batchSender`.)
+- `SpiralScanner`: `wasLastWalkTruncated()` reflects a budget-truncated walk and
+  clears on an untruncated one; `wasLastBudgetCapClamped()` is true when the
+  burst cap set the final budget, false when the pressure taper reduced it
+  below the cap (the MAJOR-1(c) shape) and false when the constant
+  `WANT_SET_BUDGET` was the binder.
+
+## 6. Live validation
+
+1. (Model check, pre-fix, optional) `/lsslod set mbPerSecondLimitPerPlayer 50`
+   on the test rig → cadence ≈ 2.4 Hz → the UNMODIFIED ramp should complete in
+   ~20 s. Confirms the model independently of the fix.
+2. (Fix check) Default config, fixed client: join → within ~30 s the
+   once-per-session log "LOD slow start complete", `governed=` absent from
+   `/lss diag`, `Budget: used=800/800` (or pressure-scaled), recv rate up
+   ~25% vs the stuck baseline.
+
+## 7. Rollout
+
+Branch `feat/ramp-window-limited-credit`; PR against main but **NOT merged** —
+main is the frozen, pre-flighted v0.12.0 release tip. Landing options (user's
+call at review time): fold into v0.12.0 pre-tag (requires re-running the D-prep
+pre-flights + CI on the new tip), or first post-release patch (v0.12.1) /
+v0.13. Client-only change; wire untouched; no backport pressure (the support
+lines inherit whenever the stack is next picked).
+
+## 8. The 1-Fable plan review fold (2026-08-21) — normative
+
+Findings and dispositions (all folded into the sections above):
+
+- **MAJOR-1 (latch provenance):** `lastWalkTruncated` alone conflates exact-fill,
+  tiny-early-ramp-budget trickles, and taper/manual-capped walks with the
+  governed window-limit. Folded: the `wasLastBudgetCapClamped` provenance flag +
+  the manual-vs-governed conjunct in the manager (§3.2), the self-arrest
+  geometry replacing the false "never truncates" claim (§2, §4.1), and the
+  bound pinned by `trickleThroughTinyBudgetSelfArrestsAndNeverCredits` plus the
+  scanner/manager wiring tests. Exact-fill remains a bounded, self-arresting
+  spurious latch (accepted; at most a handful of credit-free doublings).
+- **MAJOR-2 (streak aliasing):** the 2 s interval vs ~630 ms cycle aliasing
+  fails `answeredAllAsked` ~1-in-6 intervals, and a single-miss reset makes the
+  10-streak unreachable on the headline rig. Folded: one-miss forgiveness
+  (`rampUncreditedRun`, §3.4) with the alternating-credit safety argument and
+  the two streak tests. The reviewer's alternative (crediting against
+  `deltaDeclared − Δawaiting`) was considered and set aside: it changes the
+  rung's meaning for pile-up shapes the hiccup pin protects, while forgiveness
+  is strictly a reset-policy change.
+- **minor-1:** the §4 vanilla-behind-in-OPEN containment claim was false
+  (evaluated only in RAMP/ENGAGED) — removed.
+- **minor-2:** the test plan admitted a blanket pre-snap `if (latch) return`
+  implementation — `windowLimitedOfferBackedPlateauStillSnaps` added.
+- Verified by the reviewer (no change needed): the mechanism arithmetic, the
+  pre-snap guard's bit-identicality when unlatched, the tick-order attribution,
+  the latch-clearing coverage (including the DISABLED-scan corner), the
+  credited-streak accounting, and the pinned-decision inventory.

--- a/docs/planning/ramp-window-limited-credit-plan.md
+++ b/docs/planning/ramp-window-limited-credit-plan.md
@@ -96,15 +96,33 @@ New interval-scoped latch on `TransferRateGovernor`, mirroring `noteMovement()`:
   by the GOVERNED cap:
 
 ```java
-int governedBurst = this.governor.burstColumnsPerSecond();
+int governedBurst = governedBurstCap(); // the ONE composition both sites read
 int manual = LSSClientConfig.CONFIG.lodColumnsPerSecondLimit;
 if (scanned > 0 && sent
+        && this.scanner.wasLastScanFast()          // completion-clocked only
         && this.scanner.wasLastWalkTruncated()
         && this.scanner.wasLastBudgetCapClamped()
         && governedBurst > 0 && (manual <= 0 || governedBurst <= manual)) {
     this.governor.noteWindowLimited();
 }
 ```
+
+Two as-built amendments (§9, the implementation panel):
+- **The fast conjunct** (dynamics MAJOR-2): only a COMPLETION-CLOCKED (fast-
+  fired) walk may latch. The 1 Hz fallback fires unconditionally and re-declares
+  a full budget however slow the drain, so a backlogged slow-but-clean link
+  would otherwise satisfy `answeredAllAsked` up to ~5.3× its rate; fallback
+  fires never latch, so such links park near main's Row-4 point (the residual
+  widening is bounded: while cycles stay under ~1 s the loop is fast-clocked
+  and can credit to ~4× link — an accepted, ENGAGE-guarded landing; past ~1 s
+  the fallback outruns the fast path and Row 4 holds). The rig is 381/383 fast.
+- **The provenance tolerance** (dynamics MAJOR-1): the cap-clamped flag is
+  `budget × 4 ≥ burstCap × 3`, not exact equality — equality disarmed the latch
+  at ~9 queued columns near the ~350-column park point (round(347×0.9985)=346).
+  Deep taper (scale < ~0.75) still attributes to the taper and refuses.
+- The RAMP diag label gains a receipt: `ramp@8192 KB/s (1419/s, credits=N/10,
+  wl)` — confirmation progress + whether the current interval latched, so a
+  "still parked" field report is self-diagnosing.
 
 The last conjunct keeps the latch's meaning honest when the manual knob is the
 binding half of the min-compose (MAJOR-1(c) second shape): a manually-capped
@@ -223,15 +241,16 @@ headline rig. The streak reset gains one interval of forgiveness:
    the fix: today's failure (permanent ramp park) costs every good-server
    session ~25-35% forever; the new failure lands in OPEN = v0.11 behavior with
    all its containment.
-3. **Genuinely slow serves park via the double-miss reset (mechanism corrected
-   by the implementation panel).** Answers stream continuously, so a 1-declare
-   interval's answered ratio is ~2000 ms/cycle and `answeredAllAsked` holds up
-   to cycle ≈ 2.67 s: the 2.0-2.67 s band (≈130-180 col/s) reaches OPEN through
-   forgiven zero-declare intervals — an accepted landing (§4.2; OPEN is
-   self-paced there too). Past ~2.67 s the ratio itself falls under ¾, the
-   declare-bearing AND drain-only intervals are both uncredited, the run
-   reaches 2, and the reset parks the ramp — which is the protective outcome
-   for genuinely slow serves.
+3. **Genuinely slow serves and slow links park via the FAST conjunct (mechanism
+   corrected twice — final form is the dynamics fold).** The latch requires a
+   completion-clocked (fast) fire, and the fast path only fires while the last
+   batch reaches 95% answered before the 1 Hz fallback — i.e. while the cycle
+   stays under ~1 s. A serve/link rate slow enough to push the cycle past ~1 s
+   runs fallback-clocked, never latches, and Row 4 holds exactly as main
+   (park ≈ desired where burst ≈ serve-rate ≈ ~4× link at the boundary, vs
+   main's ~2× — the bounded widening §9 records as accepted; bufferbloat links
+   additionally engage via Row 1's ping conjunct, and the un-latched double-miss
+   reset still guards the confirmation).
 4. **Partial answers never credit and never snap.** Window-limited + answered <
    ¾ declared → all rungs fail → HOLD (the new pre-snap guard). A server hiccup
    costs an interval, not the earned desired (mirrors
@@ -295,10 +314,12 @@ Manager/scanner wiring:
 1. (Model check, pre-fix, optional) `/lsslod set mbPerSecondLimitPerPlayer 50`
    on the test rig → cadence ≈ 2.4 Hz → the UNMODIFIED ramp should complete in
    ~20 s. Confirms the model independently of the fix.
-2. (Fix check) Default config, fixed client: join → within ~30 s the
-   once-per-session log "LOD slow start complete", `governed=` absent from
-   `/lss diag`, `Budget: used=800/800` (or pressure-scaled), recv rate up
-   ~25% vs the stuck baseline.
+2. (Fix check) Default config, fixed client: join → within ~40 s (7 doublings
+   ≈ 14 s + 9 further credits ≈ 18 s + join lead-in and any forgiven alias
+   miss) the once-per-session log "LOD slow start complete", `governed=` absent
+   from `/lss diag` (while confirming it reads `ramp@… credits=N/10, wl`),
+   `Budget: used=800/800` (or pressure-scaled), recv rate up ~25% vs the stuck
+   baseline.
 
 ## 7. Rollout
 
@@ -362,3 +383,30 @@ Findings and dispositions (all folded into the sections above):
   vacuous desired-at-ceiling assertion pinned on PHASE over nine unlatched
   twins; the manager test suite gained the cadence-off manual-binding arm the
   original suite could not red on.
+
+### 9.1 The dynamics lens fold (same panel, second round)
+
+- **MAJOR-1 (provenance brittleness):** exact `budget == burstCap` disarmed the
+  latch at ~9 queued columns at the rig's park point — the fix would have been
+  green in every suite and dead on its own rig. Folded: the 25%-tolerance
+  predicate (`budget×4 ≥ cap×3`), the `marginalPressureKeepsTheCapClampFlag`
+  scanner test at rig scale (cap 350, q=9), the deep-taper refusal preserved
+  (the 500-of-1000 test unchanged).
+- **MAJOR-2 (fallback-clocked credits):** the 1 Hz fallback re-declares full
+  budgets regardless of drain, so slow-but-clean links credited to ~5.3× link
+  rate through the bypass. Folded: the `wasLastScanFast()` conjunct — the latch
+  now MEANS completion-clocked window-limited; fallback fires never latch;
+  `truncatedGovernedWalkLatchesOnFastFiresOnly` pins both directions (the
+  primed fallback scan must NOT latch; the fast follow-up must). Residual
+  widening ~2× at the fast/fallback boundary recorded as accepted (§4.3).
+- minor-1 (bit-identical claim vs the finally): resolved by the forgiveness
+  scoping in §9 — with the scope, latch-false behavior is equivalent to main's
+  (an un-latched uncredited interval resets, as before).
+- minor-2: the RAMP diag receipt (credits=N/10, wl) added.
+- minor-3: §6 timing corrected to ~40 s.
+- Residual test-system note: the fully-composed marginal shape (burst ≈ 350
+  AND queue = 9 through the real manager tick) is covered piecewise (scanner at
+  rig scale; manager at burst 1 with the fast/fallback split); a composed
+  manager test would need EWMA feeding through real ticks and is left to the
+  live check (§6.2's `wl` receipt makes the composed answer observable in one
+  diag read).

--- a/fabric/src/test/java/dev/vox/lss/networking/client/LodRequestManagerTickTest.java
+++ b/fabric/src/test/java/dev/vox/lss/networking/client/LodRequestManagerTickTest.java
@@ -926,19 +926,34 @@ class LodRequestManagerTickTest {
     // ---- Window-limited latch wiring (ramp-window-limited-credit-plan.md §3.2) ----
 
     @Test
-    void truncatedGovernedWalkLatchesTheWindowLimit() {
+    void truncatedGovernedWalkLatchesOnFastFiresOnly() {
         // A RAMP-fresh governor's burst budget is 1 (64 KB/s over the 32 KB seed,
-        // quartered) — the lod-8 disc truncates against it, the send succeeds, the
-        // governed rate is the binding half (manual knob off) → the latch sets.
+        // quartered) — the lod-8 disc truncates against it and the send succeeds.
+        // The PRIMED first scan is a FALLBACK fire and must NOT latch (dynamics
+        // review MAJOR-2: fallback-clocked full-budget re-declares on a backlogged
+        // slow link would satisfy answeredAllAsked to ~5.3x the link rate — only
+        // COMPLETION-CLOCKED fast fires may claim window-limited). Answering the
+        // batch arms the fast path; the fast fire latches.
         setupManager(config(8, true));
         manager.joinSlowStartEnabled = () -> true;
         manager.transferGovernorEnabled = () -> true;
         enableAdaptiveSeam();
-        plainTick(dim("overworld"));
+        var overworld = dim("overworld");
+        plainTick(overworld);
         assertEquals(1, sent.size(), "the primed first scan shipped");
         assertEquals(1, sent.get(0).count(), "the governed burst budget clamped the walk to 1");
-        assertTrue(manager.governor.windowLimitedLatchedForTest(),
-                "a successfully-sent governed-cap-truncated walk latches the window limit");
+        assertFalse(manager.governor.windowLimitedLatched(),
+                "the primed scan is a FALLBACK fire — fallback fires never latch");
+        answer(sent.get(0), overworld, 1); // outstanding 0 → fast eligible
+        // The spacing gate (sustained 2/s, lastSent 1) spaces the fast fire to
+        // tick 10 — before the 20-tick fallback, so the fire is the FAST path.
+        int ticks = ticksToNextBatch(overworld, 1);
+        assertTrue(ticks < LSSConstants.TICKS_PER_SECOND,
+                "premise: fired before the fallback window (tick " + ticks + ")");
+        assertTrue(manager.scannerForTest().wasLastScanFast(),
+                "premise: the follow-up fire is the FAST path");
+        assertTrue(manager.governor.windowLimitedLatched(),
+                "a successfully-sent, fast-fired, governed-cap-truncated walk latches");
     }
 
     @Test
@@ -951,7 +966,7 @@ class LodRequestManagerTickTest {
             throw new RuntimeException("transport down");
         });
         plainTick(dim("overworld"));
-        assertFalse(manager.governor.windowLimitedLatchedForTest(),
+        assertFalse(manager.governor.windowLimitedLatched(),
                 "nothing was offered — a failed send must not latch");
     }
 
@@ -974,7 +989,7 @@ class LodRequestManagerTickTest {
             plainTick(dim("overworld"));
             assertEquals(1, sent.size());
             assertEquals(1, sent.get(0).count(), "the manual knob (1) clamped the walk");
-            assertFalse(manager.governor.windowLimitedLatchedForTest(),
+            assertFalse(manager.governor.windowLimitedLatched(),
                     "manual (1) < the governed half (2): the manual knob was the binder");
         } finally {
             LSSClientConfig.CONFIG.lodColumnsPerSecondLimit = prior;
@@ -996,7 +1011,7 @@ class LodRequestManagerTickTest {
             plainTick(dim("overworld"));
             assertEquals(1, sent.size());
             assertTrue(sent.get(0).count() <= 10, "the manual cap clamped the walk");
-            assertFalse(manager.governor.windowLimitedLatchedForTest(),
+            assertFalse(manager.governor.windowLimitedLatched(),
                     "the manual knob was the binder — no governed window-limit claim");
         } finally {
             LSSClientConfig.CONFIG.lodColumnsPerSecondLimit = prior;

--- a/fabric/src/test/java/dev/vox/lss/networking/client/LodRequestManagerTickTest.java
+++ b/fabric/src/test/java/dev/vox/lss/networking/client/LodRequestManagerTickTest.java
@@ -922,4 +922,58 @@ class LodRequestManagerTickTest {
         assertEquals(5, manager.getConfirmedRing(),
                 "a d=3 crossing decrements by 3 — the REAL delta reaches the scanner");
     }
+
+    // ---- Window-limited latch wiring (ramp-window-limited-credit-plan.md §3.2) ----
+
+    @Test
+    void truncatedGovernedWalkLatchesTheWindowLimit() {
+        // A RAMP-fresh governor's burst budget is 1 (64 KB/s over the 32 KB seed,
+        // quartered) — the lod-8 disc truncates against it, the send succeeds, the
+        // governed rate is the binding half (manual knob off) → the latch sets.
+        setupManager(config(8, true));
+        manager.joinSlowStartEnabled = () -> true;
+        manager.transferGovernorEnabled = () -> true;
+        enableAdaptiveSeam();
+        plainTick(dim("overworld"));
+        assertEquals(1, sent.size(), "the primed first scan shipped");
+        assertEquals(1, sent.get(0).count(), "the governed burst budget clamped the walk to 1");
+        assertTrue(manager.governor.windowLimitedLatchedForTest(),
+                "a successfully-sent governed-cap-truncated walk latches the window limit");
+    }
+
+    @Test
+    void failedSendNeverLatchesTheWindowLimit() {
+        setupManager(config(8, true));
+        manager.joinSlowStartEnabled = () -> true;
+        manager.transferGovernorEnabled = () -> true;
+        enableAdaptiveSeam();
+        manager.setBatchSenderForTest(payload -> {
+            throw new RuntimeException("transport down");
+        });
+        plainTick(dim("overworld"));
+        assertFalse(manager.governor.windowLimitedLatchedForTest(),
+                "nothing was offered — a failed send must not latch");
+    }
+
+    @Test
+    void manualCapBindingNeverLatchesTheWindowLimit() {
+        // The min-compose's manual half as the binder (governed burst 0 — slow start
+        // off): the walk truncates against the MANUAL knob, and the latch's
+        // governed-binding conjunct must refuse (a manually-capped loop never claims
+        // to be governor-window-limited).
+        int prior = LSSClientConfig.CONFIG.lodColumnsPerSecondLimit;
+        LSSClientConfig.CONFIG.lodColumnsPerSecondLimit = 10;
+        try {
+            setupManager(config(8, true)); // joinSlowStartEnabled=false in setupManager
+            manager.transferGovernorEnabled = () -> true;
+            enableAdaptiveSeam();
+            plainTick(dim("overworld"));
+            assertEquals(1, sent.size());
+            assertTrue(sent.get(0).count() <= 10, "the manual cap clamped the walk");
+            assertFalse(manager.governor.windowLimitedLatchedForTest(),
+                    "the manual knob was the binder — no governed window-limit claim");
+        } finally {
+            LSSClientConfig.CONFIG.lodColumnsPerSecondLimit = prior;
+        }
+    }
 }

--- a/fabric/src/test/java/dev/vox/lss/networking/client/LodRequestManagerTickTest.java
+++ b/fabric/src/test/java/dev/vox/lss/networking/client/LodRequestManagerTickTest.java
@@ -956,6 +956,32 @@ class LodRequestManagerTickTest {
     }
 
     @Test
+    void manualBelowTheGovernedHalfNeverLatches() {
+        // The implementation panel's MAJOR-1 pin: with the adaptive cadence OFF the
+        // scan's governed half is the FULL sustained rate (2 at a fresh RAMP), so a
+        // manual knob of 1 is the binding clamp — and the latch must compare against
+        // the SAME composed governed half. The pre-fix code re-read burst =
+        // ceil(sustained/4) = 1 <= manual and latched a manually-capped walk.
+        int prior = LSSClientConfig.CONFIG.lodColumnsPerSecondLimit;
+        LSSClientConfig.CONFIG.lodColumnsPerSecondLimit = 1;
+        try {
+            setupManager(config(8, true));
+            manager.joinSlowStartEnabled = () -> true; // live RAMP: governed half = 2
+            manager.transferGovernorEnabled = () -> true;
+            // Adaptive cadence forced OFF (the CONFIG default is on): the governed
+            // half of the min-compose is sustainedColumnsPerSecond() = 2.
+            manager.scannerForTest().adaptiveCadenceEnabled = () -> false;
+            plainTick(dim("overworld"));
+            assertEquals(1, sent.size());
+            assertEquals(1, sent.get(0).count(), "the manual knob (1) clamped the walk");
+            assertFalse(manager.governor.windowLimitedLatchedForTest(),
+                    "manual (1) < the governed half (2): the manual knob was the binder");
+        } finally {
+            LSSClientConfig.CONFIG.lodColumnsPerSecondLimit = prior;
+        }
+    }
+
+    @Test
     void manualCapBindingNeverLatchesTheWindowLimit() {
         // The min-compose's manual half as the binder (governed burst 0 — slow start
         // off): the walk truncates against the MANUAL knob, and the latch's

--- a/fabric/src/test/java/dev/vox/lss/networking/client/QuadtreeWalkDifferentialTest.java
+++ b/fabric/src/test/java/dev/vox/lss/networking/client/QuadtreeWalkDifferentialTest.java
@@ -76,8 +76,8 @@ class QuadtreeWalkDifferentialTest {
                     this.quadArm.recenteredSinceLastFireForTest(), "movement window " + at);
             assertEquals(this.legacyArm.truncatedBelowPrefixForTest(),
                     this.quadArm.truncatedBelowPrefixForTest(), "truncatedBelowPrefix " + at);
-            assertEquals(this.legacyArm.lastWalkTruncatedForTest(),
-                    this.quadArm.lastWalkTruncatedForTest(), "lastWalkTruncated " + at);
+            assertEquals(this.legacyArm.wasLastWalkTruncated(),
+                    this.quadArm.wasLastWalkTruncated(), "lastWalkTruncated " + at);
             assertEquals(this.legacyArm.getValveTrips(), this.quadArm.getValveTrips(),
                     "valveTrips " + at);
         }

--- a/fabric/src/test/java/dev/vox/lss/networking/client/SpiralScannerTest.java
+++ b/fabric/src/test/java/dev/vox/lss/networking/client/SpiralScannerTest.java
@@ -2523,6 +2523,21 @@ class SpiralScannerTest {
     }
 
     @Test
+    void marginalPressureKeepsTheCapClampFlag() {
+        // Dynamics review MAJOR-1: exact equality disarmed the latch at ~9 queued
+        // columns near the rig's ~350 cap — the fix would have been dead at exactly
+        // its park point. The 25%-tolerance predicate must survive marginal pressure.
+        var s = scanner(64);
+        s.columnBurstCap = () -> 350;
+        var sink = new Sink();
+        int n = fireScan(s, 0, 9, 6000, 0, new ColumnStateMap(), sink);
+        assertEquals(349, n, "round(350 x 0.9985) — the taper shaved one column");
+        assertTrue(s.wasLastWalkTruncated());
+        assertTrue(s.wasLastBudgetCapClamped(),
+                "a one-column taper shave near the cap is still the cap's clamp");
+    }
+
+    @Test
     void constantBudgetBinderClearsTheCapClampFlag() {
         // A burst cap at/above WANT_SET_BUDGET never actually clamps — truncation
         // against the constant budget is the pre-governor shape and must not latch.

--- a/fabric/src/test/java/dev/vox/lss/networking/client/SpiralScannerTest.java
+++ b/fabric/src/test/java/dev/vox/lss/networking/client/SpiralScannerTest.java
@@ -2491,4 +2491,60 @@ class SpiralScannerTest {
                 "the collect applies the SAME parking ladder as hasActionableRetries — a"
                         + " vanilla-rendered (unconsumable) mark must not reopen its ring");
     }
+
+    // ---- Window-limited latch provenance (ramp-window-limited-credit-plan.md §3.2) ----
+
+    @Test
+    void burstCapClampFlagTrueWhenTheGovernedCapBindsAndTheWalkTruncates() {
+        var s = scanner(8); // lod-8 disc: hundreds of wanted positions
+        s.columnBurstCap = () -> 10;
+        var sink = new Sink();
+        int n = fireScan(s, 0, new ColumnStateMap(), sink);
+        assertEquals(10, n, "the burst cap is the binding budget");
+        assertTrue(s.wasLastWalkTruncated(), "demand beyond the window truncates");
+        assertTrue(s.wasLastBudgetCapClamped(),
+                "the cap set the final budget — the provenance half reads true");
+    }
+
+    @Test
+    void taperReducedBudgetClearsTheCapClampFlag() {
+        // 1-Fable fold MAJOR-1(c): the CPU-weak client between 25% and halt gets a
+        // taper-reduced budget — truncation there must NOT read as governed-window-
+        // limited (the latch would walk an unproven pipe to OPEN on 1-column windows).
+        var s = scanner(8);
+        s.columnBurstCap = () -> 100;
+        var sink = new Sink();
+        // Queue at half of halt → scale 0.5 → budget 50 < the 100 cap.
+        int n = fireScan(s, 0, 500, 1000, 0, new ColumnStateMap(), sink);
+        assertEquals(50, n, "the taper reduced the budget below the cap");
+        assertTrue(s.wasLastWalkTruncated(), "still truncated (demand > 50)");
+        assertFalse(s.wasLastBudgetCapClamped(),
+                "a taper-reduced budget is not the governed cap's doing");
+    }
+
+    @Test
+    void constantBudgetBinderClearsTheCapClampFlag() {
+        // A burst cap at/above WANT_SET_BUDGET never actually clamps — truncation
+        // against the constant budget is the pre-governor shape and must not latch.
+        var s = scanner(64); // > 800 wanted positions so the constant budget truncates
+        s.columnBurstCap = () -> LSSConstants.WANT_SET_BUDGET + 100;
+        var sink = new Sink();
+        int n = fireScan(s, 0, new ColumnStateMap(), sink);
+        assertEquals(LSSConstants.WANT_SET_BUDGET, n, "the constant budget binds");
+        assertTrue(s.wasLastWalkTruncated());
+        assertFalse(s.wasLastBudgetCapClamped(),
+                "the constant WANT_SET_BUDGET was the binder, not the governed cap");
+    }
+
+    @Test
+    void untruncatedCapClampedWalkReportsNoTruncation() {
+        // Cap-clamped but the demand FIT the window (the converged/trickle shape):
+        // the truncation half reads false, so the latch's conjunction cannot fire.
+        var s = scanner(2); // 24-position annulus at vd 0
+        s.columnBurstCap = () -> 100;
+        var sink = new Sink();
+        int n = fireScan(s, 0, new ColumnStateMap(), sink);
+        assertEquals(24, n, "the whole annulus fits the capped budget");
+        assertFalse(s.wasLastWalkTruncated(), "no demand beyond the window");
+    }
 }

--- a/fabric/src/test/java/dev/vox/lss/networking/client/TransferRateGovernorTest.java
+++ b/fabric/src/test/java/dev/vox/lss/networking/client/TransferRateGovernorTest.java
@@ -1167,8 +1167,9 @@ class TransferRateGovernorTest {
 
     // ---- Window-limited Row-4 bypass (ramp-window-limited-credit-plan.md) ----
 
-    /** Climbs an armed governor to the ceiling via 7 kept-up doublings (EWMA 16K —
-     *  the existing keptUp test's feed shape). Returns {time, bytes, cols} cursors;
+    /** Climbs an armed governor to the ceiling via 7 kept-up doublings (the existing
+     *  keptUp test's feed shape; the resulting size EWMA is 32K — desired×2s bytes
+     *  over desired/16K columns). Returns {time, bytes, cols} cursors;
      *  rampOpenStreak is 1 afterward (the 4M→8M doubling credited once). */
     private long[] climbToCeiling(TransferRateGovernor g) {
         long t = 0, bytes = 0, cols = 0;
@@ -1314,6 +1315,13 @@ class TransferRateGovernorTest {
         cur = stuckInterval(g, cur, false, 200, 190); // same shape, NO latch
         assertEquals(desired, g.getDesiredBytesPerSec(),
                 "the unlatched twin interval holds at Row 4 (no leaked credit)");
+        // minor-3 (panel): desired can't move at the ceiling, so pin the no-leak
+        // claim on the PHASE — nine more unlatched twins would open a leaked latch.
+        for (int i = 0; i < 9; i++) {
+            cur = stuckInterval(g, cur, false, 200, 190);
+        }
+        assertEquals(TransferRateGovernor.Phase.RAMP, g.getPhase(),
+                "unlatched intervals never credit — the latch does not leak");
         // hardReset (an active=false tick) clears a pending latch.
         g.noteWindowLimited();
         assertTrue(g.windowLimitedLatchedForTest());
@@ -1326,6 +1334,26 @@ class TransferRateGovernorTest {
         var heir = new TransferRateGovernor();
         heir.adoptFrom(donor);
         assertFalse(heir.windowLimitedLatchedForTest(), "adoptFrom reseeds the interval");
+    }
+
+    @Test
+    void unlatchedUncreditedIntervalStillResetsTheStreak() {
+        // The panel's forgiveness-scoping MAJOR: forgiveness is for WINDOW-LIMITED
+        // aliasing only. An un-latched uncredited qualifying interval keeps main's
+        // semantics — immediate reset — so alternating credited/uncredited demand
+        // (~3/8 average answered) can never walk to OPEN.
+        var g = armed();
+        long[] cur = climbToCeiling(g); // streak 1
+        for (int i = 0; i < 8; i++) cur = stuckInterval(g, cur, true, 200, 190); // 9
+        cur = stuckInterval(g, cur, false, 200, 50); // UN-latched miss: hard reset
+        cur = stuckInterval(g, cur, true, 200, 190); // one credit = streak 1, not 10
+        assertEquals(TransferRateGovernor.Phase.RAMP, g.getPhase(),
+                "an un-latched miss resets exactly as before the fix");
+        for (int i = 0; i < 8; i++) cur = stuckInterval(g, cur, true, 200, 190);
+        assertEquals(TransferRateGovernor.Phase.RAMP, g.getPhase());
+        cur = stuckInterval(g, cur, true, 200, 190);
+        assertEquals(TransferRateGovernor.Phase.OPEN, g.getPhase(),
+                "ten fresh consecutive credits confirm after the reset");
     }
 
     @Test

--- a/fabric/src/test/java/dev/vox/lss/networking/client/TransferRateGovernorTest.java
+++ b/fabric/src/test/java/dev/vox/lss/networking/client/TransferRateGovernorTest.java
@@ -380,7 +380,7 @@ class TransferRateGovernorTest {
                 "intervalSeeded", "intervalStartMillis", "intervalStartWireBytes",
                 "intervalStartColumns", "intervalStartDeclared", "intervalStartAnswered",
                 "awaitingAtStart", "haltSeenThisInterval", "movementSeenThisInterval",
-                "awaitingSeenThisInterval", "clock");
+                "awaitingSeenThisInterval", "windowLimitedSeenThisInterval", "clock");
         var src = new TransferRateGovernor();
         var dstProbe = new TransferRateGovernor();
         int seed = 7;
@@ -1163,5 +1163,204 @@ class TransferRateGovernorTest {
                 false, NORMAL_PING, true);
         assertEquals(desired, g.getDesiredBytesPerSec(),
                 "zero bytes moved is not link evidence — hold, never a snap to INITIAL");
+    }
+
+    // ---- Window-limited Row-4 bypass (ramp-window-limited-credit-plan.md) ----
+
+    /** Climbs an armed governor to the ceiling via 7 kept-up doublings (EWMA 16K —
+     *  the existing keptUp test's feed shape). Returns {time, bytes, cols} cursors;
+     *  rampOpenStreak is 1 afterward (the 4M→8M doubling credited once). */
+    private long[] climbToCeiling(TransferRateGovernor g) {
+        long t = 0, bytes = 0, cols = 0;
+        tick(g, t, 0, 0, 1, false, NORMAL_PING);
+        for (int i = 0; i < 7; i++) {
+            long desired = g.getDesiredBytesPerSec();
+            t += INTERVAL;
+            bytes += desired * (INTERVAL / 1000);
+            cols += Math.max(1, desired / (16 * KB));
+            tick(g, t, bytes, cols, 1, false, NORMAL_PING);
+        }
+        assertEquals(SS_CEILING, g.getDesiredBytesPerSec(), "climb premise: at the ceiling");
+        return new long[]{t, bytes, cols};
+    }
+
+    /** One stuck-rig stop-and-wait interval at the ceiling (the measured live shape,
+     *  rescaled to the climb's ACTUAL EWMA of 32K — the climb feeds desired×2s bytes
+     *  over desired/16K columns, so each sample is 32K/column): declared 200 →
+     *  offered ≈ 200×32K/2s = 3.2 MB/s < desired/2 = 4.19 MB/s (under-offered),
+     *  measured = answered×16K/2s (16K samples slide the EWMA down only slowly at
+     *  the 0.05 down-alpha, keeping offered < desired/2 throughout), answered/declared
+     *  ratio per the {@code answered} arg. Latches first when {@code latched}.
+     *  Returns the advanced cursors; declared rides its own cursor (index 3). */
+    private long[] stuckInterval(TransferRateGovernor g, long[] cur, boolean latched,
+                                 int declared, int answered) {
+        long t = cur[0] + INTERVAL;
+        long bytes = cur[1] + answered * 16 * KB;
+        long cols = cur[2] + answered;
+        long declCursor = (cur.length > 3 ? cur[3] : cur[2] * 100) + declared;
+        long ansCursor = (cur.length > 4 ? cur[4] : cur[2] * 100) + answered;
+        if (latched) g.noteWindowLimited();
+        g.tick(t, bytes, cols, declCursor, ansCursor, 1, false, NORMAL_PING, true);
+        return new long[]{t, bytes, cols, declCursor, ansCursor};
+    }
+
+    @Test
+    void windowLimitedStopAndWaitCompletesTheRamp() {
+        // The headline repro (plan §1): at the ceiling the stop-and-wait loop offers
+        // desired/4 × cadence ≈ 3.2 MB/s < desired/2, so Row 4 held every interval
+        // and the exit never fired. With the window-limited latch, answeredAllAsked
+        // (190/200 = 95% ≥ 3/4) credits each interval; 9 more credits after the
+        // climb's one complete the 10-streak.
+        var g = armed();
+        long[] cur = climbToCeiling(g);
+        for (int i = 0; i < 9; i++) {
+            assertEquals(TransferRateGovernor.Phase.RAMP, g.getPhase(),
+                    "still confirming at credit " + (1 + i));
+            cur = stuckInterval(g, cur, true, 200, 190);
+        }
+        assertEquals(TransferRateGovernor.Phase.OPEN, g.getPhase(),
+                "nine window-limited credited intervals + the climb's one = ten → OPEN");
+        assertEquals(0, g.sustainedColumnsPerSecond(), "OPEN is capless");
+
+        // Control arm — the same ten intervals WITHOUT the latch stay parked (the
+        // pre-fix stuck shape, byte-identical Row-4 hold).
+        var stuck = armed();
+        long[] c2 = climbToCeiling(stuck);
+        for (int i = 0; i < 10; i++) {
+            c2 = stuckInterval(stuck, c2, false, 200, 190);
+        }
+        assertEquals(TransferRateGovernor.Phase.RAMP, stuck.getPhase(),
+                "unlatched under-offer holds exactly as before the fix");
+        assertEquals(SS_CEILING, stuck.getDesiredBytesPerSec(),
+                "no growth, no snap — the bit-identical hold");
+    }
+
+    @Test
+    void windowLimitedSingleAliasedMissIsForgiven() {
+        // Plan §3.4: the 2 s interval aliases against the ~630 ms cycle, failing
+        // answeredAllAsked ~1-in-6. One uncredited qualifying interval must not wipe
+        // the streak — the exit completes at the same total credit count.
+        var g = armed();
+        long[] cur = climbToCeiling(g); // streak 1
+        for (int i = 0; i < 4; i++) cur = stuckInterval(g, cur, true, 200, 190); // 5
+        cur = stuckInterval(g, cur, true, 200, 50); // aliased miss: forgiven
+        assertEquals(TransferRateGovernor.Phase.RAMP, g.getPhase());
+        assertEquals(SS_CEILING, g.getDesiredBytesPerSec(),
+                "the miss neither credits nor snaps");
+        for (int i = 0; i < 4; i++) cur = stuckInterval(g, cur, true, 200, 190); // 9
+        assertEquals(TransferRateGovernor.Phase.RAMP, g.getPhase());
+        cur = stuckInterval(g, cur, true, 200, 190); // 10
+        assertEquals(TransferRateGovernor.Phase.OPEN, g.getPhase(),
+                "one forgiven miss: ten credits still open the ramp");
+    }
+
+    @Test
+    void windowLimitedTwoConsecutiveMissesResetTheStreak() {
+        var g = armed();
+        long[] cur = climbToCeiling(g); // streak 1
+        for (int i = 0; i < 8; i++) cur = stuckInterval(g, cur, true, 200, 190); // 9
+        cur = stuckInterval(g, cur, true, 200, 50); // miss 1: forgiven
+        cur = stuckInterval(g, cur, true, 200, 50); // miss 2: RESET
+        // If the reset fired, one credit is streak 1, not 10 — no OPEN.
+        cur = stuckInterval(g, cur, true, 200, 190);
+        assertEquals(TransferRateGovernor.Phase.RAMP, g.getPhase(),
+                "two consecutive misses are real degradation: the streak restarted");
+        for (int i = 0; i < 8; i++) cur = stuckInterval(g, cur, true, 200, 190); // 9
+        assertEquals(TransferRateGovernor.Phase.RAMP, g.getPhase());
+        cur = stuckInterval(g, cur, true, 200, 190); // 10
+        assertEquals(TransferRateGovernor.Phase.OPEN, g.getPhase());
+    }
+
+    @Test
+    void windowLimitedUnderOfferNeverSnaps() {
+        // The pre-snap guard (plan §3.3): a window-limited UNDER-OFFERED interval
+        // whose growth rungs fail is not offer-backed evidence — HOLD (the ENGAGED
+        // freeze rule), never a snap toward measured (which would wipe the earned
+        // ceiling to ~0.5 MB/s here).
+        var g = armed();
+        long[] cur = climbToCeiling(g);
+        cur = stuckInterval(g, cur, true, 200, 50); // bytes>0, growth fails
+        assertEquals(SS_CEILING, g.getDesiredBytesPerSec(),
+                "under-offered + latched + growth-failed = HOLD, never the plateau snap");
+        assertEquals(TransferRateGovernor.Phase.RAMP, g.getPhase());
+    }
+
+    @Test
+    void windowLimitedOfferBackedPlateauStillSnaps() {
+        // 1-Fable fold minor-2: the bypass is a ROW-4 bypass, not a blanket pre-snap
+        // return. A latched interval that IS offer-backed (offered×2 ≥ desired) with
+        // growth failed and bytes moved must still take the containment snap — the
+        // exact numbers of underOfferedIntervalHoldsAndPlateauSnapsWithoutRaising's
+        // plateau arm, plus the latch.
+        var g = armed();
+        g.tick(0, 0, 0, 0, 0, 1, false, NORMAL_PING, true);
+        g.tick(INTERVAL, 128 * KB, 8, 8, 8, 1, false, NORMAL_PING, true);   // EWMA 16K
+        g.tick(2 * INTERVAL, 256 * KB, 16, 16, 16, 1, false, NORMAL_PING, true); // 256K
+        assertEquals(4 * SS_INITIAL, g.getDesiredBytesPerSec());
+        g.noteWindowLimited();
+        g.tick(3 * INTERVAL, 256 * KB + 200 * KB, 36, 36, 26, 1, false, NORMAL_PING, true);
+        assertEquals(100 * KB * 5 / 4, g.getDesiredBytesPerSec(),
+                "an offer-backed latched plateau still snaps — the latch only bypasses Row 4");
+    }
+
+    @Test
+    void windowLimitedLatchIsIntervalScopedAndClearedByResets() {
+        var g = armed();
+        long[] cur = climbToCeiling(g);
+        cur = stuckInterval(g, cur, true, 200, 190); // credited, latch consumed at seed
+        assertFalse(g.windowLimitedLatchedForTest(),
+                "seedInterval clears the latch — it never leaks into the next interval");
+        long desired = g.getDesiredBytesPerSec();
+        cur = stuckInterval(g, cur, false, 200, 190); // same shape, NO latch
+        assertEquals(desired, g.getDesiredBytesPerSec(),
+                "the unlatched twin interval holds at Row 4 (no leaked credit)");
+        // hardReset (an active=false tick) clears a pending latch.
+        g.noteWindowLimited();
+        assertTrue(g.windowLimitedLatchedForTest());
+        g.tick(cur[0] + 1, cur[1], cur[2], cur[3], cur[4], 1, false, NORMAL_PING, false);
+        assertFalse(g.windowLimitedLatchedForTest(), "hardReset clears the latch");
+        // adoptFrom never carries a pending latch (interval state reseeds).
+        var donor = armed();
+        climbToCeiling(donor);
+        donor.noteWindowLimited();
+        var heir = new TransferRateGovernor();
+        heir.adoptFrom(donor);
+        assertFalse(heir.windowLimitedLatchedForTest(), "adoptFrom reseeds the interval");
+    }
+
+    @Test
+    void trickleThroughTinyBudgetSelfArrestsAndNeverCredits() {
+        // 1-Fable fold MAJOR-1(b): near INITIAL the governed burst budget is 1-3
+        // columns, so a small fixed trickle CAN truncate and latch. The escape is
+        // self-arresting at the WIRING level — each doubling doubles the budget, and
+        // once burst > demand the walk stops truncating and the latch stops. This
+        // test replays that geometry against the governor (latch only while the
+        // implied burst = desired/(4·EWMA) < the 3-column demand) and pins the
+        // bound: desired parks a few doublings up, far below the engage threshold,
+        // with zero credits and no OPEN.
+        var g = armed();
+        long t = 0, bytes = 0, cols = 0, decl = 0, ans = 0;
+        g.tick(t, 0, 0, 0, 0, 1, false, NORMAL_PING, true);
+        for (int i = 0; i < 12; i++) {
+            long desired = g.getDesiredBytesPerSec();
+            double ewma = g.getSizeEstimateForTest() > 0
+                    ? g.getSizeEstimateForTest() : 16 * KB;
+            long impliedBurst = Math.max(1, (long) (desired / ewma) / 4);
+            boolean latch = impliedBurst < 3; // the scanner's truncation geometry
+            t += INTERVAL;
+            bytes += 3 * 16 * KB;
+            cols += 3;
+            decl += 3;
+            ans += 3;
+            if (latch) g.noteWindowLimited();
+            g.tick(t, bytes, cols, decl, ans, 1, false, NORMAL_PING, true);
+        }
+        assertEquals(TransferRateGovernor.Phase.RAMP, g.getPhase(),
+                "a self-arrested trickle never opens the ramp");
+        assertEquals(4 * SS_INITIAL, g.getDesiredBytesPerSec(),
+                "the escape is bounded: two latched doublings (64K→256K), then the "
+                        + "budget outgrows the demand and Row 4 holds forever");
+        assertTrue(g.getDesiredBytesPerSec() < ENGAGE_BELOW,
+                "parked far below the credit threshold — no OPEN confirmation can start");
     }
 }

--- a/fabric/src/test/java/dev/vox/lss/networking/client/TransferRateGovernorTest.java
+++ b/fabric/src/test/java/dev/vox/lss/networking/client/TransferRateGovernorTest.java
@@ -1309,7 +1309,7 @@ class TransferRateGovernorTest {
         var g = armed();
         long[] cur = climbToCeiling(g);
         cur = stuckInterval(g, cur, true, 200, 190); // credited, latch consumed at seed
-        assertFalse(g.windowLimitedLatchedForTest(),
+        assertFalse(g.windowLimitedLatched(),
                 "seedInterval clears the latch — it never leaks into the next interval");
         long desired = g.getDesiredBytesPerSec();
         cur = stuckInterval(g, cur, false, 200, 190); // same shape, NO latch
@@ -1324,16 +1324,16 @@ class TransferRateGovernorTest {
                 "unlatched intervals never credit — the latch does not leak");
         // hardReset (an active=false tick) clears a pending latch.
         g.noteWindowLimited();
-        assertTrue(g.windowLimitedLatchedForTest());
+        assertTrue(g.windowLimitedLatched());
         g.tick(cur[0] + 1, cur[1], cur[2], cur[3], cur[4], 1, false, NORMAL_PING, false);
-        assertFalse(g.windowLimitedLatchedForTest(), "hardReset clears the latch");
+        assertFalse(g.windowLimitedLatched(), "hardReset clears the latch");
         // adoptFrom never carries a pending latch (interval state reseeds).
         var donor = armed();
         climbToCeiling(donor);
         donor.noteWindowLimited();
         var heir = new TransferRateGovernor();
         heir.adoptFrom(donor);
-        assertFalse(heir.windowLimitedLatchedForTest(), "adoptFrom reseeds the interval");
+        assertFalse(heir.windowLimitedLatched(), "adoptFrom reseeds the interval");
     }
 
     @Test

--- a/xplat/src/main/java/dev/vox/lss/networking/client/LodRequestManager.java
+++ b/xplat/src/main/java/dev/vox/lss/networking/client/LodRequestManager.java
@@ -639,16 +639,23 @@ public class LodRequestManager {
             if (scanned > 0 && sendRequests(this.sendPositionBuffer,
                     this.sendTimestampBuffer, scanned)) {
                 // The governor's window-limited latch (ramp-window-limited-credit-
-                // plan.md §3.2): a SUCCESSFULLY-SENT walk that the GOVERNED burst
-                // cap truncated — the cap was the binding, taper-free clamp
-                // (scanner provenance) AND the governed rate is the binding half
-                // of the min-compose (a manually-capped loop must not claim to be
-                // governor-window-limited). Tick order puts governor.tick() before
-                // this phase, so the latch lands in the interval this declaration
-                // counts toward.
+                // plan.md §3.2): a SUCCESSFULLY-SENT, COMPLETION-CLOCKED (fast-
+                // fired) walk that the GOVERNED burst cap truncated — the cap was
+                // the binding, near-taper-free clamp (scanner provenance) AND the
+                // governed rate is the binding half of the min-compose (a manually-
+                // capped loop must not claim to be governor-window-limited). The
+                // fast conjunct is the dynamics-review MAJOR-2 fold: a backlogged
+                // slow link runs FALLBACK-clocked (the outstanding gate refuses
+                // fast fires while >5% is unanswered) and its 1 Hz full-budget
+                // re-declares would otherwise satisfy answeredAllAsked up to
+                // ~5.3x the link rate — fallback fires never latch, so slow links
+                // keep (approximately) main's Row-4 park. Tick order puts
+                // governor.tick() before this phase, so the latch lands in the
+                // interval this declaration counts toward.
                 int governedBurst = governedBurstCap();
                 int manual = LSSClientConfig.CONFIG.lodColumnsPerSecondLimit;
-                if (this.scanner.wasLastWalkTruncated()
+                if (this.scanner.wasLastScanFast()
+                        && this.scanner.wasLastWalkTruncated()
                         && this.scanner.wasLastBudgetCapClamped()
                         && governedBurst > 0
                         && (manual <= 0 || governedBurst <= manual)) {
@@ -1271,7 +1278,10 @@ public class LodRequestManager {
             case ENGAGED -> this.governor.sustainedColumnsPerSecond() + "/s ("
                     + (this.governor.getDesiredBytesPerSec() / 1024) + " KB/s)";
             case RAMP -> "ramp@" + (this.governor.getDesiredBytesPerSec() / 1024)
-                    + " KB/s (" + this.governor.sustainedColumnsPerSecond() + "/s)";
+                    + " KB/s (" + this.governor.sustainedColumnsPerSecond() + "/s, credits="
+                    + this.governor.rampOpenStreakForDiag() + "/"
+                    + TransferRateGovernor.DISENGAGE_RATE_INTERVALS
+                    + (this.governor.windowLimitedLatched() ? ", wl" : "") + ")";
             case OPEN -> "open";
             case DISABLED -> "off";
         };

--- a/xplat/src/main/java/dev/vox/lss/networking/client/LodRequestManager.java
+++ b/xplat/src/main/java/dev/vox/lss/networking/client/LodRequestManager.java
@@ -626,8 +626,24 @@ public class LodRequestManager {
             // (a 0-count converged walk disarms; sendRequests' catch re-disarms a
             // failed send before the next tick's predicate can read it).
             this.scanner.noteDeclared(scanned);
-            if (scanned > 0) {
-                sendRequests(this.sendPositionBuffer, this.sendTimestampBuffer, scanned);
+            if (scanned > 0 && sendRequests(this.sendPositionBuffer,
+                    this.sendTimestampBuffer, scanned)) {
+                // The governor's window-limited latch (ramp-window-limited-credit-
+                // plan.md §3.2): a SUCCESSFULLY-SENT walk that the GOVERNED burst
+                // cap truncated — the cap was the binding, taper-free clamp
+                // (scanner provenance) AND the governed rate is the binding half
+                // of the min-compose (a manually-capped loop must not claim to be
+                // governor-window-limited). Tick order puts governor.tick() before
+                // this phase, so the latch lands in the interval this declaration
+                // counts toward.
+                int governedBurst = this.governor.burstColumnsPerSecond();
+                int manual = LSSClientConfig.CONFIG.lodColumnsPerSecondLimit;
+                if (this.scanner.wasLastWalkTruncated()
+                        && this.scanner.wasLastBudgetCapClamped()
+                        && governedBurst > 0
+                        && (manual <= 0 || governedBurst <= manual)) {
+                    this.governor.noteWindowLimited();
+                }
             }
         }
         return scanned;
@@ -642,7 +658,10 @@ public class LodRequestManager {
 
     private BatchSender batchSender = payload -> dev.vox.lss.platform.LoaderServices.get().sendToServer(payload);
 
-    private void sendRequests(long[] positionBuffer, long[] timestampBuffer, int count) {
+    /** @return true iff the batch reached the transport (the same condition that
+     *          bumps {@code declaredColumnsCumulative}) — the window-limited latch's
+     *          send-success conjunct. */
+    private boolean sendRequests(long[] positionBuffer, long[] timestampBuffer, int count) {
         // Snapshot to exact-length arrays: BatchChunkRequestC2SPayload's StreamCodec reads
         // these lazily when the connection encodes on the netty event loop, which races the
         // next scan overwriting the reused sendPositionBuffer/sendTimestampBuffer. The
@@ -660,8 +679,10 @@ public class LodRequestManager {
                 if (timestamps[i] <= 0) timestamps[i] = 0;
             }
         }
+        boolean sent = false;
         try {
             this.batchSender.send(new BatchChunkRequestC2SPayload(positions, timestamps, count));
+            sent = true;
             this.declaredColumnsCumulative += count; // the governor's offer-backing input
             long nowMs = System.currentTimeMillis();
             for (int i = 0; i < count; i++) {
@@ -683,6 +704,7 @@ public class LodRequestManager {
             this.scanner.noteDeclared(0);
         }
         this.metrics.recordSendCycle(count); // counts attempts — a failed batch still counts
+        return sent;
     }
 
     public boolean onColumnReceived(long packed, long columnTimestamp, ResourceKey<Level> dimension) {

--- a/xplat/src/main/java/dev/vox/lss/networking/client/LodRequestManager.java
+++ b/xplat/src/main/java/dev/vox/lss/networking/client/LodRequestManager.java
@@ -225,6 +225,18 @@ public class LodRequestManager {
         return Math.min(manual, governed);
     }
 
+    /** The GOVERNED half of the budget-clamp min-compose — the ONE composition both
+     *  the scanner's columnBurstCap supplier and the window-limited latch read (the
+     *  implementation panel's MAJOR-1: with the adaptive cadence off the governed
+     *  half is the FULL sustained rate, and a latch re-reading burst = sustained/4
+     *  mis-attributed manually-capped walks in the band [ceil(sustained/4),
+     *  sustained/2) to the governor). */
+    private int governedBurstCap() {
+        return this.scanner.adaptiveCadenceEnabled.getAsBoolean()
+                ? this.governor.burstColumnsPerSecond()
+                : this.governor.sustainedColumnsPerSecond();
+    }
+
     public LodRequestManager() {
         // Adaptive cadence: the scanner's fast trigger reads the awaiting-set size each
         // tick. Same main-client-thread contract as every other tracker consumer — every
@@ -244,9 +256,7 @@ public class LodRequestManager {
                 this.governor.sustainedColumnsPerSecond());
         this.scanner.columnBurstCap = () -> composeRateCaps(
                 LSSClientConfig.CONFIG.lodColumnsPerSecondLimit,
-                this.scanner.adaptiveCadenceEnabled.getAsBoolean()
-                        ? this.governor.burstColumnsPerSecond()
-                        : this.governor.sustainedColumnsPerSecond());
+                governedBurstCap());
     }
 
     public void onSessionConfig(SessionConfigS2CPayload config, String serverAddress) {
@@ -636,7 +646,7 @@ public class LodRequestManager {
                 // governor-window-limited). Tick order puts governor.tick() before
                 // this phase, so the latch lands in the interval this declaration
                 // counts toward.
-                int governedBurst = this.governor.burstColumnsPerSecond();
+                int governedBurst = governedBurstCap();
                 int manual = LSSClientConfig.CONFIG.lodColumnsPerSecondLimit;
                 if (this.scanner.wasLastWalkTruncated()
                         && this.scanner.wasLastBudgetCapClamped()

--- a/xplat/src/main/java/dev/vox/lss/networking/client/SpiralScanner.java
+++ b/xplat/src/main/java/dev/vox/lss/networking/client/SpiralScanner.java
@@ -444,15 +444,21 @@ class SpiralScanner {
         // the constant AND neither the pressure taper nor the wire-batch min reduced
         // it further. A taper-reduced budget (the CPU-weak client between 25% and
         // halt) must never read as governor-window-limited.
-        // Accepted corner (implementation panel minor-2): at tiny caps the taper's
-        // round + max(1,·) floor can land the tapered budget back ON the cap value
-        // (unconditionally at burstCap == 1), so a heavily-pressured early-RAMP
-        // client can read cap-clamped. Bounded by the same self-arrest geometry as
-        // exact-fill — a wrongly-latched doubling doubles the budget past the
-        // pressure point, and credits still require desired > ENGAGE_BELOW.
+        // MARGINAL-pressure tolerance (dynamics review MAJOR-1): exact equality
+        // disarmed the latch at ~9 queued columns when the cap sits near the rig's
+        // ~350 (round(347×0.9985) = 346 != 347) — ordinary Voxy ingest counts would
+        // have killed the fix at exactly the park point it targets. The cap counts
+        // as the binding clamp while the tapered budget stays within 25% of it
+        // (budget×4 >= cap×3): mild pressure tolerated, deep pressure (scale <
+        // ~0.75) attributes to the taper and refuses — preserving MAJOR-1(c)'s
+        // CPU-weak exclusion (the 500-of-1000 taper test still reads false).
+        // Accepted corner: at burstCap == 1 the max(1,·) floor keeps budget == cap
+        // under any pressure — bounded by the self-arrest geometry (a wrongly
+        // latched doubling doubles the budget past the pressure point, and credits
+        // still require desired > ENGAGE_BELOW).
         this.lastBudgetCapClamped = burstCap > 0
                 && burstCap < LSSConstants.WANT_SET_BUDGET
-                && budget == burstCap;
+                && budget * 4 >= burstCap * 3;
 
         if (budget <= 0) return -1;
 

--- a/xplat/src/main/java/dev/vox/lss/networking/client/SpiralScanner.java
+++ b/xplat/src/main/java/dev/vox/lss/networking/client/SpiralScanner.java
@@ -444,6 +444,12 @@ class SpiralScanner {
         // the constant AND neither the pressure taper nor the wire-batch min reduced
         // it further. A taper-reduced budget (the CPU-weak client between 25% and
         // halt) must never read as governor-window-limited.
+        // Accepted corner (implementation panel minor-2): at tiny caps the taper's
+        // round + max(1,·) floor can land the tapered budget back ON the cap value
+        // (unconditionally at burstCap == 1), so a heavily-pressured early-RAMP
+        // client can read cap-clamped. Bounded by the same self-arrest geometry as
+        // exact-fill — a wrongly-latched doubling doubles the budget past the
+        // pressure point, and credits still require desired > ENGAGE_BELOW.
         this.lastBudgetCapClamped = burstCap > 0
                 && burstCap < LSSConstants.WANT_SET_BUDGET
                 && budget == burstCap;
@@ -886,7 +892,8 @@ class SpiralScanner {
         this.scanRing = 0;
         this.lastExclusionRadius = -1; // next session re-anchors; no spurious shrink reset
         this.lastLodDistance = -1;     // ...same for the lod-shrink rung
-        this.lastWalkTruncated = false; // fresh session predicts the full disc — fail closed
+        this.lastWalkTruncated = false;
+        this.lastBudgetCapClamped = false; // fresh session predicts the full disc — fail closed
         this.scanTickCounter = LSSConstants.TICKS_PER_SECOND - 1;
         this.missingVanillaChunks = Integer.MAX_VALUE;
         this.cachedVoxyDistance = -1;
@@ -1023,14 +1030,10 @@ class SpiralScanner {
     boolean truncatedBelowPrefixForTest() { return this.truncatedBelowPrefix; }
     /** predictedWalkCost's truncation input — the walk differential asserts arm parity
      *  on it directly (review round 2 MINOR: only count trajectories implied it). */
-    boolean lastWalkTruncatedForTest() { return this.lastWalkTruncated; }
+    boolean wasLastWalkTruncated() { return this.lastWalkTruncated; }
     int getScanRing() { return this.scanRing; }
     int getMissingVanillaChunks() { return this.missingVanillaChunks; }
     int getLastBudget() { return this.lastBudget; }
-
-    /** Did the last walk stop early because the budget filled? (The truncation half
-     *  of the governor's window-limited latch — see {@link #lastWalkTruncated}.) */
-    boolean wasLastWalkTruncated() { return this.lastWalkTruncated; }
 
     /** Was the burst cap the binding, taper-free clamp on the last walk's budget?
      *  (The provenance half — see the maybeScan recording site.) */

--- a/xplat/src/main/java/dev/vox/lss/networking/client/SpiralScanner.java
+++ b/xplat/src/main/java/dev/vox/lss/networking/client/SpiralScanner.java
@@ -218,6 +218,10 @@ class SpiralScanner {
     // Last scan budget tracking
     private int lastBudget;
     private int lastQueued;
+    /** Did the burst-cap clamp SET the last walk's final budget (below the constant,
+     *  un-reduced by the taper)? The governed window-limit's provenance half —
+     *  see the maybeScan recording site (ramp-window-limited-credit-plan.md §3.2). */
+    private boolean lastBudgetCapClamped;
 
     // Cached Voxy view distance — refreshed every 20th getEffectiveLodDistance()
     // INVOCATION, and the walk is not the dominant caller: getPruneDistance() reads it per
@@ -433,6 +437,16 @@ class SpiralScanner {
         // for /lss diag and the trace — as a diagnostic, not a lever.
         // The want-set must fit one wire batch: replace semantics tear across frames.
         budget = Math.min(budget, Math.min(LSSConstants.MAX_BATCH_CHUNK_REQUESTS, posOut.length));
+
+        // Latch provenance for the governor's window-limited bypass
+        // (ramp-window-limited-credit-plan.md §3.2, 1-Fable fold MAJOR-1): true iff
+        // the burst-cap clamp SET the final budget — the cap actually clamped below
+        // the constant AND neither the pressure taper nor the wire-batch min reduced
+        // it further. A taper-reduced budget (the CPU-weak client between 25% and
+        // halt) must never read as governor-window-limited.
+        this.lastBudgetCapClamped = burstCap > 0
+                && burstCap < LSSConstants.WANT_SET_BUDGET
+                && budget == burstCap;
 
         if (budget <= 0) return -1;
 
@@ -1013,6 +1027,14 @@ class SpiralScanner {
     int getScanRing() { return this.scanRing; }
     int getMissingVanillaChunks() { return this.missingVanillaChunks; }
     int getLastBudget() { return this.lastBudget; }
+
+    /** Did the last walk stop early because the budget filled? (The truncation half
+     *  of the governor's window-limited latch — see {@link #lastWalkTruncated}.) */
+    boolean wasLastWalkTruncated() { return this.lastWalkTruncated; }
+
+    /** Was the burst cap the binding, taper-free clamp on the last walk's budget?
+     *  (The provenance half — see the maybeScan recording site.) */
+    boolean wasLastBudgetCapClamped() { return this.lastBudgetCapClamped; }
     int getLastQueued() { return this.lastQueued; }
     boolean wasLastScanFast() { return this.lastScanWasFast; }
     long getFastScans() { return this.fastScans; }

--- a/xplat/src/main/java/dev/vox/lss/networking/client/TransferRateGovernor.java
+++ b/xplat/src/main/java/dev/vox/lss/networking/client/TransferRateGovernor.java
@@ -156,6 +156,13 @@ final class TransferRateGovernor {
     private boolean awaitingSeenThisInterval;
     private boolean haltSeenThisInterval;
     private boolean movementSeenThisInterval;
+    /** Latched by {@link #noteWindowLimited()} (the manager's post-send hook,
+     *  ramp-window-limited-credit-plan.md §3.1/§3.2): at least one successfully-sent
+     *  scan this interval was truncated by the GOVERNED burst cap with the taper
+     *  inactive and the governed rate the binding half of the min-compose — i.e. the
+     *  walk had more demand than the governor's window admitted. RAMP-only consumer
+     *  (the Row-4 bypass); interval-scoped like the movement latch. */
+    private boolean windowLimitedSeenThisInterval;
     private int lastMissingVanilla = -1;   // newest sample (<0 = none yet)
     private int minMissingVanilla = -1;    // session floor (the permanent edge ring)
 
@@ -182,8 +189,16 @@ final class TransferRateGovernor {
     private long restartHintBytesPerSec;
     /** Consecutive CREDITED ramp intervals above the engage threshold — the
      *  RAMP→OPEN confirmation (reuses DISENGAGE_RATE_INTERVALS as the constant,
-     *  not the code path). Any non-credited interval resets it. */
+     *  not the code path). A single qualifying uncredited interval is FORGIVEN
+     *  (held, not reset — plan §3.4: the 2 s interval aliases against the
+     *  stop-and-wait cycle, failing answeredAllAsked ~1-in-6 on the measured rig,
+     *  and a single-miss reset made the 10-streak unreachable there); the SECOND
+     *  consecutive uncredited interval resets. Non-qualifying intervals stay
+     *  no-observations. */
     private int rampOpenStreak;
+    /** Consecutive qualifying UNCREDITED ramp intervals — the forgiveness counter
+     *  (plan §3.4). */
+    private int rampUncreditedRun;
 
     // ---- Size estimator (runs from session start, pre-engagement) ----
     private double sizeEwmaBytes = -1;     // -1 = no sample yet (division guarded)
@@ -445,7 +460,20 @@ final class TransferRateGovernor {
             // earning with demand. The warm rejoin is unaffected: its actuator-
             // clamped declarations put offered ≈ desired through the seed
             // conversion, so the byte-free rung still fires past this row.)
-            if (offered * 2L < this.desiredBytesPerSec) {
+            if (offered * 2L < this.desiredBytesPerSec
+                    && !this.windowLimitedSeenThisInterval) {
+                // Demand-limited: HOLD (unchanged). The window-limited bypass
+                // (ramp-window-limited-credit-plan.md): when the interval's walks
+                // FILLED the governed burst budget and were truncated with demand
+                // left over, the offer shortfall is the stop-and-wait actuator's
+                // arithmetic — offered = desired/4 × cadence, and the completion-
+                // clocked cadence (the 95%-outstanding fast gate) sits at the
+                // SERVE rate, below the 2 Hz this threshold implies whenever the
+                // server's per-player allocation drains a window slower than
+                // 500 ms. The trickle (round-3 MAJOR) cannot CREDIT through the
+                // bypass: the latch requires the governed cap as the binding
+                // clamp, a tiny-budget trickle self-arrests within a few
+                // doublings, and credits still require desired > ENGAGE_BELOW.
                 return;
             }
             boolean keptUp = measured * 4L >= this.desiredBytesPerSec * 3L;
@@ -484,10 +512,26 @@ final class TransferRateGovernor {
             if (measured <= 0) {
                 return;
             }
+            // A window-limited UNDER-OFFERED interval whose growth rungs did not
+            // fire is not offer-backed evidence — the ENGAGED path's freeze rule
+            // (MAJOR-1): HOLD, never snap. Unreachable while the latch is false
+            // (the un-latched under-offer case returned at Row 4 above), so the
+            // un-latched ladder is bit-identical.
+            if (offered * 2L < this.desiredBytesPerSec) {
+                return;
+            }
             this.desiredBytesPerSec = Math.max(SLOW_START_INITIAL_BYTES_PER_SEC,
                     Math.min(this.desiredBytesPerSec, measured * 5L / 4L));
         } finally {
-            if (qualifying && !credited) this.rampOpenStreak = 0;
+            if (qualifying) {
+                if (credited) {
+                    this.rampUncreditedRun = 0;
+                } else if (++this.rampUncreditedRun >= 2) {
+                    // Two consecutive uncredited qualifying intervals = real
+                    // degradation, not interval aliasing — reset (plan §3.4).
+                    this.rampOpenStreak = 0;
+                }
+            }
         }
     }
 
@@ -504,6 +548,7 @@ final class TransferRateGovernor {
             this.desiredBytesPerSec = 0;
         }
         this.rampOpenStreak = 0;
+        this.rampUncreditedRun = 0;
         this.keptUpStreak = 0;
         this.rateDisengageStreak = 0;
         this.engagePendingStreak = 0;
@@ -513,6 +558,7 @@ final class TransferRateGovernor {
         this.phase = Phase.OPEN;
         this.desiredBytesPerSec = 0;
         this.rampOpenStreak = 0;
+        this.rampUncreditedRun = 0;
         if (!this.slowStartNoted) {
             this.slowStartNoted = true;
             LSSLogger.info("LOD slow start complete — the connection kept up through the"
@@ -607,6 +653,7 @@ final class TransferRateGovernor {
         this.haltSeenThisInterval = false;
         this.movementSeenThisInterval = false;
         this.awaitingSeenThisInterval = awaitingSize > 0;
+        this.windowLimitedSeenThisInterval = false;
     }
 
     private void hardReset() {
@@ -623,6 +670,8 @@ final class TransferRateGovernor {
         this.haltSeenThisInterval = false;
         this.movementSeenThisInterval = false;
         this.awaitingSeenThisInterval = false;
+        this.windowLimitedSeenThisInterval = false;
+        this.rampUncreditedRun = 0;
         // The size estimator and ping baseline survive a config-toggle reset (they are
         // measurements, not control state) but die with the session in reset().
     }
@@ -631,6 +680,15 @@ final class TransferRateGovernor {
      *  measurement interval — see the kept-up branch. Main client thread. */
     void noteMovement() {
         this.movementSeenThisInterval = true;
+    }
+
+    /** Window-limited hook (ramp-window-limited-credit-plan.md §3.2): the manager
+     *  calls this after a successfully-sent scan that was truncated by the governed
+     *  burst cap (provenance-checked on the wiring side — taper-clamped, manual-
+     *  capped, and untruncated walks never reach here). Latches the Row-4 bypass
+     *  for the current measurement interval. Main client thread. */
+    void noteWindowLimited() {
+        this.windowLimitedSeenThisInterval = true;
     }
 
     /** Missing-vanilla-chunks sample (live round 5) — the scanner's 1 Hz periodic
@@ -680,6 +738,7 @@ final class TransferRateGovernor {
         this.slowStartEnabled = other.slowStartEnabled;
         this.restartHintBytesPerSec = other.restartHintBytesPerSec;
         this.rampOpenStreak = other.rampOpenStreak;
+        this.rampUncreditedRun = other.rampUncreditedRun;
         this.engageNoted = other.engageNoted;
         this.disengageNoted = other.disengageNoted;
         this.slowStartNoted = other.slowStartNoted;
@@ -687,6 +746,7 @@ final class TransferRateGovernor {
         this.haltSeenThisInterval = false;
         this.movementSeenThisInterval = false;
         this.awaitingSeenThisInterval = false;
+        this.windowLimitedSeenThisInterval = false;
     }
 
     void onDimensionChange() {
@@ -734,6 +794,10 @@ final class TransferRateGovernor {
 
     /** Test accessor: the asymmetric size estimator's current value (-1 = no sample). */
     double getSizeEstimateForTest() { return this.sizeEwmaBytes; }
+
+    /** Test accessor: the window-limited latch's current-interval state (the manager
+     *  wiring tests observe the latch, not the private field). */
+    boolean windowLimitedLatchedForTest() { return this.windowLimitedSeenThisInterval; }
 
     /** Desired rate in bytes/s while ENGAGED or RAMP, 0 otherwise — diag only. */
     long getDesiredBytesPerSec() {

--- a/xplat/src/main/java/dev/vox/lss/networking/client/TransferRateGovernor.java
+++ b/xplat/src/main/java/dev/vox/lss/networking/client/TransferRateGovernor.java
@@ -808,9 +808,14 @@ final class TransferRateGovernor {
     /** Test accessor: the asymmetric size estimator's current value (-1 = no sample). */
     double getSizeEstimateForTest() { return this.sizeEwmaBytes; }
 
-    /** Test accessor: the window-limited latch's current-interval state (the manager
-     *  wiring tests observe the latch, not the private field). */
-    boolean windowLimitedLatchedForTest() { return this.windowLimitedSeenThisInterval; }
+    /** The window-limited latch's current-interval state — the diag receipt
+     *  (dynamics review minor-2: a "still parked" field report must be able to
+     *  answer "did the latch arm?" without a code read) and the wiring tests'
+     *  observable. */
+    boolean windowLimitedLatched() { return this.windowLimitedSeenThisInterval; }
+
+    /** RAMP→OPEN confirmation progress for the diag line (credits=N/10). */
+    int rampOpenStreakForDiag() { return this.rampOpenStreak; }
 
     /** Desired rate in bytes/s while ENGAGED or RAMP, 0 otherwise — diag only. */
     long getDesiredBytesPerSec() {

--- a/xplat/src/main/java/dev/vox/lss/networking/client/TransferRateGovernor.java
+++ b/xplat/src/main/java/dev/vox/lss/networking/client/TransferRateGovernor.java
@@ -526,9 +526,22 @@ final class TransferRateGovernor {
             if (qualifying) {
                 if (credited) {
                     this.rampUncreditedRun = 0;
-                } else if (++this.rampUncreditedRun >= 2) {
-                    // Two consecutive uncredited qualifying intervals = real
-                    // degradation, not interval aliasing — reset (plan §3.4).
+                } else if (this.windowLimitedSeenThisInterval
+                        && this.rampUncreditedRun == 0) {
+                    // Forgiven ONCE, and only for a WINDOW-LIMITED interval (the
+                    // implementation panel's MAJOR: unscoped forgiveness loosened
+                    // the OPEN confirmation for every ramp session — alternating
+                    // credited/uncredited demand could confirm at ~3/8 average
+                    // answered where main required 10 consecutive). The scoped
+                    // case is exactly plan §3.4's aliasing shape: in the stop-and-
+                    // wait steady state every interval latches, and the ~1-in-6
+                    // window whose 4th batch drains into the next interval fails
+                    // answeredAllAsked without being degradation.
+                    this.rampUncreditedRun = 1;
+                } else {
+                    // Un-latched uncredited (main's semantics, restored) or the
+                    // second consecutive miss (real degradation): reset.
+                    this.rampUncreditedRun = 1;
                     this.rampOpenStreak = 0;
                 }
             }


### PR DESCRIPTION
The slow-start RAMP never completed on healthy connections whose server serves slower than the ramp ceiling: the completion-clocked request loop (stop-and-wait at the 95%-outstanding fast gate) collapses the offered rate below Row 4's under-offer threshold, and the streak reset made the 10-credit RAMP→OPEN confirmation unreachable — sessions parked at ramp@8192 KB/s forever with the want-set budget clamped ~353 instead of 800 (~25-35% throughput, measured live on the Paper test rig).

Per docs/planning/ramp-window-limited-credit-plan.md (v1.1 + §§8-9.1 review folds — 1-Fable plan review, then a 3-Opus implementation panel whose four MAJORs are all folded):
- governor: interval-scoped window-limited latch bypasses Row 4 so answeredAllAsked can credit a saturated position window; latched under-offered intervals whose growth fails HOLD (never the plateau snap); latch-scoped one-miss streak forgiveness absorbs the 2s-interval-vs-cycle aliasing.
- scanner: cap-clamped provenance with 25% taper tolerance (exact equality died at 9 queued columns on the rig's own park point).
- manager: one shared governed composition for both the budget clamp and the latch; only successfully-sent, FAST-fired (completion-clocked), governed-cap-truncated walks latch — fallback-clocked slow links keep main's park.
- diag: ramp@… now renders credits=N/10 + a wl receipt.

18 new Tier-1 tests across three suites; the four round-3/hiccup/plateau pins run unmodified; full T1 green.

NOT FOR MERGE YET: main is the frozen, pre-flighted v0.12.0 release tip. Landing options: fold pre-tag (requires re-running the D-prep pre-flights + CI), or first post-release patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)