### PR TITLE
Xaero bridge region-throughput round — bucketed drain + outstanding-load window

### DIFF
--- a/docs/planning/xaero-map-bridge-plan.md
+++ b/docs/planning/xaero-map-bridge-plan.md
@@ -628,3 +628,56 @@ center), counter renamed `skipped_loaded` → `skipped_native`, pinned by
 updated fully-surrounded skip test. Healing an ALREADY-recorded ring needs a
 column re-serve — `/lss clearcache` while connected (rejoins alone answer
 up_to_date, no data flows).
+
+## 14. Region-throughput round (2026-08-23, field-test round 2 — AMENDS §2.4/§2.7/§4)
+
+Field observation (the user's second test): at large map radius the bridge lost
+many tiles. Mechanism: a spiral ring at chunk radius r crosses ~r/4 Xaero map
+regions (~75 at r=300 vs ~3 at r=12), while region loads were granted at ≤1 per
+pump (20/s) — entries flooded in for ungranted regions, the queue overflowed,
+and evict-oldest discarded whole awaiting-load clusters (permanent holes: the
+positions are stamped and never re-served).
+
+Decompile findings that reshaped the design (all verified in MapSaveLoad/
+LeveledRegion):
+- `requestLoad(region, reason)` → `addToLoad(…, prioritize=TRUE)`: front-inserts
+  and lands even mid-drain (the non-prioritized path's `loadingFiles` drop guard
+  does not apply).
+- The loader's drain (`MapSaveLoad.run`) processes UNLIMITED cheap loads per
+  MapRunner cycle (virgin regions with no file — most of an LOD backfill — and
+  cache-only loads) but exits after ONE expensive file load.
+- `shouldAllowAnotherRegionToLoad` is semantically a 1-IN-FLIGHT window: it
+  refuses while the last-requested region's `reloadHasBeenRequested` is still
+  set (cleared when the drain finishes that region). It also synchronizes on its
+  own — possibly BRANCH — region (§12 reviewer 3's deadlock).
+
+The round (supersedes §2.4's rotation-over-entries and §2.7's gauge-paced
+~1/pass request):
+1. **Bucketed drain**: entries group by Xaero map region (32×32 chunks —
+   Xaero's consent granularity); each region is probed ONCE per pump and a
+   not-ready outcome short-circuits its whole bucket (defer_events now counts
+   per bucket per pump — the counter's scale shrank accordingly). Rotation
+   moves to bucket granularity; DEFERRED burns every bucketed entry's deferral
+   counter (cap semantics preserved).
+2. **Outstanding-load window** (`MAX_OUTSTANDING_LOADS` 8) replaces the gauge:
+   the grant phase requests loads for pending regions LARGEST-CLUSTER-FIRST
+   until 8 are in flight, refreshing the window each pump by intersecting with
+   still-pending buckets (a loaded — or fully-evicted — region frees its slot).
+   This self-clocks to the loader's real drain rate: cheap-load mixes refill
+   every pump (~160 grants/s), expensive mixes hold at the window. Each request
+   still runs the native dance (region monitor; setBeingWritten BEFORE
+   requestLoad; setNextToLoadByViewing so the NATIVE writer's own gauge sees
+   our pending loads and politely defers — bounded courtesy inversion, noted).
+   `shouldAllowAnotherRegionToLoad`/`getNextToLoadByViewing` are REMOVED from
+   the reflective surface (§4 shrinks by two members) — the branch-region
+   monitor is never taken, so §12 reviewer 3's deadlock class is gone
+   structurally (pinned: theSharedPacingGaugeIsNeverConsulted).
+3. **Wider survival window**: MAX_QUEUE 2048 → 8192 entries, MAX_QUEUE_BYTES
+   24 → 48 MB.
+4. **Observability**: `regions_waiting=` gauge added to the diag line (pending
+   regions as of the last pump — the direct grant-pressure signal).
+
+Expected field shape: grant rate stops binding for virgin-region backfills,
+commits bound at 64/tick (1280/s) > delivery, `dropped` collapses toward 0;
+post-clearcache re-streams over EXISTING map files stay expensive-load-bound
+(the loader's 1/cycle) but the 8-deep window + 8192-entry queue ride it out.

--- a/docs/planning/xaero-map-bridge-plan.md
+++ b/docs/planning/xaero-map-bridge-plan.md
@@ -169,15 +169,21 @@ CFR decompile output in `cfr-out262/`, XaeroPlus clone). Key findings:
    constraint, the commit-count cap (64) is a safety ceiling (impl review MAJOR:
    the original cap of 8 = 160 tiles/s against 300-1000 delivered columns/s
    made every fast-link backfill drop most of the map and made the clearcache
-   heal circular) — plus at most ~1 `requestLoad` per pump pass (the native
-   pacing, §2.7). The drain start ROTATES per pump (the IncomingRequestRouter
-   M4 precedent): below queue saturation nothing evicts a permanently-deferring
-   prefix, and an unrotated head-first walk would starve committable entries.
+   heal circular) — plus up to a window's worth of `requestLoad` grants per
+   pump (§14's memoryless outstanding window; supersedes the original ~1/pass
+   gauge pacing). The drain is region-BUCKETED (§14) with the rotation at
+   BUCKET granularity (the IncomingRequestRouter M4 precedent — an unrotated
+   head-first walk would starve committable buckets behind a permanently-
+   deferring prefix), the snapshot taken under ONE queue-lock acquisition and
+   the per-entry filters run INSIDE the budgeted loop; the budget check is
+   skipped until the pump has made one unit of progress (a drop or a commit
+   attempt), so a degenerate budget can never live-lock (3-Opus fold MAJOR).
 5. **Bounded latest-wins queue, keyed by packed chunk pos** — bounded by COUNT
-   (2048) and BYTES (~24 MB estimated; the ClientColumnProcessor discipline —
-   plain tiles are ~4.7 KB but overlay-heavy ocean tiles reach ~90 KB, so a
-   count cap alone admits ~165 MB; impl review MAJOR corrected this plan's
-   original ≤8 MB arithmetic). A newer tile for the same position replaces in
+   (8192) and BYTES (~48 MB estimated; §14 widened both from the original
+   2048/24 MB — the ClientColumnProcessor discipline: plain tiles are ~4.7 KB
+   but overlay-heavy ocean tiles reach ~90 KB, so the count cap alone would
+   admit ~0.5 GB; impl review MAJOR corrected this plan's original ≤8 MB
+   arithmetic). A newer tile for the same position replaces in
    place; overflow evicts oldest (counted). Cleared at session end
    (`ClientNetGlue.onDisconnect`) and on config-off; offers are additionally
    gated on a LIVE LSS session, closing the disconnect-drain race that could
@@ -226,16 +232,21 @@ CFR decompile output in `cfr-out262/`, XaeroPlus clone). Key findings:
    TTL). Per region, mirror the write gates (`!region.isWritingPaused()` under
    `writerThreadPauseSync` — the save-race exclusion — then `loadState == 2` +
    `registerVisit()` + `isResting()` under the region monitor) and the
-   MANDATORY load dance for regions not at loadState 2:
+   MANDATORY load dance for regions not at loadState 2 (§14's grant phase —
+   supersedes the original ~1/pass gauge pacing): under the region monitor,
+   `loadState != 2` → the 3→4 revival if cache-parked → `isResting()` →
    `canRequestReload_unsynced()` → `setBeingWritten(true)` →
-   `requestLoad(region, "lss-xaero-bridge")`, paced ~1/pass via
-   `getNextToLoadByViewing().shouldAllowAnotherRegionToLoad()` — fresh regions
-   NEVER self-promote, so without this the feature silently no-ops everywhere
-   Xaero hasn't already been. Entries for a region awaiting load defer without
+   `requestLoad(region, "lss-xaero-bridge")` — fresh regions NEVER
+   self-promote, so without this the feature silently no-ops everywhere Xaero
+   hasn't already been. Deferral scope is split (3-Opus fold MAJOR): REGION-
+   scoped not-ready (being saved / not resting) burns the whole bucket's
+   deferral counters and short-circuits; TILE-CHUNK-scoped not-ready (the 4×4
+   chunk's loadState, a PBO download) burns only that entry and its bucket
+   siblings keep committing. Entries for a region awaiting load defer without
    burning deferral budget; a per-entry deferral cap (~200 ladder-ready passes)
-   then drops (counted). `setBeingWritten(true)` is set and never cleared by us
-   (§1 — the save path owns the reset; clearing it would silently lose every
-   tile not later touched by the native writer).
+   then drops (counted, removal-guarded). `setBeingWritten(true)` is set and
+   never cleared by us (§1 — the save path owns the reset; clearing it would
+   silently lose every tile not later touched by the native writer).
 8. **Failure containment — the map must never cost LOD correctness.** The
    consumer callback catches ALL its own throwables (nothing escapes to
    `dispatchColumn` — an escape would trigger `reportIngestFailure` and put the
@@ -343,10 +354,12 @@ construction under it is proven — SectionConstructionPinTest et al.):
 `mainStuffSync`, `mainWorld`, `renderThreadPauseSync` (whichever of these the
 decompiled ladder actually reads — final list from the decompile).
 `MapWorld.getCurrentDimensionId()` (+ `isCacheOnlyMode` if it lives here).
-`MapSaveLoad`: `requestLoad(MapRegion, String)`, `isRegionDetectionComplete()`,
-`getNextToLoadByViewing()` (+ its `shouldAllowAnotherRegionToLoad()`).
+`MapSaveLoad`: `requestLoad(MapRegion, String)`, `isRegionDetectionComplete()`
+(the pacing pair `getNextToLoadByViewing()`/`shouldAllowAnotherRegionToLoad()`
+was in the original list — REMOVED by §14, never resolved as-built).
 `MapRegion`: field `writerThreadPauseSync`, `isWritingPaused()`,
-`getLoadState()`, `isResting()`, `registerVisit()`, `setBeingWritten(boolean)`,
+`getLoadState()`, `setLoadState(byte)` (§14's 3→4 cache-parked revival),
+`isResting()`, `registerVisit()`, `setBeingWritten(boolean)`,
 `canRequestReload_unsynced()`, `setAllCachePrepared(boolean)`, `getChunk(...)`.
 `MapTileChunk`: ctor, `getTile`/`setTile(int, int, MapTile,
 BlockStateShortShapeCache, MapProcessor)`, `setLoadState(byte)`,
@@ -368,12 +381,17 @@ identical signatures in the 1.21.1 jar): `MapProcessor.
 getMapRegionHighlightsPreparer()` + `MapRegionHighlightsPreparer.prepare(
 MapRegion,int,int,boolean)` (the createdTileChunk block), `MapProcessor.
 getCaveModeDepthConfig()` (setWrittenCave's live depth — mirroring the config
-avoids a spurious native rewrite delta), `MapSaveLoad.setNextToLoadByViewing(
-LeveledRegion)` (the pacing registration half), `MapTileChunk.includeInSave()`,
+avoids a spurious native rewrite delta), `MapTileChunk.includeInSave()`,
 `MapRegion.setChunk(int,int,MapTileChunk)`. Deliberately ABSENT:
 `updateBuffers`, `addToRefresh`, `BlockTintProvider`, `MapUpdateFastConfig`,
 `BiomeColorCalculator` (§1 — Xaero's own sweeps handle textures/refresh/save
-once the flags are set).
+once the flags are set), and — since §14 — the ENTIRE shared load-pacing
+surface: `shouldAllowAnotherRegionToLoad`/`getNextToLoadByViewing` (the
+branch-region monitor deadlock class, gone structurally) AND
+`setNextToLoadByViewing` (the 3-Opus fold: the loader never reads the token —
+only the four native consumers' pacing does, and repointing it at a far bridge
+region vetoed writer/minimap/GUI/reloader after every granted region's save;
+pinned by theSharedPacingSurfaceIsNeverTouched's reflective no-handle scan).
 
 ## 5. Pixel recipe (v1 — mirrors the decompiled `loadPixel`)
 
@@ -402,10 +420,13 @@ the manual test), no slope polish.
 
 ## 6. Observability
 
