### PR TITLE
docs: 1.21.1 NeoForge note — Xaero bridge is config-key-only there

### DIFF
--- a/docs/planning/v0.12.0-release-notes/mc1.21.1.md
+++ b/docs/planning/v0.12.0-release-notes/mc1.21.1.md
@@ -30,3 +30,4 @@
 
 - This line (including the NeoForge build) is supported at the best-effort tier. No features were cut in this release.
 - The NeoForge build carries the client half of the new behaviors too — region summaries and stamped verification work on NeoForge clients exactly as on Fabric.
+- The Xaero map bridge works on NeoForge clients as well (with the NeoForge build of Xaero's World Map), but there is no in-game toggle there — enable it with `enableXaeroMapBridge` in `lss-client-config.json`.


### PR DESCRIPTION
One-line fold from the 1.21.1 backport's 2-Opus integration review: the NeoForge client has no options page, so the line's NeoForge notes name the config key as the enable path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)