### PR TITLE
Fix the Xaero map boundary-ring hole (skip = the native edge rule)

### DIFF
--- a/docs/planning/xaero-map-bridge-plan.md
+++ b/docs/planning/xaero-map-bridge-plan.md
@@ -190,20 +190,27 @@ CFR decompile output in `cfr-out262/`, XaeroPlus clone). Key findings:
    philosophy: a dropped tile is not a correctness hole — the map is
    best-effort, and the position heals on the next dirty serve or a
    `/lss clearcache` backfill.
-6. **Overlap policy: never fight Xaero's native writer.** At COMMIT time (main
-   thread — safe and current), skip any position whose chunk is currently
-   loaded in the `ClientLevel` (`EmptyLevelChunk` counts as not-loaded, like the
-   native writer; counted `skipped_loaded`): the native writer owns loaded
-   chunks and rewrites them on its clean-flag anyway (§1 boundary self-heal —
-   our tiles get reclaimed when the player arrives, so LOD-over-native
-   degradation is self-limiting in both directions). Note: the scanner already
-   excludes vanilla-view positions from the want-set, so loaded-chunk columns
-   mostly never arrive — `skipped_loaded` is a race belt (movement crescents,
+6. **Overlap policy: skip exactly what the native writer will write.** At COMMIT
+   time (main thread — safe and current), skip a position only when its chunk
+   AND all 8 neighbors are loaded in the `ClientLevel` (`EmptyLevelChunk`
+   counts as not-loaded; counted `skipped_native`) — the native writer's OWN
+   edge rule. Skipping on "loaded" alone was the v1 rule and produced the
+   FIELD-TESTED boundary-ring defect (2026-08-23, the first manual test): the
+   native writer never writes the outermost ring of loaded chunks (no outer
+   neighbors), so with both writers declining it, every join point grew a
+   1-chunk black circle at the vanilla/LOD boundary — the ring's columns HAD
+   been served during the join window (before vanilla chunks arrived) and the
+   broad skip threw the tiles away. Under the narrowed rule the edge ring is
+   bridge-written and the native writer reclaims it on its clean-flag once
+   fully surrounded (§1 boundary self-heal — LOD-over-native degradation stays
+   self-limiting in both directions). Note: the scanner already excludes
+   vanilla-view positions from the want-set, so fully-surrounded-chunk columns
+   mostly never arrive — `skipped_native` is a race belt (movement crescents,
    RD shrink, chunk-loaded-between-serve-and-commit), not a volume path.
-   Accepted edge: a chunk loaded but outside Xaero's own write window
-   (`min(config, 32, effectiveRD)`) is skipped by both writers — a thin stale
-   ring possible when server view distance exceeds Xaero's window; heals when
-   the chunk enters the window or is re-served.
+   Accepted edge: a chunk loaded AND surrounded but outside Xaero's own write
+   window (`min(config, 32, effectiveRD)`) is skipped by both writers — a thin
+   stale ring possible when server view distance exceeds Xaero's window; heals
+   when the chunk enters the window or is re-served.
 7. **Gate ladder = the native writer's, verbatim; deferral not deletion.** Every
    pump pass re-checks, in the native order and under the native monitors
    (§1's ladder): session present + usable, `!isWritingPaused()`,
@@ -395,7 +402,7 @@ the manual test), no slope polish.
 
 ## 6. Observability
 
-Counters (`written`, `skipped_loaded`, `defer_events` — defer EVENTS, not
+Counters (`written`, `skipped_native`, `defer_events` — defer EVENTS, not
 entries — `dropped` = overflow+stale+expired aggregate, `commit_failures` —
 split out because it is the only pre-death failure signal, unlike the benign
 drop flavors — `load_requests`, `queued` gauge) + `state` (active / unavailable
@@ -604,3 +611,20 @@ writer); a server-initiated play→config reconfiguration skips the disconnect
 teardown (the session-active offer gate + stale-dimension drops contain it);
 `AWAITING_LOAD` entries have no expiry short of queue eviction (transient in
 practice; the rotation keeps them from starving the drain).
+
+## 13. Field-test round 1 (2026-08-23, the user's first manual test)
+
+The map filled correctly out to the LOD distance, with ONE defect: a 1-chunk-wide
+black ring at chunk radius ~11 around the join point (measured off the user's map
+export — thickness exactly 16 px = 1 chunk, circular like vanilla's cylindrical
+chunk loading). Root cause was an interaction of two skip rules on the same ring:
+the native writer's edge rule (all 8 neighbors must be loaded — decompiled
+`writeChunk`'s edgeChunk loop) never writes the outermost loaded ring, and the
+bridge's v1 skip ("any loaded chunk") dropped the served join-window tiles for
+that same ring. Fix: the skip is now the native edge rule itself
+(`nativelyWritable` — chunk + all 8 neighbors loaded, short-circuit on the
+center), counter renamed `skipped_loaded` → `skipped_native`, pinned by
+`aLoadedEdgeChunkIsBridgeWritten` (a loaded-but-edge chunk commits) and the
+updated fully-surrounded skip test. Healing an ALREADY-recorded ring needs a
+column re-serve — `/lss clearcache` while connected (rejoins alone answer
+up_to_date, no data flows).

--- a/fabric/src/test/java/dev/vox/lss/compat/XaeroMapCompatTest.java
+++ b/fabric/src/test/java/dev/vox/lss/compat/XaeroMapCompatTest.java
@@ -394,14 +394,43 @@ class XaeroMapCompatTest {
         assertEquals(0, this.bridge.counterForTest("written"));
     }
 
+    private void loadChunk(int chunkX, int chunkZ) {
+        this.loadedChunks.add(((long) chunkX << 32) | (chunkZ & 0xFFFFFFFFL));
+    }
+
     @Test
-    void loadedChunksAreSkippedNotWritten() {
+    void fullySurroundedLoadedChunksAreSkippedNotWritten() {
         offer(7, 9);
-        this.loadedChunks.add(((long) 7 << 32) | 9L);
+        for (int dx = -1; dx <= 1; dx++) {
+            for (int dz = -1; dz <= 1; dz++) {
+                loadChunk(7 + dx, 9 + dz);
+            }
+        }
         this.bridge.pump();
         assertEquals(0, this.bridge.queuedForTest());
-        assertEquals(1, this.bridge.counterForTest("skipped_loaded"));
+        assertEquals(1, this.bridge.counterForTest("skipped_native"));
         assertEquals(0, this.bridge.counterForTest("written"));
+    }
+
+    @Test
+    void aLoadedEdgeChunkIsBridgeWritten() {
+        // The boundary-ring regression (field-tested 2026-08-23): the native writer's
+        // edge rule refuses any chunk without all 8 neighbors loaded, so the OUTERMOST
+        // ring of loaded vanilla chunks is never natively written — skipping it here
+        // too left a 1-chunk black circle at the vanilla/LOD boundary around every
+        // join point. A loaded-but-edge chunk must be bridge-written; the native
+        // writer reclaims it on its clean-flag once fully surrounded.
+        offer(7, 9);
+        for (int dx = -1; dx <= 1; dx++) {
+            for (int dz = -1; dz <= 1; dz++) {
+                loadChunk(7 + dx, 9 + dz);
+            }
+        }
+        this.loadedChunks.remove(((long) 8 << 32) | 10L); // one missing neighbor → edge
+        this.bridge.pump();
+        assertEquals(1, this.bridge.counterForTest("written"),
+                "an edge chunk (native-unwritable) must be bridge-written");
+        assertEquals(0, this.bridge.counterForTest("skipped_native"));
     }
 
     // ---- deferral flavors (the dead-knob branches) ----

--- a/xplat/src/main/java/dev/vox/lss/compat/XaeroMapCompat.java
+++ b/xplat/src/main/java/dev/vox/lss/compat/XaeroMapCompat.java
@@ -211,7 +211,7 @@ final class XaeroMapCompat {
     private long queuedBytes; // under queueLock
 
     private final AtomicLong written = new AtomicLong();
-    private final AtomicLong skippedLoaded = new AtomicLong();
+    private final AtomicLong skippedNative = new AtomicLong();
     private final AtomicLong deferEvents = new AtomicLong();
     private final AtomicLong droppedOverflow = new AtomicLong();
     private final AtomicLong droppedStale = new AtomicLong();
@@ -430,7 +430,7 @@ final class XaeroMapCompat {
     long counterForTest(String name) {
         return switch (name) {
             case "written" -> this.written.get();
-            case "skipped_loaded" -> this.skippedLoaded.get();
+            case "skipped_native" -> this.skippedNative.get();
             case "defer_events" -> this.deferEvents.get();
             case "dropped_overflow" -> this.droppedOverflow.get();
             case "dropped_stale" -> this.droppedStale.get();
@@ -447,7 +447,7 @@ final class XaeroMapCompat {
                 + this.droppedExpired.get();
         return "XaeroMap: state=" + state + ", queued=" + queuedForTest()
                 + ", written=" + this.written.get()
-                + ", skipped_loaded=" + this.skippedLoaded.get()
+                + ", skipped_native=" + this.skippedNative.get()
                 + ", defer_events=" + this.deferEvents.get()
                 + ", dropped=" + dropped
                 + ", commit_failures=" + this.commitFailures.get()
@@ -554,11 +554,11 @@ final class XaeroMapCompat {
                 this.droppedStale.incrementAndGet();
                 continue;
             }
-            if (this.levelOps.isChunkLoaded(world, tile.chunkX(), tile.chunkZ())) {
-                // The native writer owns loaded chunks and rewrites them on its
+            if (nativelyWritable(world, tile.chunkX(), tile.chunkZ())) {
+                // The native writer owns these chunks and rewrites them on its
                 // clean-flag anyway — never fight it (plan §2.6).
                 removeIfCurrent(key, entry, tile);
-                this.skippedLoaded.incrementAndGet();
+                this.skippedNative.incrementAndGet();
                 continue;
             }
             var outcome = commitEntry(mp, saveLoad, tile,
@@ -590,6 +590,29 @@ final class XaeroMapCompat {
                 }
             }
         }
+    }
+
+    /**
+     * Will the NATIVE writer actually write this chunk? Its edge rule (decompiled
+     * {@code writeChunk}) requires the chunk AND all 8 neighbors loaded — so the
+     * outermost ring of loaded vanilla chunks is never natively written. Skipping
+     * on "loaded" alone left that ring written by NOBODY: a 1-chunk black circle
+     * at the vanilla/LOD boundary around every join point (field-tested 2026-08-23
+     * — the columns had been served during the join window, and the broad skip
+     * threw the tiles away). A loaded-but-edge chunk is bridge-written instead;
+     * the native writer reclaims it on its clean-flag once fully surrounded.
+     */
+    private boolean nativelyWritable(Object world, int chunkX, int chunkZ) {
+        if (!this.levelOps.isChunkLoaded(world, chunkX, chunkZ)) return false;
+        for (int dx = -1; dx <= 1; dx++) {
+            for (int dz = -1; dz <= 1; dz++) {
+                if ((dx != 0 || dz != 0)
+                        && !this.levelOps.isChunkLoaded(world, chunkX + dx, chunkZ + dz)) {
+                    return false;
+                }
+            }
+        }
+        return true;
     }
 
     private enum Outcome { COMMITTED, DEFERRED, AWAITING_LOAD, AWAITING_LOAD_REQUESTED, FAILED }


### PR DESCRIPTION
First manual test of the Xaero bridge found a 1-chunk-wide black circle at the vanilla/LOD boundary around the join point (measured off the map export: thickness exactly 1 chunk, circular like vanilla's cylindrical chunk loading).

Root cause — two skip rules declining the same ring:
- Xaero's native writer refuses **edge chunks** (all 8 neighbors must be loaded — the decompiled `writeChunk` edgeChunk loop), so the outermost ring of loaded vanilla chunks is never natively written.
- The bridge skipped **any loaded chunk**, dropping that ring's tiles too (its columns HAD been served during the join window before vanilla chunks arrived).

Fix: the bridge's skip is now exactly the native writer's rule — skip only when the chunk **and all 8 neighbors** are loaded (`nativelyWritable`, center short-circuit). A loaded-but-edge chunk is bridge-written; the native writer reclaims it on its clean-flag once fully surrounded. Counter renamed `skipped_loaded` → `skipped_native`; plan §2.6 rewritten + §13 field-test record; regression-pinned (`aLoadedEdgeChunkIsBridgeWritten`).

Already-recorded rings heal via `/lss clearcache` while connected (rejoins alone answer up_to_date — no columns flow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)