### PR TITLE
docs: v0.12.0 notes + plan amendment — ramp fix folds into the release

### DIFF
--- a/docs/planning/v0.12.0-release-notes/main.md
+++ b/docs/planning/v0.12.0-release-notes/main.md
@@ -11,6 +11,7 @@
 ### Bug Fixes
 
 - **Replacing the mod jar on a running server no longer risks an unclean shutdown (Fabric)** — An internal diagnostics class could load for the first time during shutdown and fail if the jar had been swapped underneath, aborting the orderly stop and the final world save. It now loads only when that diagnostic is actually enabled.
+- **The join slow start now finishes on fast connections** — The client's adaptive transfer ramp could park permanently below full speed on healthy links: its own request cycle, not the network, was the bottleneck, and the ramp misread that ceiling as the link's. The client now recognizes the pattern and completes the ramp within about 40 seconds of joining, restoring the full request budget (roughly 25% more LOD throughput on affected sessions). Client-side — works against any server version.
 
 ### Configuration
 

--- a/docs/planning/v0.12.0-release-notes/mc1.21.1.md
+++ b/docs/planning/v0.12.0-release-notes/mc1.21.1.md
@@ -11,6 +11,7 @@
 ### Bug Fixes
 
 - **Replacing the mod jar on a running server no longer risks an unclean shutdown (Fabric)** — An internal diagnostics class could load for the first time during shutdown and fail if the jar had been swapped underneath, aborting the orderly stop and the final world save. It now loads only when that diagnostic is actually enabled.
+- **The join slow start now finishes on fast connections** — The client's adaptive transfer ramp could park permanently below full speed on healthy links: its own request cycle, not the network, was the bottleneck, and the ramp misread that ceiling as the link's. The client now recognizes the pattern and completes the ramp within about 40 seconds of joining, restoring the full request budget (roughly 25% more LOD throughput on affected sessions). Client-side — works against any server version.
 
 ### Configuration
 

--- a/docs/planning/v0.12.0-release-notes/mc1.21.11.md
+++ b/docs/planning/v0.12.0-release-notes/mc1.21.11.md
@@ -11,6 +11,7 @@
 ### Bug Fixes
 
 - **Replacing the mod jar on a running server no longer risks an unclean shutdown (Fabric)** — An internal diagnostics class could load for the first time during shutdown and fail if the jar had been swapped underneath, aborting the orderly stop and the final world save. It now loads only when that diagnostic is actually enabled.
+- **The join slow start now finishes on fast connections** — The client's adaptive transfer ramp could park permanently below full speed on healthy links: its own request cycle, not the network, was the bottleneck, and the ramp misread that ceiling as the link's. The client now recognizes the pattern and completes the ramp within about 40 seconds of joining, restoring the full request budget (roughly 25% more LOD throughput on affected sessions). Client-side — works against any server version.
 
 ### Configuration
 

--- a/docs/planning/v0.12.0-release-notes/mc26.1.md
+++ b/docs/planning/v0.12.0-release-notes/mc26.1.md
@@ -11,6 +11,7 @@
 ### Bug Fixes
 
 - **Replacing the mod jar on a running server no longer risks an unclean shutdown (Fabric)** — An internal diagnostics class could load for the first time during shutdown and fail if the jar had been swapped underneath, aborting the orderly stop and the final world save. It now loads only when that diagnostic is actually enabled.
+- **The join slow start now finishes on fast connections** — The client's adaptive transfer ramp could park permanently below full speed on healthy links: its own request cycle, not the network, was the bottleneck, and the ramp misread that ceiling as the link's. The client now recognizes the pattern and completes the ramp within about 40 seconds of joining, restoring the full request budget (roughly 25% more LOD throughput on affected sessions). Client-side — works against any server version.
 
 ### Configuration
 

--- a/docs/planning/v0.12.0-release-plan.md
+++ b/docs/planning/v0.12.0-release-plan.md
@@ -722,3 +722,23 @@ anywhere.
    token — renewed 2026-08-19, ~14-day window — and possibly a manual panel
    Start after an RCON stop), PLUS: delete feat/region-summary-sync (local +
    origin, ac60ec84) only after ALL FOUR tags are pushed.
+
+### 12.7 Post-prep amendment (2026-08-22) — the ramp fix folds into v0.12.0
+
+The user resolved PR #221's landing question: **pre-tag, into v0.12.0.**
+
+- PR #221 (`feat/ramp-window-limited-credit` — the window-limited Row-4
+  bypass; docs/planning/ramp-window-limited-credit-plan.md is normative)
+  MERGED to main @ 9c7c81a8. This supersedes §12.1/§12.2's MAIN evidence
+  (20e9c051/7159eaf8); the three support tips are unchanged until the
+  backports below land.
+- Release notes: the ramp-fix Bug Fixes bullet added to all four files under
+  docs/planning/v0.12.0-release-notes/ (the fix is client-side xplat and
+  backports to every line).
+- New gates before the §12.6 sequence re-arms: (1) fresh MAIN pre-flight
+  (CI=true build at -Pmod_version=0.12.0 + release_check) on the post-merge
+  tip; (2) a 2-Fable + 3-Opus panel over the ENTIRE v0.11.1..main changeset
+  (user-directed); (3) backport of the ramp changeset to
+  support/mc26.1-v0.12, support/mc1.21.11-v0.12, support/mc1.21.1 per
+  docs/planning/ramp-fix-backport-plan.md, each with its line gates + a
+  2-Opus review. Results recorded below as they complete.


### PR DESCRIPTION
Adds the ramp-fix (PR #221) Bug Fixes bullet to all four v0.12.0 release-notes files and records the landing decision + re-armed gates as plan §12.7. Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)