### PR TITLE
docs: per-line v0.12.0 Xaero notes + plan §8.4 as-built correction

### DIFF
--- a/docs/planning/v0.12.0-release-notes/mc1.21.1.md
+++ b/docs/planning/v0.12.0-release-notes/mc1.21.1.md
@@ -4,6 +4,8 @@
 - **Region summaries: one small frame replaces a million re-checks** — With client and server both on v0.12.0, entering a dimension now costs one compact frame (a few KB) listing which regions are unchanged; the client validates the clean bulk of its cached terrain from it instead of re-declaring every column over several minutes. Verify with `/lsslod diag`'s new `Summary:` line.
 - **Stamped up-to-date responses** — The server timestamps its "your copy is current" answers, so terrain verified in one session stays verified in the next. This closes the loop where the same regions were re-checked on every single rejoin forever. Like the summary exchange, the stamps need both halves on v0.12.0 — they ride the client's summary subscription, so an older client (or one with `enableRegionSummarySync` off) simply keeps plain per-column revalidation. (On servers with the LOD store enabled, the stickiness lands one session later — the store's honest, older stamps take one extra verified rejoin to ratchet forward.)
 
+- **Xaero's World Map fills in beyond render distance (opt-in)** — With Xaero's World Map installed on the client, downloaded LOD terrain can also be written into the world map, so the map records distant terrain instead of stopping at vanilla render distance. Off by default — enable it with the "Write LODs to Xaero's Map" toggle (see below). Works even without a LOD renderer: Xaero's Map plus this mod alone will download and map the terrain once enabled (that download is new for such installs). Client-side only, any server version, no hard dependency — the bridge switches off cleanly when Xaero isn't installed or its internals change.
+
 ### Performance
 
 - **Far lighter client memory** — The client's terrain-tracking state moves to a compact section-leaf layout: roughly 6-10× smaller at the default 512-chunk LOD distance, with smoother scanning and fewer render-thread hitches when teleporting or changing dimensions.
@@ -17,6 +19,8 @@
 
 - **`enableRegionSummaries`** (server, default on) and **`enableRegionSummarySync`** (client, in `lss-client-config.json`, default on) — kill switches for the new summary exchange.
 - **`enableQuadtreeScan`** (client, in `lss-client-config.json`, default on) — the new fast ring-scan path; disable to restore the per-position walk.
+
+- **`enableXaeroMapBridge`** (client, in `lss-client-config.json`, default OFF; also the "Write LODs to Xaero's Map" toggle on the Sodium options page) — the Xaero map bridge above is opt-in: map writes are saved map data (chunks near you stay Xaero's own and Xaero redraws its tiles whenever you revisit an area, but distant LOD-drawn tiles persist until you do), so nothing is written until you turn the toggle on. On servers explored before this update, enable it and run `/lss clearcache` while connected to re-stream the terrain and backfill the map (a full re-download; the map fills progressively while it runs).
 
 ### Compatibility
 

--- a/docs/planning/v0.12.0-release-notes/mc1.21.10.md
+++ b/docs/planning/v0.12.0-release-notes/mc1.21.10.md
@@ -4,6 +4,8 @@
 - **Region summaries: one small frame replaces a million re-checks** — With client and server both on v0.12.0, entering a dimension now costs one compact frame (a few KB) listing which regions are unchanged; the client validates the clean bulk of its cached terrain from it instead of re-declaring every column over several minutes. Verify with `/lsslod diag`'s new `Summary:` line.
 - **Stamped up-to-date responses** — The server timestamps its "your copy is current" answers, so terrain verified in one session stays verified in the next. This closes the loop where the same regions were re-checked on every single rejoin forever. Like the summary exchange, the stamps need both halves on v0.12.0 — they ride the client's summary subscription, so an older client (or one with `enableRegionSummarySync` off) simply keeps plain per-column revalidation. (On servers with the LOD store enabled, the stickiness lands one session later — the store's honest, older stamps take one extra verified rejoin to ratchet forward.)
 
+- **Xaero's World Map fills in beyond render distance (opt-in)** — With Xaero's World Map installed on the client, downloaded LOD terrain can also be written into the world map, so the map records distant terrain instead of stopping at vanilla render distance. Off by default — enable it with `enableXaeroMapBridge` in `lss-client-config.json` (this line has no in-game options page). Works even without a LOD renderer: Xaero's Map plus this mod alone will download and map the terrain once enabled (that download is new for such installs). Client-side only, any server version, no hard dependency — the bridge switches off cleanly when Xaero isn't installed or its internals change.
+
 ### Performance
 
 - **Far lighter client memory** — The client's terrain-tracking state moves to a compact section-leaf layout: roughly 6-10× smaller at the default 512-chunk LOD distance, with smoother scanning and fewer render-thread hitches when teleporting or changing dimensions.