-Counters (`written`, `skipped_native`, `defer_events` — defer EVENTS, not
-entries — `dropped` = overflow+stale+expired aggregate, `commit_failures` —
-split out because it is the only pre-death failure signal, unlike the benign
-drop flavors — `load_requests`, `queued` gauge) + `state` (active / unavailable
+Counters (`written`, `skipped_native`, `defer_events` — defer EVENTS: one per
+BUCKET per pump for region-scoped flavors, one per entry for tile-chunk-scoped
+(§14) — `dropped` = overflow+stale+expired aggregate (removal-guarded: counts
+DROPS, never attempts), `commit_failures` — split out because it is the only
+pre-death failure signal, unlike the benign drop flavors — `load_requests`,
+`queued` gauge, `regions_waiting` gauge — waiting regions as PROBED by the last
+pump, a lower bound under budget truncation) + `state` (active / unavailable
 / dead / disabled), surfaced ONLY in the client `/lss diag` conditional line
 (comma-separated, the house style) — no exporter/soak schema churn. The
 `unavailable` state is the RESOLVE-FAILED case (Xaero present, internals
@@ -629,7 +650,7 @@ updated fully-surrounded skip test. Healing an ALREADY-recorded ring needs a
 column re-serve — `/lss clearcache` while connected (rejoins alone answer
 up_to_date, no data flows).
 
-## 14. Region-throughput round (2026-08-23, field-test round 2 — AMENDS §2.4/§2.7/§4)
+## 14. Region-throughput round (2026-08-23, field-test round 2 — AMENDS §2.4/§2.5/§2.7/§4/§6, all amended in place)
 
 Field observation (the user's second test): at large map radius the bridge lost
 many tiles. Mechanism: a spiral ring at chunk radius r crosses ~r/4 Xaero map
@@ -651,33 +672,120 @@ LeveledRegion):
   set (cleared when the drain finishes that region). It also synchronizes on its
   own — possibly BRANCH — region (§12 reviewer 3's deadlock).
 
-The round (supersedes §2.4's rotation-over-entries and §2.7's gauge-paced
-~1/pass request):
-1. **Bucketed drain**: entries group by Xaero map region (32×32 chunks —
-   Xaero's consent granularity); each region is probed ONCE per pump and a
-   not-ready outcome short-circuits its whole bucket (defer_events now counts
-   per bucket per pump — the counter's scale shrank accordingly). Rotation
-   moves to bucket granularity; DEFERRED burns every bucketed entry's deferral
-   counter (cap semantics preserved).
-2. **Outstanding-load window** (`MAX_OUTSTANDING_LOADS` 8) replaces the gauge:
-   the grant phase requests loads for pending regions LARGEST-CLUSTER-FIRST
-   until 8 are in flight, refreshing the window each pump by intersecting with
-   still-pending buckets (a loaded — or fully-evicted — region frees its slot).
-   This self-clocks to the loader's real drain rate: cheap-load mixes refill
-   every pump (~160 grants/s), expensive mixes hold at the window. Each request
+The round as-built (supersedes §2.4's rotation-over-entries and §2.7's
+gauge-paced ~1/pass request; items reshaped in place by the §14.1 fold):
+1. **Bucketed drain**: ONE queue-lock snapshot, pure-arithmetic grouping by
+   Xaero map region (32×32 chunks — Xaero's consent granularity), the
+   stale-dimension/natively-writable filters per entry INSIDE the budgeted
+   commit loop, and a progress guarantee — the budget check is skipped until
+   one drop or commit attempt has happened, so a broke budget can never
+   live-lock (fold MAJOR: the original pre-walk ran outside the budget with a
+   lock acquisition + chunk lookups per entry). Each region is probed ONCE per
+   pump; a REGION-scoped not-ready outcome short-circuits its whole bucket
+   (defer_events counts per bucket per pump), while TILE-CHUNK-scoped busy
+   states (the 4×4 loadState, a PBO download) defer only their own entry and
+   the bucket's siblings keep committing (fold MAJOR: region-wide burn expired
+   whole buckets over one busy tile chunk). Rotation is at bucket granularity;
+   region-scoped DEFERRED burns every bucketed entry's deferral counter (cap
+   semantics preserved; drops are removal-guarded so counters count drops).
+2. **MEMORYLESS outstanding-load window** (`MAX_OUTSTANDING_LOADS` 8) replaces
+   the gauge: the commit probe classifies every awaiting region from Xaero's
+   OWN state read in the same region monitor — `canRequestReload_unsynced()`
+   false means a request is genuinely queued/loading/refreshing (IN-FLIGHT,
+   occupies a slot); loadState 3 means cache-parked (needs revival); otherwise
+   REQUESTABLE. The grant phase requests the largest pending clusters into the
+   remaining slots. No bookkeeping set exists to leak or skew (fold MAJORs:
+   the first cut intersected a remembered set with the probed-this-pump
+   buckets, which both released slots for merely-unprobed regions AND leaked
+   slots forever against the loader's three dead ends). Dead ends self-heal:
+   failed/empty loads end in removeMapRegion and the next probe's
+   getLeafMapRegion(create=true) hands back a fresh requestable region;
+   cache-only loads park at loadState 3 (isResting and canRequestReload both
+   false forever) and are revived via Xaero's own 3→4 transition (the
+   clearRegion idiom; restored to 3 if the guards still refuse). Requests are
+   ISSUED smallest-of-the-chosen-first (fold MINOR): the loader drains
+   toLoad.get(0) against our priority front-inserts (LIFO), so the largest
+   cluster must be the FINAL front-insert to drain first. Self-clocking:
+   cheap-load (virgin) mixes refill every pump; expensive mixes hold at the
+   window near the loader's real drain (~10 expensive loads/s at the 100 ms
+   MapRunner cadence — the original text said ~160 grants/s off a 2× cadence
+   error; the cheap-mix refill ceiling is ~8/pump at 20 pumps/s). Each request
    still runs the native dance (region monitor; setBeingWritten BEFORE
-   requestLoad; setNextToLoadByViewing so the NATIVE writer's own gauge sees
-   our pending loads and politely defers — bounded courtesy inversion, noted).
-   `shouldAllowAnotherRegionToLoad`/`getNextToLoadByViewing` are REMOVED from
-   the reflective surface (§4 shrinks by two members) — the branch-region
-   monitor is never taken, so §12 reviewer 3's deadlock class is gone
-   structurally (pinned: theSharedPacingGaugeIsNeverConsulted).
+   requestLoad — state-pinned, not order-pinned). The ENTIRE shared pacing
+   surface is untouched: `shouldAllowAnotherRegionToLoad`/
+   `getNextToLoadByViewing` were never resolved (branch-region-monitor
+   deadlock, gone structurally), and `setNextToLoadByViewing` was REMOVED by
+   the fold — the loader never reads the token; it is purely the pacing input
+   of the four native consumers (writer/minimap/GUI/reloader), and repointing
+   it at a far bridge region vetoed all four for multi-second stretches after
+   each granted region's save (`hasRemovableSourceData` post-save, refreshes).
+   Left alone, the native writer's own requests front-insert AHEAD of our
+   batch — the right priority. Pinned: theSharedPacingSurfaceIsNeverTouched
+   (events + token-identity + reflective no-handle scan).
 3. **Wider survival window**: MAX_QUEUE 2048 → 8192 entries, MAX_QUEUE_BYTES
    24 → 48 MB.
-4. **Observability**: `regions_waiting=` gauge added to the diag line (pending
-   regions as of the last pump — the direct grant-pressure signal).
+4. **Observability**: `regions_waiting=` gauge added to the diag line (waiting
+   regions as PROBED by the last pump — a lower bound under budget truncation;
+   the direct grant-pressure signal).
 
 Expected field shape: grant rate stops binding for virgin-region backfills,
 commits bound at 64/tick (1280/s) > delivery, `dropped` collapses toward 0;
 post-clearcache re-streams over EXISTING map files stay expensive-load-bound
-(the loader's 1/cycle) but the 8-deep window + 8192-entry queue ride it out.
+(the loader's ~10/s) but the 8-deep window + 8192-entry queue ride it out.
+
+Accepted (documented) edges: budget-truncated pumps under-count in-flight
+regions (unprobed buckets are unknown) and can transiently over-grant by at
+most one window per pump — requests are idempotent (a queued region reads
+not-requestable), so the excess is bounded and only widens the in-flight set,
+never re-requests; a region-scoped DEFERRED burns deferral budget for entries
+that might individually be committable next pump (blast radius accepted — the
+flavors are save-transient); `regions_waiting` can read low right after a
+truncated pump.
+
+### 14.1 3-Opus review + fold record (2026-08-23, PR #231)
+
+Three Opus reviewers (drain correctness / loader-model fidelity / test-and-doc
+rigor) over the first cut. All findings folded; the decisive reshapes:
+- **Live-lock class** (R2-MAJOR-1/R1-MAJOR-3): the bucketing pre-walk ran
+  per-entry queue locks + chunk lookups OUTSIDE the nanos budget; a budget
+  break before any bucket then intersected the window memory with an empty
+  map, releasing every slot — a zero-work pump that repeated forever. Fixed:
+  one-lock snapshot, filters inside the budget, the progress guarantee
+  (pinned: aZeroBudgetPumpStillMakesProgressEveryPump).
+- **Window memory unsound** (R2-MAJOR-2 + R1-MAJOR-1): retainAll(pending)
+  mistook not-probed for landed (window degenerates to request-all, LIFO then
+  inverts nearest-first) while the loader's three dead-end outcomes (fail →
+  loadState 4 + removeMapRegion; empty → removeMapRegion; cache-only →
+  loadState 3) leaked remembered slots forever — 8 leaks = bridge stops
+  requesting for the session. Fixed by deleting the memory: verdicts from
+  canRequestReload_unsynced in the commit probe's monitor (R2's key decompile
+  fact: it is false exactly while reloadHasBeenRequested/recache/refreshing),
+  plus the 3→4 revival for the parked dead end (pinned:
+  theWindowRefillsAsLoadsLand, aRemovedDeadEndRegionIsReRequestedOnAFreshObject,
+  aCacheParkedRegionIsRevivedViaTheNativeThreeToFourTransition,
+  aParkedRegionWithPendingNativeWorkIsLeftAlone).
+- **Native-consumer veto** (R1-MINOR-2, upgraded on inspection): our
+  setNextToLoadByViewing repointing blocked all four native consumers'
+  shouldAllowAnotherRegionToLoad for recurring multi-second stretches; the
+  loader itself never reads the token (grep-verified: MapLimiter,
+  MapFullReloader, MapWriter, GuiMap, MinimapRenderListener only). Removed.
+- **Tile-chunk deferral scope** (R3-M3/R1-MINOR-4): split DEFERRED_TILE from
+  region-scoped DEFERRED (pinned:
+  aBusyTileChunkDefersOnlyItsOwnEntriesAndSiblingsCommit).
+- **Vacuous pins** (R3-M1/M2): the largest-first test's insertion order
+  equaled its sorted order (big cluster now offered LAST, and the pin is
+  issued-LAST per the LIFO inversion); the setBeingWritten-before-requestLoad
+  order pin matched the commit probe's event (the stub now records the
+  region's beingWritten STATE inside requestLoad). Stub honesty upgrades:
+  requestLoad flips canRequestReload false (models reloadHasBeenRequested),
+  canRequestReload_unsynced/isResting use the decompiled formulas,
+  setLoadState is monitor-enforced + event-recorded, createdRegionLoadState
+  knob for detection-creates-unloaded scenarios.
+- **Counter honesty** (R2-MINOR-2): removeIfCurrent returns whether it
+  removed; drop counters count drops (a survived fresher tile no longer
+  recounts every pump); an in-place tile replace resets the entry's deferral
+  patience. Grant loop got the dead check (R2-MINOR-3).
+- REFUTED by bytecode (recorded so nobody re-chases them): duplicate
+  requestLoad is impossible (remove+add(0) dedupe + canRequestReload guard);
+  unbounded toLoad growth is impossible; the filter walk was ~1× not 9×
+  isChunkLoaded per entry (nativelyWritable short-circuits on the center).

--- a/fabric/src/test/java/dev/vox/lss/compat/XaeroMapCompatTest.java
+++ b/fabric/src/test/java/dev/vox/lss/compat/XaeroMapCompatTest.java
@@ -47,10 +47,13 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  *       prepare→overlays→write per-pixel order (the stub's prepareForWriting
  *       clears overlays like the real one, so a wrong order wipes them), and
  *       {@code setBeingWritten} set-and-NEVER-cleared;</li>
- *   <li>the mandatory paced requestLoad dance: setBeingWritten BEFORE requestLoad,
- *       the pacing gauge consulted BEFORE any region monitor (lock-order — the
- *       deadlock pin), one request per pump, awaiting-load exempt from the
- *       deferral cap;</li>
+ *   <li>the region load dance: beingWritten TRUE at request time (STATE-recorded
+ *       by the stub — event order was vacuous, the commit probe also sets it),
+ *       the memoryless outstanding window (in-flight recognized from Xaero's own
+ *       canRequestReload, the loader's dead ends self-heal, cache-parked regions
+ *       revive 3→4), Xaero's shared pacing surface untouched in BOTH directions,
+ *       largest cluster issued LAST for the LIFO drain, awaiting-load exempt
+ *       from the deferral cap;</li>
  *   <li>queue policy: latest-wins with DISTINCT tiles, oldest-first eviction,
  *       count AND byte bounds, cross-dimension replacement, config-off clear,
  *       no-session drop;</li>
@@ -285,8 +288,8 @@ class XaeroMapCompatTest {
 
     @Test
     void theByteGaugeBoundsOverlayHeavyTiles() {
-        // Max-overlay tiles are ~87 KB by the gauge's estimate; the 24 MB budget
-        // admits ~290 of them — far below the 2048 count cap.
+        // Max-overlay tiles are ~87 KB by the gauge's estimate; the 48 MB budget
+        // admits ~550 of them — far below the 8192 count cap.
         var runs = new XaeroTileExtractor.OverlayRun[256][];
         for (int i = 0; i < 256; i++) {
             runs[i] = new XaeroTileExtractor.OverlayRun[XaeroTileExtractor.MAX_OVERLAYS];
@@ -490,41 +493,44 @@ class XaeroMapCompatTest {
         assertEquals(1, this.bridge.counterForTest("load_requests"));
         assertEquals(1, this.bridge.regionsWaitingForTest());
         var events = XaeroStubEvents.snapshot();
-        int setBeingWritten = events.indexOf("region.setBeingWritten true");
-        int requestLoad = events.indexOf("saveLoad.requestLoad lss-xaero-bridge");
-        assertTrue(setBeingWritten >= 0 && requestLoad > setBeingWritten,
-                "setBeingWritten(true) must precede requestLoad (it stops the load drain"
-                        + " demoting an empty fresh region): " + events);
-        assertTrue(events.contains("saveLoad.setNextToLoadByViewing"),
-                "the request must register with Xaero's shared admission bookkeeping");
+        assertTrue(events.contains("saveLoad.requestLoad lss-xaero-bridge beingWritten"),
+                "beingWritten must already be TRUE at request time — it stops the load"
+                        + " drain demoting an empty fresh region (STATE-recorded by the"
+                        + " stub; event order was vacuous, the commit probe also sets it): "
+                        + events);
+        assertFalse(events.contains("saveLoad.setNextToLoadByViewing"),
+                "the native consumers' pacing token must never be repointed: " + events);
         assertEquals(1, this.bridge.queuedForTest(), "awaiting-load entries stay queued");
 
-        // The outstanding window: while the load hasn't landed, further pumps issue
-        // NO re-request…
+        // The memoryless window: once requested, Xaero's own canRequestReload
+        // answers false (the stub flips it like the real reloadHasBeenRequested),
+        // so every further pump reads IN-FLIGHT and issues NO re-request…
         for (int i = 0; i < XaeroMapCompat.DEFER_CAP + 50; i++) {
             this.bridge.pump();
         }
         assertEquals(1, this.processor.saveLoad.loadRequests.size(),
-                "outstanding window: one request per region until its load lands");
+                "one request per region until its load lands");
         // …and awaiting-load deferrals are EXEMPT from the deferral cap.
         assertEquals(1, this.bridge.queuedForTest(),
                 "an entry awaiting a region load must never be dropped by the deferral cap");
 
-        // The load lands: the next pump commits and frees the window slot.
+        // The load lands: the next pump commits and nothing waits.
         region.loadState = 2;
         this.bridge.pump();
         assertEquals(1, this.bridge.counterForTest("written"));
         assertEquals(0, this.bridge.queuedForTest());
-        assertEquals(0, this.bridge.outstandingLoadsForTest());
+        assertEquals(0, this.bridge.regionsWaitingForTest());
     }
 
     @Test
-    void theSharedPacingGaugeIsNeverConsulted() {
-        // The deadlock class is structurally gone (throughput round, plan §14):
+    void theSharedPacingSurfaceIsNeverTouched() {
+        // BOTH directions of Xaero's load-pacing surface stay untouched (plan §14):
         // shouldAllowAnotherRegionToLoad synchronizes on its own (possibly BRANCH)
-        // region — a lock-order inversion against Xaero's parent-then-leaf loader —
-        // and the bridge replaces it with its own outstanding window, so the method
-        // must never be invoked at all.
+        // region — a lock-order inversion against Xaero's parent-then-leaf loader
+        // thread (a real client deadlock) — and setNextToLoadByViewing is purely
+        // the four native consumers' pacing token (the loader never reads it);
+        // repointing it at a far bridge region vetoed writer/minimap/GUI/reloader
+        // for multi-second stretches after each granted region's save.
         offer(64, 64);
         var gauge = new MapRegion(); // park a "previous" region in the pacing slot
         this.processor.saveLoad.nextToLoadByViewing = gauge;
@@ -535,41 +541,144 @@ class XaeroMapCompatTest {
         var events = XaeroStubEvents.snapshot();
         assertFalse(events.contains("pacing.shouldAllowAnotherRegionToLoad"),
                 "the shared gauge must never be consulted (deadlock-class removal): " + events);
+        assertFalse(events.contains("saveLoad.setNextToLoadByViewing"),
+                "the pacing token must never be repointed (native-consumer veto): " + events);
+        assertTrue(this.processor.saveLoad.nextToLoadByViewing == gauge,
+                "the pacing token must be left exactly as found");
         assertEquals(1, this.processor.saveLoad.loadRequests.size(),
-                "the outstanding window still grants the load");
+                "the memoryless window still grants the load");
+        // Structural: no reflective handle for the pacing surface may even exist.
+        for (var f : XaeroMapCompat.Handles.class.getDeclaredFields()) {
+            var n = f.getName().toLowerCase(java.util.Locale.ROOT);
+            assertFalse(n.contains("shouldallow") || n.contains("nexttoload"),
+                    "no handle for the pacing surface may exist: " + f.getName());
+        }
     }
 
     @Test
     void grantsGoToTheLargestPendingRegionsUpToTheWindow() {
-        // 10 pending regions; region (2,2) holds THREE tiles, the rest one each. The
-        // grant phase must batch up to MAX_OUTSTANDING_LOADS requests per pump and
-        // spend them largest-cluster-first, so each grant unlocks the most tiles.
-        offer(64, 64);
-        offer(68, 64);
-        offer(72, 64); // three tiles in region (2,2)
+        // 10 pending regions; region (2,2) holds THREE tiles, the rest one each —
+        // and the big cluster is offered LAST, so insertion order cannot masquerade
+        // as size order (3-Opus fold: the old arrangement made the sort vacuous).
+        // The grant phase spends up to MAX_OUTSTANDING_LOADS requests per pump on
+        // the largest clusters, ISSUED smallest-first: the loader drains
+        // toLoad.get(0) against our priority front-inserts (LIFO), so the
+        // LAST-issued (largest) region is the one drained FIRST.
         for (int i = 1; i <= 9; i++) {
             offer(64 + i * 32, 320); // regions (2+i, 10), one tile each
         }
+        offer(64, 64);
+        offer(68, 64);
+        offer(72, 64); // three tiles in region (2,2) — offered LAST
         var bigRegion = unloadedRegion();
         this.processor.regions.put((2L << 32) | 2L, bigRegion);
         for (int i = 1; i <= 9; i++) {
             this.processor.regions.put(((long) (2 + i) << 32) | 10L, unloadedRegion());
         }
         this.bridge.pump();
-        assertEquals(XaeroMapCompat.MAX_OUTSTANDING_LOADS,
-                this.processor.saveLoad.loadRequests.size(),
+        var requests = this.processor.saveLoad.loadRequests;
+        assertEquals(XaeroMapCompat.MAX_OUTSTANDING_LOADS, requests.size(),
                 "one pump must batch a full window of load requests");
-        assertEquals(XaeroMapCompat.MAX_OUTSTANDING_LOADS, this.bridge.outstandingLoadsForTest());
-        assertTrue(this.processor.saveLoad.loadRequests.get(0) == bigRegion,
-                "the region holding the most queued tiles must be requested FIRST");
+        assertTrue(requests.get(requests.size() - 1) == bigRegion,
+                "the region holding the most queued tiles must be issued LAST — the"
+                        + " final front-insert is what the LIFO drain serves FIRST");
         assertEquals(10, this.bridge.regionsWaitingForTest());
+        assertEquals(0, this.bridge.counterForTest("commit_failures"));
+    }
+
+    @Test
+    void theWindowRefillsAsLoadsLand() {
+        // 12 waiting regions, window 8: pump 1 requests 8 (the stub flips their
+        // canRequestReload — honestly in flight). Landing 3 frees 3 slots: the
+        // next pump commits the landed tiles AND requests exactly 3 more.
+        for (int i = 0; i < 12; i++) {
+            offer(64 + i * 32, 320); // regions (2..13, 10)
+            this.processor.regions.put(((long) (2 + i) << 32) | 10L, unloadedRegion());
+        }
+        this.bridge.pump();
+        assertEquals(8, this.processor.saveLoad.loadRequests.size());
+        this.bridge.pump();
+        assertEquals(8, this.processor.saveLoad.loadRequests.size(),
+                "window full, no slot free — no new grants");
+        for (int i = 0; i < 3; i++) {
+            this.processor.saveLoad.loadRequests.get(i).loadState = 2; // lands
+        }
+        this.bridge.pump();
+        assertEquals(3, this.bridge.counterForTest("written"), "landed tiles commit");
+        assertEquals(11, this.processor.saveLoad.loadRequests.size(),
+                "the 3 freed slots must refill with exactly 3 new grants");
+    }
+
+    @Test
+    void aRemovedDeadEndRegionIsReRequestedOnAFreshObject() {
+        // Two of the loader's three dead ends END IN removeMapRegion (failed read →
+        // loadState 4 + remove; empty load → remove): the granted region OBJECT
+        // disappears without ever reaching loadState 2. A slot-tracking window
+        // would leak that slot forever (3-Opus fold MAJOR); the memoryless window
+        // self-heals — the next probe's getLeafMapRegion(create=true) hands back a
+        // fresh unloaded region that reads requestable again.
+        offer(64, 64);
+        long key = (2L << 32) | 2L;
+        this.processor.regions.put(key, unloadedRegion());
+        this.bridge.pump();
+        assertEquals(1, this.processor.saveLoad.loadRequests.size());
+        this.bridge.pump();
+        assertEquals(1, this.processor.saveLoad.loadRequests.size(), "in flight: no re-request");
+        var deadEnded = this.processor.regions.remove(key); // Xaero's removeMapRegion
+        this.processor.createdRegionLoadState = 0;          // detection creates UNLOADED
+        this.bridge.pump();
+        assertEquals(2, this.processor.saveLoad.loadRequests.size(),
+                "the dead-ended region must be re-requested…");
+        assertTrue(this.processor.saveLoad.loadRequests.get(1) != deadEnded
+                        && this.processor.saveLoad.loadRequests.get(1)
+                                == this.processor.regions.get(key),
+                "…on the FRESH region object the probe re-created");
+    }
+
+    @Test
+    void aCacheParkedRegionIsRevivedViaTheNativeThreeToFourTransition() {
+        // The loader's third dead end (3-Opus fold MAJOR): a cache-only load parks
+        // the region at loadState 3, where isResting AND canRequestReload are both
+        // false FOREVER — without revival the bucket waits until session end.
+        // Xaero's own clearRegion idiom (3→4) makes it requestable again.
+        offer(64, 64);
+        var region = new MapRegion();
+        region.loadState = 3;
+        this.processor.regions.put((2L << 32) | 2L, region);
+        this.bridge.pump();
+        assertEquals(1, this.processor.saveLoad.loadRequests.size(),
+                "a cache-parked region must be revived and requested");
+        assertTrue(XaeroStubEvents.snapshot().contains("region.setLoadState 4"),
+                "the revival must be Xaero's own 3→4 transition");
+        region.loadState = 2; // the load lands
+        this.bridge.pump();
+        assertEquals(1, this.bridge.counterForTest("written"));
+        assertEquals(0, this.bridge.queuedForTest());
+    }
+
+    @Test
+    void aParkedRegionWithPendingNativeWorkIsLeftAlone() {
+        // The revival must RESTORE loadState 3 when the guards still refuse (a
+        // pending native recache/refresh owns the region) — and never mark
+        // beingWritten on the way out.
+        offer(64, 64);
+        var region = new MapRegion();
+        region.loadState = 3;
+        region.canRequestReload = false; // pending native work
+        this.processor.regions.put((2L << 32) | 2L, region);
+        this.bridge.pump();
+        assertTrue(this.processor.saveLoad.loadRequests.isEmpty());
+        assertEquals(3, region.loadState, "the failed revival must restore loadState 3");
+        org.junit.jupiter.api.Assertions.assertNull(region.beingWritten,
+                "a refused request must not mark beingWritten");
+        assertEquals(1, this.bridge.queuedForTest(), "the bucket keeps waiting");
     }
 
     @Test
     void aBucketOfManyEntriesCountsOneDeferEventPerPump() {
         // The bucketed drain probes each region ONCE per pump — at large radius a
         // ring crosses ~r/4 regions, and per-entry probing burned the whole budget
-        // on identical AWAITING_LOAD answers (the throughput round's motivation).
+        // on identical awaiting-load answers (the throughput round's motivation).
         for (int i = 0; i < 20; i++) {
             offer(64 + i, 64); // 20 tiles, all in region (2,2) — chunkX 64..83
         }
@@ -578,6 +687,11 @@ class XaeroMapCompatTest {
         assertEquals(1, this.bridge.counterForTest("defer_events"),
                 "one defer event per BUCKET per pump, not per entry");
         assertEquals(20, this.bridge.queuedForTest());
+        long lookups = XaeroStubEvents.snapshot().stream()
+                .filter(e -> e.startsWith("processor.getLeafMapRegion")).count();
+        assertEquals(2, lookups,
+                "20 same-region entries must cost exactly TWO region lookups — one"
+                        + " commit probe (bucket short-circuit) + one grant request");
     }
 
     @Test
@@ -742,14 +856,58 @@ class XaeroMapCompatTest {
     }
 
     @Test
-    void theNanosBudgetStopsTheDrainImmediately() {
-        offer(0, 0);
-        offer(4, 0);
-        this.bridge.pumpNanosBudget = 0; // every entry is over budget
+    void aZeroBudgetPumpStillMakesProgressEveryPump() {
+        // The live-lock MAJOR (3-Opus fold): the old pre-walk ran OUTSIDE the nanos
+        // budget, so a broke pump could do literally nothing while retaining the
+        // whole queue, forever. The budget check is now skipped until one unit of
+        // progress (a drop or a commit attempt) — a zero budget commits exactly
+        // ONE entry per pump, still grants probed waiting regions, and the queue
+        // always drains.
+        offer(0, 0);   // committable bucket (auto-created loaded region)
+        offer(4, 0);   // same bucket
+        offer(64, 64); // waiting bucket — region (2,2)
+        this.processor.regions.put((2L << 32) | 2L, unloadedRegion());
+        this.bridge.pumpNanosBudget = 0;
         this.bridge.pump();
-        assertEquals(0, this.bridge.counterForTest("written"),
-                "a zero time budget must commit nothing");
-        assertEquals(2, this.bridge.queuedForTest(), "over-budget entries are retained");
+        assertEquals(1, this.bridge.counterForTest("written"),
+                "a zero budget must still commit exactly one entry (progress guarantee)");
+        for (int i = 0; i < 8 && this.bridge.queuedForTest() > 1; i++) {
+            this.bridge.pump();
+        }
+        assertEquals(2, this.bridge.counterForTest("written"),
+                "over pumps the zero-budget drain must empty the committable bucket");
+        assertEquals(1, this.bridge.queuedForTest(), "only the awaiting entry remains");
+        assertEquals(1, this.processor.saveLoad.loadRequests.size(),
+                "the waiting region must be granted its load despite the broke budget");
+    }
+
+    @Test
+    void aBusyTileChunkDefersOnlyItsOwnEntriesAndSiblingsCommit() {
+        // Three entries in ONE region, distinct tile chunks; the first entry's tile
+        // chunk is PBO-downloading. The old region-wide deferral starved (and after
+        // DEFER_CAP pumps EXPIRED) whole buckets over one busy tile chunk (3-Opus
+        // fold MAJOR); tile-chunk-scoped deferral lets the siblings commit now,
+        // and the busy entry expires ALONE at its own cap.
+        offer(0, 0);  // tileChunk (0,0) — armed busy
+        offer(4, 0);  // tileChunk (1,0)
+        offer(8, 0);  // tileChunk (2,0)
+        var region = new MapRegion();
+        var busy = new MapTileChunk(region, 0, 0);
+        busy.loadState = 2;
+        busy.leafTexture.downloadFromPBO = true;
+        region.setChunk(0, 0, busy);
+        this.processor.regions.put(0L, region);
+        this.bridge.pump();
+        assertEquals(2, this.bridge.counterForTest("written"),
+                "siblings in other tile chunks must commit past the busy one");
+        assertEquals(1, this.bridge.queuedForTest());
+        for (int i = 0; i < XaeroMapCompat.DEFER_CAP + 2; i++) {
+            this.bridge.pump();
+        }
+        assertEquals(0, this.bridge.queuedForTest(),
+                "the busy entry expires at its own deferral cap");
+        assertEquals(1, this.bridge.counterForTest("dropped_expired"),
+                "…counted exactly once (removal-guarded counting)");
     }
 
     @Test

--- a/fabric/src/test/java/dev/vox/lss/compat/XaeroMapCompatTest.java
+++ b/fabric/src/test/java/dev/vox/lss/compat/XaeroMapCompatTest.java
@@ -295,14 +295,14 @@ class XaeroMapCompatTest {
                         Blocks.WATER.defaultBlockState(), (byte) 0, false, 1);
             }
         }
-        for (int i = 0; i < 400; i++) {
+        for (int i = 0; i < 700; i++) {
             var heavy = tile(i * 4, 0);
             var withRuns = new XaeroTileExtractor.PreparedTile(heavy.chunkX(), heavy.chunkZ(),
                     heavy.worldBottomY(), heavy.floorState(), heavy.floorY(), heavy.topY(),
                     heavy.biome(), heavy.light(), heavy.glowing(), runs);
             this.bridge.offerPrepared(OVERWORLD, withRuns);
         }
-        assertTrue(this.bridge.queuedForTest() < 400,
+        assertTrue(this.bridge.queuedForTest() < 700,
                 "the byte gauge must evict before the count cap on overlay-heavy tiles"
                         + " (queued=" + this.bridge.queuedForTest() + ")");
         assertTrue(this.bridge.queuedBytesForTest() <= XaeroMapCompat.MAX_QUEUE_BYTES);
@@ -479,7 +479,7 @@ class XaeroMapCompatTest {
     // ---- the region load dance ----
 
     @Test
-    void unloadedRegionGetsExactlyOnePacedLoadRequestWithBeingWrittenFirst() {
+    void unloadedRegionIsLoadRequestedWithBeingWrittenFirstAndNeverReRequested() {
         offer(64, 64); // region (2,2), fresh
         var region = new MapRegion();
         region.loadState = 0;
@@ -488,6 +488,7 @@ class XaeroMapCompatTest {
         assertEquals(1, this.processor.saveLoad.loadRequests.size(),
                 "an unloaded region must be load-REQUESTED (fresh regions never self-promote)");
         assertEquals(1, this.bridge.counterForTest("load_requests"));
+        assertEquals(1, this.bridge.regionsWaitingForTest());
         var events = XaeroStubEvents.snapshot();
         int setBeingWritten = events.indexOf("region.setBeingWritten true");
         int requestLoad = events.indexOf("saveLoad.requestLoad lss-xaero-bridge");
@@ -495,31 +496,35 @@ class XaeroMapCompatTest {
                 "setBeingWritten(true) must precede requestLoad (it stops the load drain"
                         + " demoting an empty fresh region): " + events);
         assertTrue(events.contains("saveLoad.setNextToLoadByViewing"),
-                "the request must register with the pacing gauge");
+                "the request must register with Xaero's shared admission bookkeeping");
         assertEquals(1, this.bridge.queuedForTest(), "awaiting-load entries stay queued");
 
-        // Pacing: while the gauge refuses, further pumps issue NO second request…
-        this.processor.saveLoad.nextToLoadByViewing.allowAnotherRegionToLoad = false;
+        // The outstanding window: while the load hasn't landed, further pumps issue
+        // NO re-request…
         for (int i = 0; i < XaeroMapCompat.DEFER_CAP + 50; i++) {
             this.bridge.pump();
         }
-        assertEquals(1, this.processor.saveLoad.loadRequests.size(), "paced: one request total");
+        assertEquals(1, this.processor.saveLoad.loadRequests.size(),
+                "outstanding window: one request per region until its load lands");
         // …and awaiting-load deferrals are EXEMPT from the deferral cap.
         assertEquals(1, this.bridge.queuedForTest(),
                 "an entry awaiting a region load must never be dropped by the deferral cap");
 
-        // The load lands: the next pump commits.
+        // The load lands: the next pump commits and frees the window slot.
         region.loadState = 2;
         this.bridge.pump();
         assertEquals(1, this.bridge.counterForTest("written"));
         assertEquals(0, this.bridge.queuedForTest());
+        assertEquals(0, this.bridge.outstandingLoadsForTest());
     }
 
     @Test
-    void thePacingGaugeIsConsultedBeforeAnyRegionMonitor() {
-        // The deadlock pin (review MAJOR): shouldAllowAnotherRegionToLoad synchronizes
-        // on its own (possibly BRANCH) region while Xaero's loader nests
-        // parent-then-leaf — production must consult it BEFORE touching any region.
+    void theSharedPacingGaugeIsNeverConsulted() {
+        // The deadlock class is structurally gone (throughput round, plan §14):
+        // shouldAllowAnotherRegionToLoad synchronizes on its own (possibly BRANCH)
+        // region — a lock-order inversion against Xaero's parent-then-leaf loader —
+        // and the bridge replaces it with its own outstanding window, so the method
+        // must never be invoked at all.
         offer(64, 64);
         var gauge = new MapRegion(); // park a "previous" region in the pacing slot
         this.processor.saveLoad.nextToLoadByViewing = gauge;
@@ -528,18 +533,51 @@ class XaeroMapCompatTest {
         this.processor.regions.put((2L << 32) | 2L, region);
         this.bridge.pump();
         var events = XaeroStubEvents.snapshot();
-        int pacing = events.indexOf("pacing.shouldAllowAnotherRegionToLoad");
-        int firstRegionTouch = -1;
-        for (int i = 0; i < events.size(); i++) {
-            if (events.get(i).startsWith("region.")) {
-                firstRegionTouch = i;
-                break;
-            }
+        assertFalse(events.contains("pacing.shouldAllowAnotherRegionToLoad"),
+                "the shared gauge must never be consulted (deadlock-class removal): " + events);
+        assertEquals(1, this.processor.saveLoad.loadRequests.size(),
+                "the outstanding window still grants the load");
+    }
+
+    @Test
+    void grantsGoToTheLargestPendingRegionsUpToTheWindow() {
+        // 10 pending regions; region (2,2) holds THREE tiles, the rest one each. The
+        // grant phase must batch up to MAX_OUTSTANDING_LOADS requests per pump and
+        // spend them largest-cluster-first, so each grant unlocks the most tiles.
+        offer(64, 64);
+        offer(68, 64);
+        offer(72, 64); // three tiles in region (2,2)
+        for (int i = 1; i <= 9; i++) {
+            offer(64 + i * 32, 320); // regions (2+i, 10), one tile each
         }
-        assertTrue(pacing >= 0, "the gauge must be consulted: " + events);
-        assertTrue(firstRegionTouch < 0 || pacing < firstRegionTouch,
-                "the pacing gauge must be consulted BEFORE any region monitor work"
-                        + " (lock-order vs Xaero's loader thread): " + events);
+        var bigRegion = unloadedRegion();
+        this.processor.regions.put((2L << 32) | 2L, bigRegion);
+        for (int i = 1; i <= 9; i++) {
+            this.processor.regions.put(((long) (2 + i) << 32) | 10L, unloadedRegion());
+        }
+        this.bridge.pump();
+        assertEquals(XaeroMapCompat.MAX_OUTSTANDING_LOADS,
+                this.processor.saveLoad.loadRequests.size(),
+                "one pump must batch a full window of load requests");
+        assertEquals(XaeroMapCompat.MAX_OUTSTANDING_LOADS, this.bridge.outstandingLoadsForTest());
+        assertTrue(this.processor.saveLoad.loadRequests.get(0) == bigRegion,
+                "the region holding the most queued tiles must be requested FIRST");
+        assertEquals(10, this.bridge.regionsWaitingForTest());
+    }
+
+    @Test
+    void aBucketOfManyEntriesCountsOneDeferEventPerPump() {
+        // The bucketed drain probes each region ONCE per pump — at large radius a
+        // ring crosses ~r/4 regions, and per-entry probing burned the whole budget
+        // on identical AWAITING_LOAD answers (the throughput round's motivation).
+        for (int i = 0; i < 20; i++) {
+            offer(64 + i, 64); // 20 tiles, all in region (2,2) — chunkX 64..83
+        }
+        this.processor.regions.put((2L << 32) | 2L, unloadedRegion());
+        this.bridge.pump();
+        assertEquals(1, this.bridge.counterForTest("defer_events"),
+                "one defer event per BUCKET per pump, not per entry");
+        assertEquals(20, this.bridge.queuedForTest());
     }
 
     @Test
@@ -558,14 +596,14 @@ class XaeroMapCompatTest {
     }
 
     @Test
-    void twoUnloadedRegionsShareTheOneRequestPerPumpPacing() {
+    void twoUnloadedRegionsAreGrantedInTheSamePump() {
         offer(64, 64);   // region (2,2)
         offer(320, 320); // region (10,10)
         this.processor.regions.put((2L << 32) | 2L, unloadedRegion());
         this.processor.regions.put((10L << 32) | 10L, unloadedRegion());
         this.bridge.pump();
-        assertEquals(1, this.processor.saveLoad.loadRequests.size(),
-                "at most ONE requestLoad per pump pass (the native ~1/pass pacing)");
+        assertEquals(2, this.processor.saveLoad.loadRequests.size(),
+                "both fit the outstanding window — one pump grants both");
     }
 
     private MapRegion unloadedRegion() {
@@ -840,7 +878,8 @@ class XaeroMapCompatTest {
         var line = this.bridge.describe();
         assertTrue(line.startsWith("XaeroMap: state=active, queued="), line);
         assertTrue(line.contains(", written=") && line.contains(", defer_events=")
-                && line.contains(", dropped=") && line.contains(", commit_failures="), line);
+                && line.contains(", dropped=") && line.contains(", commit_failures=")
+                && line.contains(", regions_waiting="), line);
         this.enabled = false;
         assertTrue(this.bridge.describe().contains("state=disabled"));
     }

--- a/fabric/src/test/java/xaero/map/MapProcessor.java
+++ b/fabric/src/test/java/xaero/map/MapProcessor.java
@@ -30,6 +30,10 @@ public class MapProcessor {
     public MapRegionHighlightsPreparer highlightsPreparer = new MapRegionHighlightsPreparer();
     public final java.util.Map<Long, MapRegion> regions = new java.util.HashMap<>();
     public boolean leafMapRegionReturnsNull;
+    /** LoadState for regions getLeafMapRegion auto-creates. The stub default (2 =
+     *  loaded) keeps plain commit tests short; the real detection creates fresh
+     *  regions UNLOADED — tests of the removeMapRegion dead-end self-heal set 0. */
+    public byte createdRegionLoadState = 2;
 
     public boolean isWritingPaused() {
         if (!Thread.holdsLock(this.renderThreadPauseSync)) {
@@ -65,6 +69,7 @@ public class MapProcessor {
         var existing = this.regions.get(key);
         if (existing == null && create) {
             existing = new MapRegion();
+            existing.loadState = this.createdRegionLoadState;
             this.regions.put(key, existing);
         }
         return existing;

--- a/fabric/src/test/java/xaero/map/file/MapSaveLoad.java
+++ b/fabric/src/test/java/xaero/map/file/MapSaveLoad.java
@@ -3,7 +3,11 @@ package xaero.map.file;
 import xaero.map.region.LeveledRegion;
 import xaero.map.region.MapRegion;
 
-/** Tier-1 stub — records the load-request dance. */
+/** Tier-1 stub — records the load-request dance. requestLoad is STATEFUL like the
+ *  real loader (reloadHasBeenRequested flips, so canRequestReload_unsynced answers
+ *  false until the test "lands" the load) and records the region's beingWritten
+ *  STATE at request time — the honest setBeingWritten-before-requestLoad pin
+ *  (3-Opus fold: event ORDER was vacuous, the commit probe also sets it). */
 public class MapSaveLoad {
     public boolean regionDetectionComplete = true;
     public LeveledRegion<?> nextToLoadByViewing;
@@ -13,7 +17,9 @@ public class MapSaveLoad {
 
     public void requestLoad(MapRegion region, String reason) {
         this.loadRequests.add(region);
-        dev.vox.lss.compat.XaeroStubEvents.record("saveLoad.requestLoad " + reason);
+        region.canRequestReload = false; // models reloadHasBeenRequested
+        dev.vox.lss.compat.XaeroStubEvents.record("saveLoad.requestLoad " + reason
+                + (Boolean.TRUE.equals(region.beingWritten) ? " beingWritten" : " NOT-beingWritten"));
     }
 
     public LeveledRegion<?> getNextToLoadByViewing() { return this.nextToLoadByViewing; }

--- a/fabric/src/test/java/xaero/map/region/LeveledRegion.java
+++ b/fabric/src/test/java/xaero/map/region/LeveledRegion.java
@@ -2,11 +2,14 @@ package xaero.map.region;
 
 /** Tier-1 stub parent (the pacing gauge lives here in the real jar too; the real
  *  class is abstract with a RegionTexture-bounded type parameter — irrelevant to
- *  the resolved members). The gauge consult is EVENT-RECORDED: production must
- *  consult it BEFORE taking any region monitor (the real method synchronizes on
- *  its own — possibly BRANCH — region, and Xaero's loader thread nests
- *  parent-then-leaf, so consulting under a leaf monitor is a lock-order
- *  inversion; review MAJOR — a real client deadlock). */
+ *  the resolved members). Retained SOLELY for the negative pins: the gauge
+ *  consult is EVENT-RECORDED so tests can assert it is NEVER invoked (the real
+ *  method synchronizes on its own — possibly BRANCH — region, and Xaero's loader
+ *  thread nests parent-then-leaf, so consulting under a leaf monitor is a
+ *  lock-order inversion; review MAJOR — a real client deadlock). The paired
+ *  {@code setNextToLoadByViewing} token (stub MapSaveLoad) is likewise
+ *  never-called-pinned: the loader never reads it, only the four native
+ *  consumers' pacing does (3-Opus fold). */
 public class LeveledRegion<T> {
     public boolean allowAnotherRegionToLoad = true;
 

--- a/fabric/src/test/java/xaero/map/region/MapRegion.java
+++ b/fabric/src/test/java/xaero/map/region/MapRegion.java
@@ -10,6 +10,9 @@ public class MapRegion extends LeveledRegion<Object> {
     public boolean writingPaused;
     public byte loadState = 2;
     public boolean resting = true;
+    /** Models the real formula's pending-flags conjunct (!reloadHasBeenRequested
+     *  && !recacheHasBeenRequested && !isRefreshing) — the stub MapSaveLoad flips
+     *  it false on requestLoad, so a granted region honestly reads in-flight. */
     public boolean canRequestReload = true;
     public int visits;
     public Boolean beingWritten; // null until first set — pins "set true, never cleared"
@@ -35,11 +38,18 @@ public class MapRegion extends LeveledRegion<Object> {
         return this.loadState;
     }
 
-    public void setLoadState(byte state) { this.loadState = state; }
+    public void setLoadState(byte state) {
+        requireRegionMonitor("setLoadState");
+        this.loadState = state;
+        dev.vox.lss.compat.XaeroStubEvents.record("region.setLoadState " + state);
+    }
 
+    /** FAITHFUL formula (decompiled): loadState != 3 && != 1 && !recache — so a
+     *  cache-parked (3) region reads not-resting until the 3→4 revival, exactly
+     *  like the real loader's dead end. The manual field models the recache term. */
     public boolean isResting() {
         requireRegionMonitor("isResting");
-        return this.resting;
+        return this.resting && this.loadState != 3 && this.loadState != 1;
     }
 
     public void registerVisit() {
@@ -53,9 +63,12 @@ public class MapRegion extends LeveledRegion<Object> {
         dev.vox.lss.compat.XaeroStubEvents.record("region.setBeingWritten " + beingWritten);
     }
 
+    /** FAITHFUL formula (decompiled): pending-flags-clear && (ls 0 | 4 | 2-and-
+     *  beingWritten) — the memoryless window's honest in-flight predicate. */
     public boolean canRequestReload_unsynced() {
         requireRegionMonitor("canRequestReload_unsynced");
-        return this.canRequestReload;
+        return this.canRequestReload && (this.loadState == 0 || this.loadState == 4
+                || (this.loadState == 2 && Boolean.TRUE.equals(this.beingWritten)));
     }
 
     public void setAllCachePrepared(boolean prepared) {

--- a/xplat/src/main/java/dev/vox/lss/compat/XaeroMapCompat.java
+++ b/xplat/src/main/java/dev/vox/lss/compat/XaeroMapCompat.java
@@ -43,16 +43,20 @@ import java.util.function.BooleanSupplier;
  * the shared end-of-client-tick body, MAIN CLIENT THREAD (Xaero enforces it with
  * {@code isSameThread} throws) — re-runs the native writer's gate ladder
  * verbatim, then commits under Xaero's own locks in the decompiled
- * {@code MapWriter.writeChunk} sequence, including the mandatory paced
+ * {@code MapWriter.writeChunk} sequence, including the mandatory
  * {@code requestLoad} dance for regions Xaero hasn't loaded (fresh regions never
  * self-promote) and the set-never-clear {@code setBeingWritten} lifecycle (the
- * save path owns the reset). The load-pacing gauge is consulted ONCE per pump
- * BEFORE any region monitor — {@code shouldAllowAnotherRegionToLoad} synchronizes
- * on its own (possibly BRANCH) region, and Xaero's loader thread nests
- * parent-then-leaf, so consulting it while holding a leaf monitor is a
- * lock-order inversion (review MAJOR — a real client deadlock). GPU work stays
- * Xaero's: the bridge only flags {@code setToUpdateBuffers}, never calls
- * {@code updateBuffers}.
+ * save path owns the reset). The drain is REGION-BUCKETED with an
+ * outstanding-load window (plan §14): entries group by their Xaero map region
+ * (32×32 chunks — Xaero's consent granularity), loaded regions commit in
+ * clusters, and load requests go to the pending regions holding the most tiles,
+ * at most {@value #MAX_OUTSTANDING_LOADS} in flight. Xaero's own
+ * {@code shouldAllowAnotherRegionToLoad} gauge is deliberately NEVER consulted:
+ * it synchronizes on its own (possibly BRANCH) region — a lock-order inversion
+ * against Xaero's parent-then-leaf loader thread (review MAJOR, a real client
+ * deadlock) — and semantically it is just a 1-in-flight window, which the
+ * outstanding window generalizes. GPU work stays Xaero's: the bridge only flags
+ * {@code setToUpdateBuffers}, never calls {@code updateBuffers}.
  *
  * <p><b>Registration lifecycle</b> (review MAJOR): the consumer is what holds the
  * handshake's CAPABILITY_VOXEL_COLUMNS bit ({@code LSSApi.hasVoxelConsumers()}),
@@ -69,11 +73,11 @@ import java.util.function.BooleanSupplier;
  */
 final class XaeroMapCompat {
 
-    static final int MAX_QUEUE = 2048;
+    static final int MAX_QUEUE = 8192;
     /** Byte gauge companion to the count cap (the ClientColumnProcessor discipline —
      *  a count cap alone admits ~165 MB of max-overlay tiles; plain tiles are ~4.7 KB
      *  but ocean tiles carry per-pixel overlay runs). Estimated, not exact. */
-    static final long MAX_QUEUE_BYTES = 24L * 1024 * 1024;
+    static final long MAX_QUEUE_BYTES = 48L * 1024 * 1024;
     /** Safety ceiling only — the nanos budget below is the binding constraint
      *  (review MAJOR: 8 committed only 160 tiles/s against 300-1000 delivered
      *  columns/s, making every backfill drop most of the map). */
@@ -81,6 +85,11 @@ final class XaeroMapCompat {
     static final long PUMP_NANOS_BUDGET = 2_000_000L;
     /** Ladder-ready deferrals (busy region, PBO download) before an entry drops. */
     static final int DEFER_CAP = 200;
+    /** Our in-flight region-load window — the honest generalization of Xaero's own
+     *  1-in-flight gauge (plan §14): the loader drains unlimited CHEAP (virgin)
+     *  loads per cycle but only one expensive file load, so a small fixed window
+     *  self-clocks the request rate to the real drain rate. */
+    static final int MAX_OUTSTANDING_LOADS = 8;
     /** Consecutive failures (commit-side or extraction-side) before the bridge
      *  latches dead for the SESSION (re-armed at disconnect). */
     static final int THROW_LATCH = 5;
@@ -228,6 +237,11 @@ final class XaeroMapCompat {
     /** Rotating drain start (the IncomingRequestRouter M4 precedent): without it a
      *  permanently-deferring queue prefix starves committable entries forever. */
     private int drainRotation; // main thread only
+    /** Regions we have requested loads for whose loads have not landed — refreshed
+     *  each pump by intersecting with the still-pending buckets. Main thread only. */
+    private final java.util.LinkedHashSet<Long> outstandingLoads = new java.util.LinkedHashSet<>();
+    /** Regions with queued tiles awaiting their Xaero load, as of the last pump. */
+    private volatile int regionsWaiting;
 
     private static final class Entry {
         volatile XaeroTileExtractor.PreparedTile tile; // replaced under queueLock (latest wins)
@@ -277,6 +291,8 @@ final class XaeroMapCompat {
      */
     void onSessionEnd() {
         clearQueue();
+        this.outstandingLoads.clear();
+        this.regionsWaiting = 0;
         this.dead = false;
         this.consecutiveFailures = 0;
         this.consecutiveExtractFailures.set(0);
@@ -423,6 +439,14 @@ final class XaeroMapCompat {
         return this.dead;
     }
 
+    int regionsWaitingForTest() {
+        return this.regionsWaiting;
+    }
+
+    int outstandingLoadsForTest() {
+        return this.outstandingLoads.size();
+    }
+
     boolean registeredForTest() {
         return this.registered;
     }
@@ -451,7 +475,8 @@ final class XaeroMapCompat {
                 + ", defer_events=" + this.deferEvents.get()
                 + ", dropped=" + dropped
                 + ", commit_failures=" + this.commitFailures.get()
-                + ", load_requests=" + this.loadRequests.get();
+                + ", load_requests=" + this.loadRequests.get()
+                + ", regions_waiting=" + this.regionsWaiting;
     }
 
     // ---- the pump (main client thread) ----
@@ -515,33 +540,33 @@ final class XaeroMapCompat {
                 dimensionId = this.h.getCurrentDimensionId.invoke(mapWorld);
                 if (this.levelOps.dimension(world) != dimensionId) return;
             }
-            // The load-pacing gauge, consulted ONCE per pump and BEFORE any region
-            // monitor — the native shape (MapWriter.onRender computes it before its
-            // visit loop). shouldAllowAnotherRegionToLoad synchronizes on its own
-            // (possibly BRANCH) region while Xaero's loader thread nests
-            // parent-then-leaf, so calling it under a leaf monitor is a lock-order
-            // inversion and a real main-thread deadlock (review MAJOR).
-            boolean allowLoadRequest = shouldAllowAnotherLoad(saveLoad);
-            drainEntries(keys, mp, saveLoad, world, dimensionId, allowLoadRequest);
+            drainEntries(keys, mp, saveLoad, world, dimensionId);
         }
     }
 
+    /** One queue entry paired with its key for the bucketed drain. */
+    private record Pending(Long key, Entry entry, XaeroTileExtractor.PreparedTile tile) {}
+
+    /**
+     * The bucketed drain (the region-throughput round, plan §14). One pass over the
+     * snapshot groups entries by their Xaero MAP REGION (32×32 chunks — Xaero's
+     * consent granularity: no tile may commit until its region's save file is
+     * loaded). Then: COMMIT phase over region buckets (rotated — the
+     * IncomingRequestRouter M4 precedent), probing each region ONCE per pump and
+     * short-circuiting its whole bucket on a not-ready outcome (at large radius a
+     * spiral ring crosses ~r/4 regions, and per-entry probing burned the budget on
+     * thousands of identical AWAITING_LOAD answers); then the GRANT phase requests
+     * loads for the pending regions holding the MOST queued tiles, so each grant
+     * unlocks a whole cluster.
+     */
     private void drainEntries(List<Long> keys, Object mp, Object saveLoad,
-                              Object world, Object dimensionId,
-                              boolean allowLoadRequest) throws Throwable {
+                              Object world, Object dimensionId) throws Throwable {
         long start = System.nanoTime();
-        int commits = 0;
-        boolean loadRequestedThisPump = false;
-        // Rotate the drain start per pump (the IncomingRequestRouter M4 precedent):
-        // below queue saturation nothing evicts a permanently-deferring prefix, and
-        // an unrotated head-first walk would let it starve committable entries.
-        int size = keys.size();
-        int startIndex = size == 0 ? 0 : Math.floorMod(this.drainRotation++, size);
-        for (int n = 0; n < size; n++) {
-            if (commits >= MAX_COMMITS_PER_PUMP || System.nanoTime() - start > this.pumpNanosBudget) {
-                return;
-            }
-            Long key = keys.get((startIndex + n) % size);
+
+        // Bucket by region, filtering stale/native-owned entries (LevelOps only — no
+        // Xaero reflection in this walk). LinkedHashMap keeps spiral locality.
+        var buckets = new LinkedHashMap<Long, List<Pending>>();
+        for (Long key : keys) {
             Entry entry;
             synchronized (this.queueLock) {
                 entry = this.queue.get(key);
@@ -561,34 +586,124 @@ final class XaeroMapCompat {
                 this.skippedNative.incrementAndGet();
                 continue;
             }
-            var outcome = commitEntry(mp, saveLoad, tile,
-                    allowLoadRequest && !loadRequestedThisPump);
-            switch (outcome) {
-                case COMMITTED -> {
-                    removeIfCurrent(key, entry, tile);
-                    this.written.incrementAndGet();
-                    this.consecutiveFailures = 0;
-                    commits++;
+            long regionKey = (((long) (tile.chunkX() >> 5)) << 32)
+                    | ((tile.chunkZ() >> 5) & 0xFFFFFFFFL);
+            buckets.computeIfAbsent(regionKey, k -> new ArrayList<>())
+                    .add(new Pending(key, entry, tile));
+        }
+
+        // COMMIT phase: rotate over buckets; one region probe per bucket per pump.
+        var bucketKeys = new ArrayList<>(buckets.keySet());
+        var pendingLoad = new LinkedHashMap<Long, List<Pending>>(); // regions awaiting load
+        int commits = 0;
+        int size = bucketKeys.size();
+        int startIndex = size == 0 ? 0 : Math.floorMod(this.drainRotation++, size);
+        bucketLoop:
+        for (int n = 0; n < size; n++) {
+            if (commits >= MAX_COMMITS_PER_PUMP || System.nanoTime() - start > this.pumpNanosBudget) {
+                break;
+            }
+            Long regionKey = bucketKeys.get((startIndex + n) % size);
+            var bucket = buckets.get(regionKey);
+            for (var pending : bucket) {
+                if (commits >= MAX_COMMITS_PER_PUMP
+                        || System.nanoTime() - start > this.pumpNanosBudget) {
+                    break bucketLoop;
                 }
-                case AWAITING_LOAD_REQUESTED -> {
-                    loadRequestedThisPump = true;
-                    this.deferEvents.incrementAndGet();
-                }
-                case AWAITING_LOAD -> this.deferEvents.incrementAndGet();
-                case DEFERRED -> {
-                    // Ladder was ready but the region/tile-chunk wasn't — this is the
-                    // only defer flavor that burns the per-entry budget (plan §2.7).
-                    this.deferEvents.incrementAndGet();
-                    if (++entry.ladderReadyDeferrals > DEFER_CAP) {
-                        removeIfCurrent(key, entry, tile);
-                        this.droppedExpired.incrementAndGet();
+                var outcome = commitEntry(mp, pending.tile());
+                switch (outcome) {
+                    case COMMITTED -> {
+                        removeIfCurrent(pending.key(), pending.entry(), pending.tile());
+                        this.written.incrementAndGet();
+                        this.consecutiveFailures = 0;
+                        commits++;
+                    }
+                    case AWAITING_LOAD -> {
+                        // The whole bucket shares this region's state: one defer event
+                        // per BUCKET per pump (no per-entry probe churn), the entries
+                        // stay queued, the region goes to the grant phase.
+                        this.deferEvents.incrementAndGet();
+                        pendingLoad.put(regionKey, bucket);
+                        continue bucketLoop;
+                    }
+                    case DEFERRED -> {
+                        // Ladder was ready but the LOADED region/tile-chunk was busy —
+                        // the only defer flavor that burns the deferral budget (plan
+                        // §2.7). The whole bucket shares the state: burn each entry's
+                        // counter once (cap semantics preserved) and move on.
+                        this.deferEvents.incrementAndGet();
+                        for (var p : bucket) {
+                            if (++p.entry().ladderReadyDeferrals > DEFER_CAP) {
+                                removeIfCurrent(p.key(), p.entry(), p.tile());
+                                this.droppedExpired.incrementAndGet();
+                            }
+                        }
+                        continue bucketLoop;
+                    }
+                    case FAILED -> {
+                        // Possibly entry-specific (a hostile state) — drop it and keep
+                        // trying the bucket's siblings unless the latch fired.
+                        removeIfCurrent(pending.key(), pending.entry(), pending.tile());
+                        if (this.dead) return;
                     }
                 }
-                case FAILED -> {
-                    removeIfCurrent(key, entry, tile);
-                    if (this.dead) return;
-                }
             }
+        }
+        this.regionsWaiting = pendingLoad.size();
+
+        // GRANT phase: refresh the outstanding window (a region no longer pending —
+        // loaded, or its tiles all evicted — frees its slot), then request loads for
+        // the pending regions with the MOST queued tiles, so each grant unlocks a
+        // whole cluster. The window (≤ MAX_OUTSTANDING_LOADS) is the honest
+        // generalization of Xaero's own 1-in-flight gauge: the loader drains
+        // unlimited CHEAP (virgin-region) loads per cycle but only one expensive
+        // file load, so request rate self-clocks to the real drain rate.
+        this.outstandingLoads.retainAll(pendingLoad.keySet());
+        if (this.outstandingLoads.size() >= MAX_OUTSTANDING_LOADS) return;
+        var byValue = new ArrayList<>(pendingLoad.entrySet());
+        byValue.sort((a, b) -> Integer.compare(b.getValue().size(), a.getValue().size()));
+        for (var candidate : byValue) {
+            if (this.outstandingLoads.size() >= MAX_OUTSTANDING_LOADS) return;
+            Long regionKey = candidate.getKey();
+            if (this.outstandingLoads.contains(regionKey)) continue;
+            if (requestRegionLoad(mp, saveLoad, regionKey)) {
+                this.outstandingLoads.add(regionKey);
+                this.loadRequests.incrementAndGet();
+            }
+        }
+    }
+
+    /**
+     * The native writer's load-request dance for one region (MapWriter:340-348 —
+     * region monitor only): setBeingWritten-BEFORE-request is load-bearing (it stops
+     * the load drain demoting an empty fresh region), and requestLoad front-inserts
+     * with priority (verified: the 2-arg overload passes prioritize=true, which also
+     * bypasses the loader's mid-drain add guard). setNextToLoadByViewing keeps
+     * Xaero's shared admission bookkeeping honest — the NATIVE writer's own gauge
+     * consult sees our pending load and politely defers its next request. NB:
+     * requestLoad is main-thread-only despite its queue-add look — its tail runs a
+     * highlight prepare that hard-throws off Minecraft.isSameThread().
+     */
+    private boolean requestRegionLoad(Object mp, Object saveLoad, long regionKey) {
+        try {
+            int regionX = (int) (regionKey >> 32);
+            int regionZ = (int) regionKey;
+            Object region = this.h.getLeafMapRegion.invoke(mp, SURFACE_LAYER,
+                    regionX, regionZ, true);
+            if (region == null) return false;
+            synchronized (region) {
+                if ((byte) this.h.getLoadState.invoke(region) == 2) return false;
+                if (!(boolean) this.h.isResting.invoke(region)) return false;
+                if (!(boolean) this.h.canRequestReload.invoke(region)) return false;
+                this.h.setBeingWritten.invoke(region, true);
+                this.h.requestLoad.invoke(saveLoad, region, "lss-xaero-bridge");
+                this.h.setNextToLoadByViewing.invoke(saveLoad, region);
+                return true;
+            }
+        } catch (Throwable t) {
+            if (t instanceof Error err && !(t instanceof AssertionError)) throw err;
+            noteFailure(t);
+            return false;
         }
     }
 
@@ -615,20 +730,18 @@ final class XaeroMapCompat {
         return true;
     }
 
-    private enum Outcome { COMMITTED, DEFERRED, AWAITING_LOAD, AWAITING_LOAD_REQUESTED, FAILED }
+    private enum Outcome { COMMITTED, DEFERRED, AWAITING_LOAD, FAILED }
 
     /**
      * One entry against its region — the decompiled {@code MapWriter.writeChunk}
      * region discipline: {@code writerThreadPauseSync} + {@code !isWritingPaused()}
      * (the save-race exclusion), the region monitor for load-state/visit/resting,
      * {@code setBeingWritten(true)} set and NEVER cleared by us (save-eligibility —
-     * the save path owns the reset), the paced {@code requestLoad} dance for
-     * unloaded regions, tile-chunk creation with its cache flags, then the pixel
-     * commit.
+     * the save path owns the reset), tile-chunk creation with its cache flags, then
+     * the pixel commit. Load REQUESTS live in the grant phase
+     * ({@link #requestRegionLoad}) — an unloaded region answers AWAITING_LOAD here.
      */
-    private Outcome commitEntry(Object mp, Object saveLoad,
-                                XaeroTileExtractor.PreparedTile tile,
-                                boolean allowLoadRequest) {
+    private Outcome commitEntry(Object mp, XaeroTileExtractor.PreparedTile tile) {
         try {
             int chunkX = tile.chunkX();
             int chunkZ = tile.chunkZ();
@@ -664,20 +777,9 @@ final class XaeroMapCompat {
                         }
                     }
                     if (!proper) {
-                        // The mandatory load dance (fresh regions NEVER self-promote to
-                        // loadState 2): setBeingWritten-BEFORE-request is load-bearing —
-                        // it stops the load drain demoting an empty fresh region. The
-                        // pacing gauge was consulted OUTSIDE region monitors (see
-                        // pumpLadder). NB: requestLoad is main-thread-only despite its
-                        // queue-add look — its tail runs a highlight prepare that
-                        // hard-throws off Minecraft.isSameThread().
-                        if (resting && allowLoadRequest
-                                && (boolean) this.h.canRequestReload.invoke(region)) {
-                            this.h.requestLoad.invoke(saveLoad, region, "lss-xaero-bridge");
-                            this.h.setNextToLoadByViewing.invoke(saveLoad, region);
-                            this.loadRequests.incrementAndGet();
-                            return Outcome.AWAITING_LOAD_REQUESTED;
-                        }
+                        // Fresh regions NEVER self-promote to loadState 2 — the grant
+                        // phase requests the load; this entry (and its whole bucket)
+                        // just waits.
                         return Outcome.AWAITING_LOAD;
                     }
                 }
@@ -695,12 +797,6 @@ final class XaeroMapCompat {
             noteFailure(t);
             return Outcome.FAILED;
         }
-    }
-
-    private boolean shouldAllowAnotherLoad(Object saveLoad) throws Throwable {
-        Object nextToLoad = this.h.getNextToLoadByViewing.invoke(saveLoad);
-        return nextToLoad == null
-                || (boolean) this.h.shouldAllowAnotherRegionToLoad.invoke(nextToLoad);
     }
 
     /** The decompiled per-tile commit sequence, verbatim order (plan §1). */
@@ -811,9 +907,7 @@ final class XaeroMapCompat {
         final MethodHandle getCurrentDimensionId;
         final MethodHandle isRegionDetectionComplete;
         final MethodHandle requestLoad;
-        final MethodHandle getNextToLoadByViewing;
         final MethodHandle setNextToLoadByViewing;
-        final MethodHandle shouldAllowAnotherRegionToLoad;
         final MethodHandle writerThreadPauseSync;
         final MethodHandle regionIsWritingPaused;
         final MethodHandle getLoadState;
@@ -930,14 +1024,9 @@ final class XaeroMapCompat {
             this.requestLoad = lookup.findVirtual(saveLoadClass, "requestLoad",
                             MethodType.methodType(void.class, regionClass, String.class))
                     .asType(MethodType.methodType(void.class, Object.class, Object.class, String.class));
-            this.getNextToLoadByViewing = virtual(lookup, saveLoadClass, "getNextToLoadByViewing",
-                    MethodType.methodType(leveledRegionClass), Object.class);
             this.setNextToLoadByViewing = lookup.findVirtual(saveLoadClass, "setNextToLoadByViewing",
                             MethodType.methodType(void.class, leveledRegionClass))
                     .asType(MethodType.methodType(void.class, Object.class, Object.class));
-            this.shouldAllowAnotherRegionToLoad = virtual(lookup, leveledRegionClass,
-                    "shouldAllowAnotherRegionToLoad",
-                    MethodType.methodType(boolean.class), boolean.class);
 
             this.writerThreadPauseSync = getter(lookup, regionClass, "writerThreadPauseSync");
             this.regionIsWritingPaused = virtual(lookup, regionClass, "isWritingPaused",

--- a/xplat/src/main/java/dev/vox/lss/compat/XaeroMapCompat.java
+++ b/xplat/src/main/java/dev/vox/lss/compat/XaeroMapCompat.java
@@ -46,16 +46,23 @@ import java.util.function.BooleanSupplier;
  * {@code MapWriter.writeChunk} sequence, including the mandatory
  * {@code requestLoad} dance for regions Xaero hasn't loaded (fresh regions never
  * self-promote) and the set-never-clear {@code setBeingWritten} lifecycle (the
- * save path owns the reset). The drain is REGION-BUCKETED with an
- * outstanding-load window (plan §14): entries group by their Xaero map region
- * (32×32 chunks — Xaero's consent granularity), loaded regions commit in
- * clusters, and load requests go to the pending regions holding the most tiles,
- * at most {@value #MAX_OUTSTANDING_LOADS} in flight. Xaero's own
- * {@code shouldAllowAnotherRegionToLoad} gauge is deliberately NEVER consulted:
- * it synchronizes on its own (possibly BRANCH) region — a lock-order inversion
- * against Xaero's parent-then-leaf loader thread (review MAJOR, a real client
- * deadlock) — and semantically it is just a 1-in-flight window, which the
- * outstanding window generalizes. GPU work stays Xaero's: the bridge only flags
+ * save path owns the reset). The drain is REGION-BUCKETED with a MEMORYLESS
+ * outstanding-load window (plan §14 as reshaped by the 3-Opus fold): entries
+ * group by their Xaero map region (32×32 chunks — Xaero's consent granularity),
+ * loaded regions commit in clusters, and load requests go to the pending regions
+ * holding the most tiles, at most {@value #MAX_OUTSTANDING_LOADS} in flight —
+ * where "in flight" is recognized fresh each pump from Xaero's OWN state
+ * ({@code canRequestReload_unsynced()} is false exactly while a request is
+ * queued/loading/refreshing), never from a bookkeeping set that could leak
+ * against the loader's dead-end outcomes. Xaero's shared load-pacing surface is
+ * deliberately untouched in BOTH directions: {@code shouldAllowAnotherRegionToLoad}
+ * is never consulted (it synchronizes on its own — possibly BRANCH — region, a
+ * lock-order inversion against Xaero's parent-then-leaf loader thread; review
+ * MAJOR, a real client deadlock), and {@code setNextToLoadByViewing} is never
+ * called (the loader itself never reads it — it is purely the pacing token of
+ * the four native consumers, and pointing it at a far bridge region vetoed all
+ * four; left alone, native requests front-insert AHEAD of our batch, the right
+ * priority). GPU work stays Xaero's: the bridge only flags
  * {@code setToUpdateBuffers}, never calls {@code updateBuffers}.
  *
  * <p><b>Registration lifecycle</b> (review MAJOR): the consumer is what holds the
@@ -75,8 +82,9 @@ final class XaeroMapCompat {
 
     static final int MAX_QUEUE = 8192;
     /** Byte gauge companion to the count cap (the ClientColumnProcessor discipline —
-     *  a count cap alone admits ~165 MB of max-overlay tiles; plain tiles are ~4.7 KB
-     *  but ocean tiles carry per-pixel overlay runs). Estimated, not exact. */
+     *  a count cap alone admits ~0.5 GB of max-overlay tiles at ~68 KB each; plain
+     *  tiles are ~4.7 KB but ocean tiles carry per-pixel overlay runs). Estimated,
+     *  not exact. */
     static final long MAX_QUEUE_BYTES = 48L * 1024 * 1024;
     /** Safety ceiling only — the nanos budget below is the binding constraint
      *  (review MAJOR: 8 committed only 160 tiles/s against 300-1000 delivered
@@ -87,8 +95,13 @@ final class XaeroMapCompat {
     static final int DEFER_CAP = 200;
     /** Our in-flight region-load window — the honest generalization of Xaero's own
      *  1-in-flight gauge (plan §14): the loader drains unlimited CHEAP (virgin)
-     *  loads per cycle but only one expensive file load, so a small fixed window
-     *  self-clocks the request rate to the real drain rate. */
+     *  loads per cycle but only one expensive file load (~10/s), so a small fixed
+     *  window self-clocks the request rate to the real drain rate. In-flight is
+     *  derived fresh each pump from {@code canRequestReload_unsynced()} — see
+     *  {@link #grantLoads}. Budget-truncated pumps may under-count in-flight
+     *  regions (unprobed buckets are unknown), transiently over-granting by at
+     *  most one window per pump; requests are idempotent (an already-queued
+     *  region answers not-requestable), so the excess is bounded and harmless. */
     static final int MAX_OUTSTANDING_LOADS = 8;
     /** Consecutive failures (commit-side or extraction-side) before the bridge
      *  latches dead for the SESSION (re-armed at disconnect). */
@@ -237,17 +250,18 @@ final class XaeroMapCompat {
     /** Rotating drain start (the IncomingRequestRouter M4 precedent): without it a
      *  permanently-deferring queue prefix starves committable entries forever. */
     private int drainRotation; // main thread only
-    /** Regions we have requested loads for whose loads have not landed — refreshed
-     *  each pump by intersecting with the still-pending buckets. Main thread only. */
-    private final java.util.LinkedHashSet<Long> outstandingLoads = new java.util.LinkedHashSet<>();
-    /** Regions with queued tiles awaiting their Xaero load, as of the last pump. */
+    /** Regions with queued tiles awaiting their Xaero load, as PROBED by the last
+     *  pump — a diag gauge, and a lower bound under budget truncation (buckets the
+     *  commit loop never reached are unknown). */
     private volatile int regionsWaiting;
 
     private static final class Entry {
         volatile XaeroTileExtractor.PreparedTile tile; // replaced under queueLock (latest wins)
         final Object dimension;
         int bytes; // under queueLock
-        int ladderReadyDeferrals; // main thread only
+        /** Pump-side (++) with a decode-side reset on tile replace — the race is
+         *  benign (one deferral tick lost or kept; the cap is approximate). */
+        int ladderReadyDeferrals;
 
         Entry(Object dimension, XaeroTileExtractor.PreparedTile tile, int bytes) {
             this.dimension = dimension;
@@ -291,7 +305,6 @@ final class XaeroMapCompat {
      */
     void onSessionEnd() {
         clearQueue();
-        this.outstandingLoads.clear();
         this.regionsWaiting = 0;
         this.dead = false;
         this.consecutiveFailures = 0;
@@ -374,6 +387,7 @@ final class XaeroMapCompat {
                     this.queuedBytes += bytes - existing.bytes;
                     existing.tile = tile;
                     existing.bytes = bytes;
+                    existing.ladderReadyDeferrals = 0; // fresh serve = fresh patience
                     return;
                 }
                 // Stale-dimension entry: the new serve replaces it (fresh Entry, so
@@ -405,15 +419,19 @@ final class XaeroMapCompat {
      * Remove only if the entry AND its tile are still the ones this pump pass
      * examined — a plain remove would silently delete a fresher tile (or a
      * replacement Entry) the decode thread installed mid-commit (review MINOR:
-     * the latest-wins guarantee must survive the commit window).
+     * the latest-wins guarantee must survive the commit window). Returns whether
+     * the removal actually happened, so drop counters count DROPS, not attempts
+     * (3-Opus fold: a survived entry must not re-count every pump).
      */
-    private void removeIfCurrent(Long key, Entry entry, XaeroTileExtractor.PreparedTile tile) {
+    private boolean removeIfCurrent(Long key, Entry entry, XaeroTileExtractor.PreparedTile tile) {
         synchronized (this.queueLock) {
             var current = this.queue.get(key);
             if (current == entry && entry.tile == tile) {
                 this.queuedBytes -= entry.bytes;
                 this.queue.remove(key);
+                return true;
             }
+            return false;
         }
     }
 
@@ -441,10 +459,6 @@ final class XaeroMapCompat {
 
     int regionsWaitingForTest() {
         return this.regionsWaiting;
-    }
-
-    int outstandingLoadsForTest() {
-        return this.outstandingLoads.size();
     }
 
     boolean registeredForTest() {
@@ -488,16 +502,17 @@ final class XaeroMapCompat {
             clearQueue(); // the live toggle: flipping off drops the backlog immediately
             return;
         }
-        List<Long> keys;
         synchronized (this.queueLock) {
-            if (this.queue.isEmpty()) return;
-            keys = new ArrayList<>(this.queue.keySet());
+            if (this.queue.isEmpty()) {
+                this.regionsWaiting = 0;
+                return;
+            }
         }
         try {
             // No blanket failure-count reset here: commit failures are contained per
             // entry inside the drain, so the ladder returning normally proves nothing —
             // only a successful COMMIT resets the death-latch count.
-            pumpLadder(keys);
+            pumpLadder();
         } catch (Throwable t) {
             if (t instanceof Error err && !(t instanceof AssertionError)) throw err;
             noteFailure(t);
@@ -511,7 +526,7 @@ final class XaeroMapCompat {
      * THE anti-wrong-dimension binding: like Xaero's own writer, commits pause
      * while the user browses another dimension's map.
      */
-    private void pumpLadder(List<Long> keys) throws Throwable {
+    private void pumpLadder() throws Throwable {
         Object session = this.h.getCurrentSession.invoke();
         if (session == null || !(boolean) this.h.sessionIsUsable.invoke(session)) return;
         Object mp = this.h.getMapProcessor.invoke(session);
@@ -540,76 +555,85 @@ final class XaeroMapCompat {
                 dimensionId = this.h.getCurrentDimensionId.invoke(mapWorld);
                 if (this.levelOps.dimension(world) != dimensionId) return;
             }
-            drainEntries(keys, mp, saveLoad, world, dimensionId);
+            drainEntries(mp, saveLoad, world, dimensionId);
         }
     }
 
     /** One queue entry paired with its key for the bucketed drain. */
     private record Pending(Long key, Entry entry, XaeroTileExtractor.PreparedTile tile) {}
 
+    /** A region probed this pump whose bucket is awaiting its Xaero load — the
+     *  verdict is Xaero's own state, read inside the probe's region monitor. */
+    private record WaitingRegion(long regionKey, int tiles, Outcome verdict) {}
+
     /**
-     * The bucketed drain (the region-throughput round, plan §14). One pass over the
-     * snapshot groups entries by their Xaero MAP REGION (32×32 chunks — Xaero's
-     * consent granularity: no tile may commit until its region's save file is
-     * loaded). Then: COMMIT phase over region buckets (rotated — the
-     * IncomingRequestRouter M4 precedent), probing each region ONCE per pump and
-     * short-circuiting its whole bucket on a not-ready outcome (at large radius a
-     * spiral ring crosses ~r/4 regions, and per-entry probing burned the budget on
-     * thousands of identical AWAITING_LOAD answers); then the GRANT phase requests
-     * loads for the pending regions holding the MOST queued tiles, so each grant
-     * unlocks a whole cluster.
+     * The bucketed drain (the region-throughput round, plan §14 as reshaped by the
+     * 3-Opus fold). ONE queue-lock snapshot, then a pure-arithmetic grouping by
+     * Xaero MAP REGION (32×32 chunks — Xaero's consent granularity: no tile may
+     * commit until its region's save file is loaded; the old per-entry re-fetch
+     * paid a lock acquisition per queued entry and ran the chunk-lookup filters
+     * OUTSIDE the nanos budget — the live-lock MAJOR). Then: COMMIT phase over
+     * region buckets (rotated — the IncomingRequestRouter M4 precedent), the
+     * stale-dimension/natively-writable filters running per entry INSIDE the
+     * budgeted loop, probing each region ONCE per pump and short-circuiting its
+     * whole bucket on a region-scoped not-ready outcome (at large radius a spiral
+     * ring crosses ~r/4 regions, and per-entry probing burned the budget on
+     * thousands of identical awaiting-load answers); then the GRANT phase
+     * ({@link #grantLoads}). The budget check is skipped until the pump has made
+     * at least ONE unit of progress (a drop or a commit attempt), so even a
+     * degenerate budget drains the queue over pumps instead of live-locking.
      */
-    private void drainEntries(List<Long> keys, Object mp, Object saveLoad,
+    private void drainEntries(Object mp, Object saveLoad,
                               Object world, Object dimensionId) throws Throwable {
         long start = System.nanoTime();
 
-        // Bucket by region, filtering stale/native-owned entries (LevelOps only — no
-        // Xaero reflection in this walk). LinkedHashMap keeps spiral locality.
-        var buckets = new LinkedHashMap<Long, List<Pending>>();
-        for (Long key : keys) {
-            Entry entry;
-            synchronized (this.queueLock) {
-                entry = this.queue.get(key);
+        List<Pending> snapshot;
+        synchronized (this.queueLock) {
+            snapshot = new ArrayList<>(this.queue.size());
+            for (var e : this.queue.entrySet()) {
+                snapshot.add(new Pending(e.getKey(), e.getValue(), e.getValue().tile));
             }
-            if (entry == null) continue;
-            var tile = entry.tile;
-            if (entry.dimension != dimensionId) {
-                // Can never become valid — the pump-side stale-dimension drop (plan §2.5).
-                removeIfCurrent(key, entry, tile);
-                this.droppedStale.incrementAndGet();
-                continue;
-            }
-            if (nativelyWritable(world, tile.chunkX(), tile.chunkZ())) {
-                // The native writer owns these chunks and rewrites them on its
-                // clean-flag anyway — never fight it (plan §2.6).
-                removeIfCurrent(key, entry, tile);
-                this.skippedNative.incrementAndGet();
-                continue;
-            }
-            long regionKey = (((long) (tile.chunkX() >> 5)) << 32)
-                    | ((tile.chunkZ() >> 5) & 0xFFFFFFFFL);
-            buckets.computeIfAbsent(regionKey, k -> new ArrayList<>())
-                    .add(new Pending(key, entry, tile));
+        }
+        var buckets = new LinkedHashMap<Long, List<Pending>>(); // keeps spiral locality
+        for (var pending : snapshot) {
+            long regionKey = (((long) (pending.tile().chunkX() >> 5)) << 32)
+                    | ((pending.tile().chunkZ() >> 5) & 0xFFFFFFFFL);
+            buckets.computeIfAbsent(regionKey, k -> new ArrayList<>()).add(pending);
         }
 
-        // COMMIT phase: rotate over buckets; one region probe per bucket per pump.
         var bucketKeys = new ArrayList<>(buckets.keySet());
-        var pendingLoad = new LinkedHashMap<Long, List<Pending>>(); // regions awaiting load
+        var waiting = new ArrayList<WaitingRegion>();
         int commits = 0;
+        boolean progressed = false;
         int size = bucketKeys.size();
         int startIndex = size == 0 ? 0 : Math.floorMod(this.drainRotation++, size);
         bucketLoop:
         for (int n = 0; n < size; n++) {
-            if (commits >= MAX_COMMITS_PER_PUMP || System.nanoTime() - start > this.pumpNanosBudget) {
-                break;
-            }
             Long regionKey = bucketKeys.get((startIndex + n) % size);
             var bucket = buckets.get(regionKey);
             for (var pending : bucket) {
-                if (commits >= MAX_COMMITS_PER_PUMP
-                        || System.nanoTime() - start > this.pumpNanosBudget) {
+                if (progressed && (commits >= MAX_COMMITS_PER_PUMP
+                        || System.nanoTime() - start > this.pumpNanosBudget)) {
                     break bucketLoop;
                 }
+                if (pending.entry().dimension != dimensionId) {
+                    // Can never become valid — the pump-side stale-dimension drop (§2.5).
+                    if (removeIfCurrent(pending.key(), pending.entry(), pending.tile())) {
+                        this.droppedStale.incrementAndGet();
+                    }
+                    progressed = true;
+                    continue;
+                }
+                if (nativelyWritable(world, pending.tile().chunkX(), pending.tile().chunkZ())) {
+                    // The native writer owns these chunks and rewrites them on its
+                    // clean-flag anyway — never fight it (plan §2.6).
+                    if (removeIfCurrent(pending.key(), pending.entry(), pending.tile())) {
+                        this.skippedNative.incrementAndGet();
+                    }
+                    progressed = true;
+                    continue;
+                }
+                progressed = true;
                 var outcome = commitEntry(mp, pending.tile());
                 switch (outcome) {
                     case COMMITTED -> {
@@ -618,26 +642,38 @@ final class XaeroMapCompat {
                         this.consecutiveFailures = 0;
                         commits++;
                     }
-                    case AWAITING_LOAD -> {
-                        // The whole bucket shares this region's state: one defer event
-                        // per BUCKET per pump (no per-entry probe churn), the entries
-                        // stay queued, the region goes to the grant phase.
+                    case DEFERRED_TILE -> {
+                        // TILE-CHUNK-scoped busy (its 4×4 loadState / PBO download):
+                        // the region is fine, so siblings keep committing and only
+                        // THIS entry's patience burns (3-Opus fold MAJOR: the
+                        // region-wide burn expired whole buckets over one busy
+                        // tile chunk).
                         this.deferEvents.incrementAndGet();
-                        pendingLoad.put(regionKey, bucket);
-                        continue bucketLoop;
+                        if (++pending.entry().ladderReadyDeferrals > DEFER_CAP
+                                && removeIfCurrent(pending.key(), pending.entry(), pending.tile())) {
+                            this.droppedExpired.incrementAndGet();
+                        }
                     }
                     case DEFERRED -> {
-                        // Ladder was ready but the LOADED region/tile-chunk was busy —
-                        // the only defer flavor that burns the deferral budget (plan
-                        // §2.7). The whole bucket shares the state: burn each entry's
-                        // counter once (cap semantics preserved) and move on.
+                        // REGION-scoped busy (being saved / not resting): the whole
+                        // bucket shares the state — burn each entry's counter once
+                        // (cap semantics preserved) and move on.
                         this.deferEvents.incrementAndGet();
                         for (var p : bucket) {
-                            if (++p.entry().ladderReadyDeferrals > DEFER_CAP) {
-                                removeIfCurrent(p.key(), p.entry(), p.tile());
+                            if (++p.entry().ladderReadyDeferrals > DEFER_CAP
+                                    && removeIfCurrent(p.key(), p.entry(), p.tile())) {
                                 this.droppedExpired.incrementAndGet();
                             }
                         }
+                        continue bucketLoop;
+                    }
+                    case AWAITING_REQUESTABLE, AWAITING_PARKED, AWAITING_IN_FLIGHT -> {
+                        // The whole bucket waits on this region's load: one defer
+                        // event per BUCKET per pump, entries stay queued (awaiting-
+                        // load is exempt from the deferral cap), and the verdict
+                        // feeds the grant phase's memoryless window.
+                        this.deferEvents.incrementAndGet();
+                        waiting.add(new WaitingRegion(regionKey, bucket.size(), outcome));
                         continue bucketLoop;
                     }
                     case FAILED -> {
@@ -649,25 +685,44 @@ final class XaeroMapCompat {
                 }
             }
         }
-        this.regionsWaiting = pendingLoad.size();
+        this.regionsWaiting = waiting.size();
+        grantLoads(mp, saveLoad, waiting);
+    }
 
-        // GRANT phase: refresh the outstanding window (a region no longer pending —
-        // loaded, or its tiles all evicted — frees its slot), then request loads for
-        // the pending regions with the MOST queued tiles, so each grant unlocks a
-        // whole cluster. The window (≤ MAX_OUTSTANDING_LOADS) is the honest
-        // generalization of Xaero's own 1-in-flight gauge: the loader drains
-        // unlimited CHEAP (virgin-region) loads per cycle but only one expensive
-        // file load, so request rate self-clocks to the real drain rate.
-        this.outstandingLoads.retainAll(pendingLoad.keySet());
-        if (this.outstandingLoads.size() >= MAX_OUTSTANDING_LOADS) return;
-        var byValue = new ArrayList<>(pendingLoad.entrySet());
-        byValue.sort((a, b) -> Integer.compare(b.getValue().size(), a.getValue().size()));
-        for (var candidate : byValue) {
-            if (this.outstandingLoads.size() >= MAX_OUTSTANDING_LOADS) return;
-            Long regionKey = candidate.getKey();
-            if (this.outstandingLoads.contains(regionKey)) continue;
-            if (requestRegionLoad(mp, saveLoad, regionKey)) {
-                this.outstandingLoads.add(regionKey);
+    /**
+     * The GRANT phase: request Xaero loads for waiting regions, at most
+     * {@value #MAX_OUTSTANDING_LOADS} in flight. The window is MEMORYLESS —
+     * in-flight regions are recognized each pump from Xaero's own
+     * {@code canRequestReload_unsynced()} (false exactly while a request is
+     * queued/loading/refreshing), read under the region monitor by the commit
+     * probe. No bookkeeping set to leak (3-Opus fold MAJORs): the loader's
+     * dead-end load outcomes all come back requestable by themselves — a failed
+     * or empty load ends in {@code removeMapRegion}, and the next probe's
+     * {@code getLeafMapRegion(create=true)} hands back a FRESH loadState-0
+     * region; a cache-only load parks at loadState 3 and is revived via Xaero's
+     * own 3→4 transition (the {@code clearRegion} idiom) in
+     * {@link #requestRegionLoad}. Requests go to the largest pending clusters,
+     * ISSUED smallest-first: the loader drains {@code toLoad.get(0)} against our
+     * priority front-inserts (LIFO), so the largest cluster must be the FINAL
+     * front-insert to drain first. Cost is bounded: ≤{@value #MAX_OUTSTANDING_LOADS}
+     * requestLoad calls per pump (each runs Xaero's main-thread highlight
+     * prepare), and in steady state the window self-clocks near the loader's
+     * real expensive-load drain rate (~10/s at the 100 ms MapRunner cadence).
+     */
+    private void grantLoads(Object mp, Object saveLoad, List<WaitingRegion> waiting) {
+        int inFlight = 0;
+        var candidates = new ArrayList<WaitingRegion>();
+        for (var w : waiting) {
+            if (w.verdict() == Outcome.AWAITING_IN_FLIGHT) inFlight++;
+            else candidates.add(w);
+        }
+        int budget = MAX_OUTSTANDING_LOADS - inFlight;
+        if (budget <= 0 || candidates.isEmpty()) return;
+        candidates.sort((a, b) -> Integer.compare(b.tiles(), a.tiles()));
+        var chosen = candidates.subList(0, Math.min(budget, candidates.size()));
+        for (int i = chosen.size() - 1; i >= 0; i--) {
+            if (this.dead) return;
+            if (requestRegionLoad(mp, saveLoad, chosen.get(i).regionKey())) {
                 this.loadRequests.incrementAndGet();
             }
         }
@@ -678,11 +733,19 @@ final class XaeroMapCompat {
      * region monitor only): setBeingWritten-BEFORE-request is load-bearing (it stops
      * the load drain demoting an empty fresh region), and requestLoad front-inserts
      * with priority (verified: the 2-arg overload passes prioritize=true, which also
-     * bypasses the loader's mid-drain add guard). setNextToLoadByViewing keeps
-     * Xaero's shared admission bookkeeping honest — the NATIVE writer's own gauge
-     * consult sees our pending load and politely defers its next request. NB:
-     * requestLoad is main-thread-only despite its queue-add look — its tail runs a
-     * highlight prepare that hard-throws off Minecraft.isSameThread().
+     * bypasses the loader's mid-drain add guard). A cache-parked region (loadState 3
+     * — the loader's cache-only dead end, where isResting AND canRequestReload are
+     * both false forever) is first revived via Xaero's own 3→4 transition (the
+     * {@code clearRegion} idiom, the SP-bridge-proven revival), and RESTORED to 3 if
+     * the guards still refuse — pending native work owns it. {@code
+     * setNextToLoadByViewing} is deliberately NOT called (3-Opus fold): the loader
+     * never reads it — it is purely the pacing token of Xaero's four native
+     * consumers (writer/minimap/GUI/reloader), and pointing it at a far bridge
+     * region vetoed all four for multi-second stretches after each granted region's
+     * save; left alone, the native writer's own requests front-insert AHEAD of our
+     * batch, which is the right priority. NB: requestLoad is main-thread-only
+     * despite its queue-add look — its tail runs a highlight prepare that
+     * hard-throws off Minecraft.isSameThread().
      */
     private boolean requestRegionLoad(Object mp, Object saveLoad, long regionKey) {
         try {
@@ -692,12 +755,20 @@ final class XaeroMapCompat {
                     regionX, regionZ, true);
             if (region == null) return false;
             synchronized (region) {
-                if ((byte) this.h.getLoadState.invoke(region) == 2) return false;
-                if (!(boolean) this.h.isResting.invoke(region)) return false;
-                if (!(boolean) this.h.canRequestReload.invoke(region)) return false;
+                byte loadState = (byte) this.h.getLoadState.invoke(region);
+                if (loadState == 2) return false;
+                boolean revived = false;
+                if (loadState == 3) {
+                    this.h.setLoadState.invoke(region, (byte) 4);
+                    revived = true;
+                }
+                if (!(boolean) this.h.isResting.invoke(region)
+                        || !(boolean) this.h.canRequestReload.invoke(region)) {
+                    if (revived) this.h.setLoadState.invoke(region, (byte) 3);
+                    return false;
+                }
                 this.h.setBeingWritten.invoke(region, true);
                 this.h.requestLoad.invoke(saveLoad, region, "lss-xaero-bridge");
-                this.h.setNextToLoadByViewing.invoke(saveLoad, region);
                 return true;
             }
         } catch (Throwable t) {
@@ -730,7 +801,15 @@ final class XaeroMapCompat {
         return true;
     }
 
-    private enum Outcome { COMMITTED, DEFERRED, AWAITING_LOAD, FAILED }
+    /** Region-scoped outcomes short-circuit the whole bucket; DEFERRED_TILE is
+     *  tile-chunk-scoped (siblings keep committing); the three AWAITING flavors
+     *  carry the region's requestability — Xaero's own state, read inside the
+     *  probe's region monitor — into the grant phase's memoryless window. */
+    private enum Outcome {
+        COMMITTED, DEFERRED, DEFERRED_TILE,
+        AWAITING_REQUESTABLE, AWAITING_PARKED, AWAITING_IN_FLIGHT,
+        FAILED
+    }
 
     /**
      * One entry against its region — the decompiled {@code MapWriter.writeChunk}
@@ -739,7 +818,9 @@ final class XaeroMapCompat {
      * {@code setBeingWritten(true)} set and NEVER cleared by us (save-eligibility —
      * the save path owns the reset), tile-chunk creation with its cache flags, then
      * the pixel commit. Load REQUESTS live in the grant phase
-     * ({@link #requestRegionLoad}) — an unloaded region answers AWAITING_LOAD here.
+     * ({@link #requestRegionLoad}) — an unloaded region answers an AWAITING flavor
+     * here, classified from {@code canRequestReload_unsynced()} + loadState in the
+     * same monitor read.
      */
     private Outcome commitEntry(Object mp, XaeroTileExtractor.PreparedTile tile) {
         try {
@@ -755,12 +836,12 @@ final class XaeroMapCompat {
             Object writerPause = this.h.writerThreadPauseSync.invoke(region);
             synchronized (writerPause) {
                 if ((boolean) this.h.regionIsWritingPaused.invoke(region)) return Outcome.DEFERRED;
-                boolean proper;
                 boolean resting;
                 boolean createdTileChunk = false;
                 Object tileChunk = null;
                 synchronized (region) {
-                    proper = (byte) this.h.getLoadState.invoke(region) == 2;
+                    byte loadState = (byte) this.h.getLoadState.invoke(region);
+                    boolean proper = loadState == 2;
                     if (proper) this.h.registerVisit.invoke(region);
                     resting = (boolean) this.h.isResting.invoke(region);
                     if (resting) {
@@ -779,14 +860,26 @@ final class XaeroMapCompat {
                     if (!proper) {
                         // Fresh regions NEVER self-promote to loadState 2 — the grant
                         // phase requests the load; this entry (and its whole bucket)
-                        // just waits.
-                        return Outcome.AWAITING_LOAD;
+                        // just waits, classified from Xaero's own state right here in
+                        // the region monitor (the memoryless window's input):
+                        // requestable now, cache-parked (needs the 3→4 revival), or
+                        // genuinely in flight (queued/loading/refreshing — occupies a
+                        // window slot).
+                        if ((boolean) this.h.canRequestReload.invoke(region)) {
+                            return Outcome.AWAITING_REQUESTABLE;
+                        }
+                        return loadState == 3 ? Outcome.AWAITING_PARKED
+                                : Outcome.AWAITING_IN_FLIGHT;
                     }
                 }
                 if (!resting || tileChunk == null) return Outcome.DEFERRED;
-                if ((int) this.h.tileChunkGetLoadState.invoke(tileChunk) != 2) return Outcome.DEFERRED;
+                if ((int) this.h.tileChunkGetLoadState.invoke(tileChunk) != 2) {
+                    return Outcome.DEFERRED_TILE;
+                }
                 Object leafTexture = this.h.getLeafTexture.invoke(tileChunk);
-                if ((boolean) this.h.shouldDownloadFromPBO.invoke(leafTexture)) return Outcome.DEFERRED;
+                if ((boolean) this.h.shouldDownloadFromPBO.invoke(leafTexture)) {
+                    return Outcome.DEFERRED_TILE;
+                }
 
                 commitPixels(mp, region, tileChunk, createdTileChunk,
                         localTcX, localTcZ, tile);
@@ -907,10 +1000,10 @@ final class XaeroMapCompat {
         final MethodHandle getCurrentDimensionId;
         final MethodHandle isRegionDetectionComplete;
         final MethodHandle requestLoad;
-        final MethodHandle setNextToLoadByViewing;
         final MethodHandle writerThreadPauseSync;
         final MethodHandle regionIsWritingPaused;
         final MethodHandle getLoadState;
+        final MethodHandle setLoadState;
         final MethodHandle isResting;
         final MethodHandle registerVisit;
         final MethodHandle setBeingWritten;
@@ -957,7 +1050,6 @@ final class XaeroMapCompat {
             Class<?> saveLoadClass = resolver.resolve("xaero.map.file.MapSaveLoad");
             Class<?> mapWorldClass = resolver.resolve("xaero.map.world.MapWorld");
             Class<?> regionClass = resolver.resolve("xaero.map.region.MapRegion");
-            Class<?> leveledRegionClass = resolver.resolve("xaero.map.region.LeveledRegion");
             Class<?> tileChunkClass = resolver.resolve("xaero.map.region.MapTileChunk");
             Class<?> tileClass = resolver.resolve("xaero.map.region.MapTile");
             Class<?> blockClass = resolver.resolve("xaero.map.region.MapBlock");
@@ -1024,15 +1116,15 @@ final class XaeroMapCompat {
             this.requestLoad = lookup.findVirtual(saveLoadClass, "requestLoad",
                             MethodType.methodType(void.class, regionClass, String.class))
                     .asType(MethodType.methodType(void.class, Object.class, Object.class, String.class));
-            this.setNextToLoadByViewing = lookup.findVirtual(saveLoadClass, "setNextToLoadByViewing",
-                            MethodType.methodType(void.class, leveledRegionClass))
-                    .asType(MethodType.methodType(void.class, Object.class, Object.class));
 
             this.writerThreadPauseSync = getter(lookup, regionClass, "writerThreadPauseSync");
             this.regionIsWritingPaused = virtual(lookup, regionClass, "isWritingPaused",
                     MethodType.methodType(boolean.class), boolean.class);
             this.getLoadState = virtual(lookup, regionClass, "getLoadState",
                     MethodType.methodType(byte.class), byte.class);
+            this.setLoadState = lookup.findVirtual(regionClass, "setLoadState",
+                            MethodType.methodType(void.class, byte.class))
+                    .asType(MethodType.methodType(void.class, Object.class, byte.class));
             this.isResting = virtual(lookup, regionClass, "isResting",
                     MethodType.methodType(boolean.class), boolean.class);
             this.registerVisit = virtual(lookup, regionClass, "registerVisit",


### PR DESCRIPTION
Field-test round 2 (large maps lose tiles): a spiral ring at radius r crosses ~r/4 Xaero map regions (~75 at r=300), while region loads were granted at ≤1/pump (20/s) — awaiting-load clusters overflowed the queue and evict-oldest discarded them permanently.

Decompile-verified loader model (plan §14): `requestLoad` is priority-true (front-inserts, lands mid-drain); the drain processes **unlimited cheap loads** (virgin regions — most of an LOD backfill) per MapRunner cycle but only one expensive file load; the shared `shouldAllowAnotherRegionToLoad` gauge is semantically a 1-in-flight window — and it synchronizes on a possibly-BRANCH region (the §12 deadlock class).

The round:
- **Bucketed drain**: entries group by map region; one probe per region per pump short-circuits whole buckets (`defer_events` now counts per bucket); rotation at bucket granularity; deferral-cap semantics preserved.
- **Outstanding-load window (8)** replaces the gauge: grants go largest-cluster-first until 8 are in flight, refreshed per pump — self-clocking to the loader's real drain rate (~160 grants/s on virgin mixes, throttled on file-backed ones). The gauge is **never consulted** and its two handles are removed — the branch-region deadlock class is gone structurally (pinned).
- Queue widened to 8192 entries / 48 MB; `regions_waiting=` diag gauge.

61 Xaero tests green (5 new/updated pins); full local gates green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)