### PR TITLE
fix: backport-reviewer comment nits — §10 citation, RAMP receipt javadoc

### DIFF
--- a/docs/planning/v0.12.0-release-plan.md
+++ b/docs/planning/v0.12.0-release-plan.md
@@ -774,7 +774,9 @@ MINORs folded (fold commit + this docs commit):
   refreshedHeader publish-order comment softened (narrowed, not closed);
   ramp plan §5's `windowLimitedBypassStillRequiresAnswers` recorded as
   shipped-piecewise; ReferenceColumnStateMap VERBATIM claim scoped;
-  Paper stamped-residual comment matches plan §11 item 5 (UNCANARIED);
+  Paper stamped-residual comment matches plan §10 item 5 (UNCANARIED —
+  the §11 citation in the fold commit's comment was itself a typo, caught
+  by the 1.21.11 backport reviewer and fixed everywhere);
   stamp_heal.sh before-pin wording; CLAUDE.md flake-catalog entry for the
   thin summary-scenario margins.
 

--- a/neoforge/.eclipse/configurations/neoforge - Client.launch
+++ b/neoforge/.eclipse/configurations/neoforge - Client.launch
@@ -1,0 +1,10 @@
+<?xml version="1.0" ?>
+<launchConfiguration type="org.eclipse.jdt.launching.localJavaApplication">
+    <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="neoforge"></stringAttribute>
+    <stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="net.neoforged.devlaunch.Main"></stringAttribute>
+    <stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value=" @/home/vox/projects/voxel-server-support/neoforge/build/moddev/clientRunProgramArgs.txt"></stringAttribute>
+    <stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value=" @/home/vox/projects/voxel-server-support/neoforge/build/moddev/clientRunVmArgs.txt -Dfml.modFolders=lsstest%%/home/vox/projects/voxel-server-support/neoforge/bin/gametest:lss%%/home/vox/projects/voxel-server-support/neoforge/bin/main"></stringAttribute>
+    <stringAttribute key="org.eclipse.jdt.launching.WORKING_DIRECTORY" value="/home/vox/projects/voxel-server-support/neoforge/run"></stringAttribute>
+    <booleanAttribute key="org.eclipse.jdt.launching.STOP_IN_MAIN" value="false"></booleanAttribute>
+    <booleanAttribute key="org.eclipse.jdt.launching.ATTR_ATTR_USE_ARGFILE" value="false"></booleanAttribute>
+</launchConfiguration>

--- a/neoforge/.eclipse/configurations/neoforge - GameTestServer.launch
+++ b/neoforge/.eclipse/configurations/neoforge - GameTestServer.launch
@@ -1,0 +1,10 @@
+<?xml version="1.0" ?>
+<launchConfiguration type="org.eclipse.jdt.launching.localJavaApplication">
+    <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="neoforge"></stringAttribute>
+    <stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="net.neoforged.devlaunch.Main"></stringAttribute>
+    <stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value=" @/home/vox/projects/voxel-server-support/neoforge/build/moddev/gameTestServerRunProgramArgs.txt"></stringAttribute>
+    <stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value=" @/home/vox/projects/voxel-server-support/neoforge/build/moddev/gameTestServerRunVmArgs.txt -Dfml.modFolders=lsstest%%/home/vox/projects/voxel-server-support/neoforge/bin/gametest:lss%%/home/vox/projects/voxel-server-support/neoforge/bin/main"></stringAttribute>
+    <stringAttribute key="org.eclipse.jdt.launching.WORKING_DIRECTORY" value="/home/vox/projects/voxel-server-support/neoforge/run"></stringAttribute>
+    <booleanAttribute key="org.eclipse.jdt.launching.STOP_IN_MAIN" value="false"></booleanAttribute>
+    <booleanAttribute key="org.eclipse.jdt.launching.ATTR_ATTR_USE_ARGFILE" value="false"></booleanAttribute>
+</launchConfiguration>

--- a/neoforge/.eclipse/configurations/neoforge - Server.launch
+++ b/neoforge/.eclipse/configurations/neoforge - Server.launch
@@ -1,0 +1,10 @@
+<?xml version="1.0" ?>
+<launchConfiguration type="org.eclipse.jdt.launching.localJavaApplication">
+    <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="neoforge"></stringAttribute>
+    <stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="net.neoforged.devlaunch.Main"></stringAttribute>
+    <stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value=" @/home/vox/projects/voxel-server-support/neoforge/build/moddev/serverRunProgramArgs.txt"></stringAttribute>
+    <stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value=" @/home/vox/projects/voxel-server-support/neoforge/build/moddev/serverRunVmArgs.txt -Dfml.modFolders=lss%%/home/vox/projects/voxel-server-support/neoforge/bin/main"></stringAttribute>
+    <stringAttribute key="org.eclipse.jdt.launching.WORKING_DIRECTORY" value="/home/vox/projects/voxel-server-support/neoforge/run"></stringAttribute>
+    <booleanAttribute key="org.eclipse.jdt.launching.STOP_IN_MAIN" value="false"></booleanAttribute>
+    <booleanAttribute key="org.eclipse.jdt.launching.ATTR_ATTR_USE_ARGFILE" value="false"></booleanAttribute>
+</launchConfiguration>

--- a/paper/src/main/java/dev/vox/lss/paper/PaperRequestProcessingService.java
+++ b/paper/src/main/java/dev/vox/lss/paper/PaperRequestProcessingService.java
@@ -391,7 +391,7 @@ public class PaperRequestProcessingService {
         // wiring): compare-backed rungs stamp "verified now" unless the position's
         // change is marked-but-undrained or the region latch is armed. Null table
         // (pre-region-stamps test wirings) keeps the NEVER default — no stamps.
-        // Paper residual (plan §9.3 as corrected by §11 item 5, accepted-with-eyes-
+        // Paper residual (plan §9.3 as corrected by §10 item 5, accepted-with-eyes-
         // open and UNCANARIED): an event-blind content change (the unfired-event
         // class) is invisible to BOTH guards; its stamp seals until the chunk's next
         // save — the store resweep bounds the store-rung arm. No soak canaries the

--- a/xplat/src/main/java/dev/vox/lss/networking/client/LodRequestManager.java
+++ b/xplat/src/main/java/dev/vox/lss/networking/client/LodRequestManager.java
@@ -1272,7 +1272,8 @@ public class LodRequestManager {
     /** Governor receipt for /lss diag (review n14: rate_gated conflates manual and
      *  governed refusals — this label disambiguates). Four shapes since the slow
      *  start: ENGAGED keeps the pre-phase "<cols>/s (<KB>/s)" (the live-round
-     *  receipt format), RAMP renders "ramp@<KB>/s (<cols>/s)", plus "open"/"off". */
+     *  receipt format), RAMP renders "ramp@<KB>/s (<cols>/s, credits=N/10[, wl])"
+     *  (the window-limited fold's field receipt), plus "open"/"off". */
     public String getGovernedRateLabel() {
         return switch (this.governor.getPhase()) {
             case ENGAGED -> this.governor.sustainedColumnsPerSecond() + "/s ("


### PR DESCRIPTION
Two comment-only corrections from the per-line backport review pairs: the stamped-plan UNCANARIED citation is §10 item 5 (not §11), and the RAMP diag javadoc now documents the credits/wl receipt. Plus the matching release-plan §12.8 record fix. Picked to all three support lines after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)