@@ -17,6 +19,8 @@
 
 - **`enableRegionSummaries`** (server, default on) and **`enableRegionSummarySync`** (client, in `lss-client-config.json`, default on) — kill switches for the new summary exchange.
 - **`enableQuadtreeScan`** (client, in `lss-client-config.json`, default on) — the new fast ring-scan path; disable to restore the per-position walk.
+
+- **`enableXaeroMapBridge`** (client, in `lss-client-config.json`, default OFF — on this line the config file is the only switch; there is no in-game options page) — the Xaero map bridge above is opt-in: map writes are saved map data (chunks near you stay Xaero's own and Xaero redraws its tiles whenever you revisit an area, but distant LOD-drawn tiles persist until you do), so nothing is written until you enable the key. On servers explored before this update, enable it and run `/lss clearcache` while connected to re-stream the terrain and backfill the map (a full re-download; the map fills progressively while it runs).
 
 ### Compatibility
 

--- a/docs/planning/v0.12.0-release-notes/mc1.21.11.md
+++ b/docs/planning/v0.12.0-release-notes/mc1.21.11.md
@@ -4,6 +4,8 @@
 - **Region summaries: one small frame replaces a million re-checks** — With client and server both on v0.12.0, entering a dimension now costs one compact frame (a few KB) listing which regions are unchanged; the client validates the clean bulk of its cached terrain from it instead of re-declaring every column over several minutes. Verify with `/lsslod diag`'s new `Summary:` line.
 - **Stamped up-to-date responses** — The server timestamps its "your copy is current" answers, so terrain verified in one session stays verified in the next. This closes the loop where the same regions were re-checked on every single rejoin forever. Like the summary exchange, the stamps need both halves on v0.12.0 — they ride the client's summary subscription, so an older client (or one with `enableRegionSummarySync` off) simply keeps plain per-column revalidation. (On servers with the LOD store enabled, the stickiness lands one session later — the store's honest, older stamps take one extra verified rejoin to ratchet forward.)
 
+- **Xaero's World Map fills in beyond render distance (opt-in)** — With Xaero's World Map installed on the client, downloaded LOD terrain can also be written into the world map, so the map records distant terrain instead of stopping at vanilla render distance. Off by default — enable it with the "Write LODs to Xaero's Map" toggle (see below). Works even without a LOD renderer: Xaero's Map plus this mod alone will download and map the terrain once enabled (that download is new for such installs). Client-side only, any server version, no hard dependency — the bridge switches off cleanly when Xaero isn't installed or its internals change.
+
 ### Performance
 
 - **Far lighter client memory** — The client's terrain-tracking state moves to a compact section-leaf layout: roughly 6-10× smaller at the default 512-chunk LOD distance, with smoother scanning and fewer render-thread hitches when teleporting or changing dimensions.
@@ -17,6 +19,8 @@
 
 - **`enableRegionSummaries`** (server, default on) and **`enableRegionSummarySync`** (client, in `lss-client-config.json`, default on) — kill switches for the new summary exchange.
 - **`enableQuadtreeScan`** (client, in `lss-client-config.json`, default on) — the new fast ring-scan path; disable to restore the per-position walk.
+
+- **`enableXaeroMapBridge`** (client, in `lss-client-config.json`, default OFF; also the "Write LODs to Xaero's Map" toggle on the Sodium options page) — the Xaero map bridge above is opt-in: map writes are saved map data (chunks near you stay Xaero's own and Xaero redraws its tiles whenever you revisit an area, but distant LOD-drawn tiles persist until you do), so nothing is written until you turn the toggle on. On servers explored before this update, enable it and run `/lss clearcache` while connected to re-stream the terrain and backfill the map (a full re-download; the map fills progressively while it runs).
 
 ### Compatibility
 

--- a/docs/planning/v0.12.0-release-notes/mc26.1.md
+++ b/docs/planning/v0.12.0-release-notes/mc26.1.md
@@ -4,6 +4,8 @@
 - **Region summaries: one small frame replaces a million re-checks** — With client and server both on v0.12.0, entering a dimension now costs one compact frame (a few KB) listing which regions are unchanged; the client validates the clean bulk of its cached terrain from it instead of re-declaring every column over several minutes. Verify with `/lsslod diag`'s new `Summary:` line.
 - **Stamped up-to-date responses** — The server timestamps its "your copy is current" answers, so terrain verified in one session stays verified in the next. This closes the loop where the same regions were re-checked on every single rejoin forever. Like the summary exchange, the stamps need both halves on v0.12.0 — they ride the client's summary subscription, so an older client (or one with `enableRegionSummarySync` off) simply keeps plain per-column revalidation. (On servers with the LOD store enabled, the stickiness lands one session later — the store's honest, older stamps take one extra verified rejoin to ratchet forward.)
 
+- **Xaero's World Map fills in beyond render distance (opt-in)** — With Xaero's World Map installed on the client, downloaded LOD terrain can also be written into the world map, so the map records distant terrain instead of stopping at vanilla render distance. Off by default — enable it with the "Write LODs to Xaero's Map" toggle (see below). Works even without a LOD renderer: Xaero's Map plus this mod alone will download and map the terrain once enabled (that download is new for such installs). Client-side only, any server version, no hard dependency — the bridge switches off cleanly when Xaero isn't installed or its internals change.
+
 ### Performance
 
 - **Far lighter client memory** — The client's terrain-tracking state moves to a compact section-leaf layout: roughly 6-10× smaller at the default 512-chunk LOD distance, with smoother scanning and fewer render-thread hitches when teleporting or changing dimensions.
@@ -17,6 +19,8 @@
 
 - **`enableRegionSummaries`** (server, default on) and **`enableRegionSummarySync`** (client, in `lss-client-config.json`, default on) — kill switches for the new summary exchange.
 - **`enableQuadtreeScan`** (client, in `lss-client-config.json`, default on) — the new fast ring-scan path; disable to restore the per-position walk.
+
+- **`enableXaeroMapBridge`** (client, in `lss-client-config.json`, default OFF; also the "Write LODs to Xaero's Map" toggle on the Sodium options page) — the Xaero map bridge above is opt-in: map writes are saved map data (chunks near you stay Xaero's own and Xaero redraws its tiles whenever you revisit an area, but distant LOD-drawn tiles persist until you do), so nothing is written until you turn the toggle on. On servers explored before this update, enable it and run `/lss clearcache` while connected to re-stream the terrain and backfill the map (a full re-download; the map fills progressively while it runs).
 
 ### Compatibility
 

--- a/docs/planning/xaero-map-bridge-plan.md
+++ b/docs/planning/xaero-map-bridge-plan.md
@@ -472,15 +472,28 @@ behavior.
    test finds visible seams at the native/LOD boundary.
 2. Cave layers.
 3. Voxy-store backfill for converged servers (§2.10).
-4. Support-line ports (after the user's manual test, with the rest of the
-   staged v0.12.0+ work). NOT verbatim (impl review corrected §2.11's claim) —
-   three mechanical per-line API substitutions in the new xplat code:
-   `level.getMinY()/getMaxY()` → `getMinBuildHeight()/getMaxBuildHeight()` on
-   1.21.1 only, and `state.getLightDampening()` → `getLightBlock(BlockGetter,
-   BlockPos)` on ALL THREE 1.21.x lines (verified against the per-line
-   mappings); plus the menu hunk's `Identifier.parse` → `ResourceLocation.parse`
-   on 1.21.1 and the whole menu hunk dropped on 1.21.10 (its Sodium cut).
-   Verify the per-line Xaero 1.45.0 jar in the test instance.
+4. Support-line ports — DONE 2026-08-23 (port/xaero-* branches, 2-Opus
+   reviewed per line). The AS-BUILT substitutions, correcting this item's
+   original recipe in two places (the backport reviews caught both): the
+   light-opacity rename is `state.getLightDampening()` → **no-arg**
+   `getLightBlock()` on 1.21.11 AND 1.21.10 (the 2-arg
+   `getLightBlock(BlockGetter, BlockPos)` overload exists ONLY on 1.21.1,
+   where the port passes `EmptyBlockGetter.INSTANCE, BlockPos.ZERO` — the
+   constant-opacity approximation; the original "2-arg on all three 1.21.x"
+   claim was wrong on two of the three), and the list was missing the test
+   constant rename `Blocks.STAINED_GLASS.blue()/.red()` →
+   `BLUE_/RED_STAINED_GLASS` (needed on EVERY support line — the flat
+   constants predate 26.2's ColorCollection). The rest as originally planned:
+   `getMinY()/getMaxY()+1` → `getMinBuildHeight()/getMaxBuildHeight()` on
+   1.21.1 only (max already EXCLUSIVE — the +1 drops), `Identifier` →
+   `ResourceLocation` on 1.21.1 and 1.21.10 (tests + the 1.21.1 menu hunk;
+   1.21.11 keeps Identifier), the menu hunk dropped on 1.21.10 (its Sodium
+   cut — config key + diag are that line's full control surface), and the
+   1.21.1 test bench uses the line's `Registry<Biome>` section family via its
+   `SectionConstruction` seam in place of `PalettedContainerFactory`.
+   Still owed per line: the live check of that line's Xaero 1.45.0 jar in its
+   test instance (the reflective surface was member-verified against the 26.2
+   and 1.21.1 jars only; resolve failure fails soft to `state=unavailable`).
 
 ## 9. Execution order
 


### PR DESCRIPTION
Folds the doc findings from the 2-Opus backport reviews: every line's v0.12.0 notes file gains the Xaero feature + config bullets (opt-in wording; 1.21.10 variant has no options page so the config file is named as the only switch), and plan §8.4 becomes the as-built port record with the two recipe corrections (no-arg getLightBlock on 1.21.11/1.21.10; the stained-glass substitution added).

🤖 Generated with [Claude Code](https://claude.com/claude-code)