### PR TITLE
fix(xaero): run the texture rebuild ourselves under isResting — never the setToUpdateBuffers flag

### DIFF
--- a/docs/planning/xaero-map-bridge-plan.md
+++ b/docs/planning/xaero-map-bridge-plan.md
@@ -837,10 +837,14 @@ different regions, loadStates 2/3/2: not a corrupt region, a protocol race.
   frame, under the region monitor) queues a region for caching when
   `shouldCache && recacheHasBeenRequested && isAllCachePrepared && !isRefreshing`
   (`MapSaveLoad.requestCache`). The saver later pops it and THROWS if
-  `!isAllCachePrepared()` — there is no re-check, no requeue.
+  `!isAllCachePrepared()` — no requeue (`requestCache` has ONE call site, inside
+  the region monitor).
 - `MapTileChunk.updateBuffers` (the 64×64 texture rebuild; render-thread-only —
-  it throws "Wrong thread!" otherwise) ends with `region.setAllCachePrepared(false)`.
-  So any rebuild landing between the queueing and the pop crashes the saver.
+  it throws "Wrong thread!" otherwise) does `region.setAllCachePrepared(false)`
+  near its START (pc 109, before the 4096-pixel pass). So any rebuild landing
+  between the queueing and the pop crashes the saver. (The pop re-checks
+  `shouldCache && recacheHasBeenRequested && !skipCaching` — failing THAT takes a
+  cancel path; the unprepared check itself has no such exit.)
 - What keeps the NATIVE writer out of that window: `MapRegion.isResting()` =
   `loadState ∉ {1,3} && !recacheHasBeenRequested`, and `writeChunk` writes (and
   rebuilds — `updateBuffers` directly on the written tile chunk at inside (3,3)
@@ -902,9 +906,14 @@ different regions, loadStates 2/3/2: not a corrupt region, a protocol race.
   `MapProcessor.getWorldBlockTintProvider()`, `MapUpdateFastConfig(MapProcessor)`
   — all verified against the 1.21.11 1.45.0 jar (FQN-identical on every line;
   `setToUpdateBuffers` is no longer bound). The stub `updateBuffers` enforces
-  both region monitors and mirrors the `setAllCachePrepared(false)` side
-  effect, so the test pins assert the real invariant (the flip happens only
-  under the gates).
+  the writer-pause AND region monitors and mirrors the `setAllCachePrepared(false)`
+  side effect, so the test pins assert the real invariant (the flip happens only
+  under the gates). Precision (review A): the native writer holds only
+  `writerThreadPauseSync` at its own `updateBuffers` calls (the region monitor is
+  released after the write); the bridge's additional region-monitor hold is a
+  chosen tightening, safe because the jar's only two nesting orders are both
+  render-thread-only (no inversion possible) and `updateBuffers` never takes a
+  foreign region's monitor (`getNeighbourTileChunk(..., allowOtherRegions=false)`).
 - Pins (XaeroMapCompatTest, the rebuild-phase block): flag never set + no
   rebuild at commit; rebuild after the idle window under the gates with
   `beingWritten` re-armed and the change consumed after; per-tile-chunk
@@ -916,8 +925,18 @@ different regions, loadStates 2/3/2: not a corrupt region, a protocol race.
 
 Owed: the live re-test on the lss-test-1.21.11 instance (the crash reproduced
 within ~20-40 min of map browsing each time; a clean hour with
-`buffer_updates` climbing and `commit_failures=0` closes it), then the port to
-every line (xplat-only + stubs/tests — no line flavor points).
+`buffer_updates` climbing, `pending_updates` NOT pinned at the hard cap and
+`commit_failures=0` closes it), then the port to every line (xplat-only +
+stubs/tests — no line flavor points). How to read a recurrence (review A): the
+bridge no longer sets the flag anywhere, but Xaero itself does — the native
+writer's right/bottom-right neighbor flags, and `MapProcessor.handleRefresh`
+(after a save that found the region `!isAllCachePrepared()`) flags every
+terrain-bearing tile chunk of the region — and both go through the same
+`isResting`-blind sweep. A recurrence therefore points at Xaero's own flags (a
+region saved while a bridge rebuild was still owed makes the refresh path more
+likely), not at a bridge rebuild; keep rebuild latency well inside the save
+cadence (the idle window + the age ceiling are seconds; a hard-cap backlog is
+what would stretch it).
 
 ### 15.1 Review fold (2026-08-23, 2-Opus over PR #237 — review B landed first)
 
@@ -966,3 +985,49 @@ is called with `allowOtherRegions=false`) and does not arm our own `DEFERRED_TIL
   texture that the region cache may hold until the next native write or reload
   (Reviewer B's one unverifiable claim — the live hour on 1.21.11 is the check);
   `describeRendersTheHouseStyle` remains a token-presence pin (pre-existing).
+
+### 15.2 Review fold — reviewer A (protocol / deadlock lens, verified pc-level)
+
+Reviewer A re-derived §15 from the jar and VERIFIED the exclusion argument end to
+end (`requestCache`'s single call site and guards, the saver's pop + throw, the
+sweep's gates, the native writer's post-write block, the save section's
+`isBeingWritten` throw-on-false at pc 1611 — which our set-never-clear cannot
+trip — and `toSave`'s dedupe), and found NO lock-order inversion (§15's
+precision note above). Refuted wording fixed in place (the region monitor, the
+"ends with", the "no re-check"). Folded:
+
+- **MAJOR — the flag was also Xaero's park guard.** `LeafRegionTexture.postUpload`
+  parks a region (`setLoadState(3)`, `tileChunk.clean()` releasing its 16 tiles)
+  once it is not being written, 1 s has passed since `registerVisit`, and no tile
+  chunk is flagged `toUpdateBuffers`. With the flag never set, a save that reset
+  `beingWritten` plus one quiet second could park a tile chunk whose rebuild was
+  still owed → `loadState != 2` → dropped, texture never built (blank until a
+  reload; a re-written tile chunk could even be cached pre-rewrite). The flush now
+  keeps every region with an owed rebuild VISITED each pump — `registerVisit`
+  once per region under the region monitor, the writer's own signal — so Xaero
+  cannot park it under us; pinned (`owedRegionsAreKeptVisitedSoXaeroCannotParkThem`).
+- **MAJOR — the 2 ms rebuild budget could pin commits at the hard cap**: the flush
+  now borrows the commit budget once the queue is empty (commits need nothing)
+  and half of it while the owed set is past the soft cap (`UPDATE_BORROW_NANOS`,
+  saturating add — the seams take `Long.MAX_VALUE`, which is how the latch test
+  caught the overflow); the frame-hook lever is recorded in the constant's
+  javadoc for the case the live counters show `pending_updates` pinned.
+- MAJOR (interpretation) — Xaero's own `handleRefresh` flags: recorded in the
+  "owed" paragraph so a live recurrence is read correctly.
+- MINOR — `rebuildTileChunk` checks the TILE CHUNK's loadState too (a tile-chunk-only
+  teardown leaves the region's untouched); unloaded/parked/replaced drops count
+  `dropped_unloaded` (own counter — a parking race must be tellable apart from the
+  stall/dimension/session drops); the dead latch clears the owed set on the next
+  pump's dead path (NOT inside `noteFailure` — that runs inside the flush's own
+  iteration, and clearing there tore the map out from under the iterator);
+  `onSessionEnd` counts the owed rebuilds it discards (accepted: the last ≤2 s of
+  commits before a disconnect may reach the region cache with a stale texture —
+  no best-effort flush against a world that is going away); a hard-capped drain
+  pass keeps the last `regions_waiting` gauge instead of writing 0; the stub's
+  "both monitors" javadoc reworded as the bridge's tightening.
+- Pins added: keep-visited (once per region per pump; never for an unloaded
+  region), budget borrowing (none under the soft cap with a non-empty queue, half
+  past it, all of it on an empty queue), the tile-chunk teardown drop, the
+  session-end count, the rebuild path never sets the flag. Reviewer A's other test
+  gaps were already covered by the review-B fold (zero budget, two regions,
+  stall reset, latch release).

--- a/docs/planning/xaero-map-bridge-plan.md
+++ b/docs/planning/xaero-map-bridge-plan.md
@@ -101,11 +101,16 @@ CFR decompile output in `cfr-out262/`, XaeroPlus clone). Key findings:
   cave-mode-only); biome sampled at topHeight; void column =
   `write(AIR, worldBottomY, worldBottomY, biome, 0, false, false)`; slopes may
   stay `slopeUnknown` (self-heal at render).
-- **No direct `updateBuffers` needed**: `setChanged(true)` +
+- ~~**No direct `updateBuffers` needed**: `setChanged(true)` +
   `setToUpdateBuffers(true)` is sufficient — Xaero's `LeafRegionTexture.preUpload`
-  sweep performs the GPU work under its own locks/budget. This also shrinks the
-  reflective surface (no `BlockTintProvider`/`MapUpdateFastConfig`/
-  `BiomeColorCalculator` handles).
+  sweep performs the GPU work under its own locks/budget.~~ **SUPERSEDED by §15
+  (field-test round 3)**: the flag is consumed by the sweep with NO `isResting()`
+  check, i.e. possibly after the region was queued for cache-saving on prepared
+  textures — the saver then throws. The native writer only ever un-prepares a
+  region INSIDE its `isResting` gate (`updateBuffers` directly, at the (3,3)
+  chunk / the bottom neighbor); the bridge now does the same, coalesced per
+  tile chunk. `BlockTintProvider`/`MapUpdateFastConfig` joined the bound
+  surface for it.
 - **Persistence**: the MapRunner sweep saves being-written, terrain-bearing
   regions on its own cadence (`hasHadTerrain` propagates from
   `tileChunk.setHasHadTerrain()`), force-flushing on dimension finish. No
@@ -156,9 +161,10 @@ CFR decompile output in `cfr-out262/`, XaeroPlus clone). Key findings:
    same locks, the same gate ladder, and the same lifecycle flags. Where the
    decompiled `writeChunk` and this plan disagree, **the decompile is
    normative** — mirror it (CFR output is in the research scratchpad;
-   re-decompile on Xaero updates). No direct `updateBuffers`:
-   `setChanged(true)` + `setToUpdateBuffers(true)` and let Xaero's preUpload
-   sweep do GPU work (§1).
+   re-decompile on Xaero updates). Texture rebuilds are OURS, like the native
+   writer's: `updateBuffers` under the same gates, coalesced per tile chunk
+   (§15) — never the `setToUpdateBuffers` flag (its sweep-side consumption
+   escapes `isResting`, the cache-not-prepared crash).
 4. **Two-stage pipeline, budgeted.** Stage 1 (LSS decode thread, inside the
    consumer callback): extract a compact immutable `PreparedTile` — per pixel:
    floor BlockState, height, topHeight, biome, block-light byte, plus the fluid
@@ -366,8 +372,12 @@ was in the original list — REMOVED by §14, never resolved as-built).
 `canRequestReload_unsynced()`, `setAllCachePrepared(boolean)`, `getChunk(...)`.
 `MapTileChunk`: ctor, `getTile`/`setTile(int, int, MapTile,
 BlockStateShortShapeCache, MapProcessor)`, `setLoadState(byte)`,
-`setChanged(boolean)`, `setToUpdateBuffers(boolean)`, `setHasHadTerrain()`,
-`getLoadState()`, `getLeafTexture()` (+ `shouldDownloadFromPBO()`).
+`setChanged(boolean)`, `wasChanged()`, `updateBuffers(MapProcessor,
+BlockTintProvider, OverlayManager, boolean, BlockStateShortShapeCache,
+MapUpdateFastConfig)` (§15 — replaced `setToUpdateBuffers(boolean)`, which is
+never bound now), `setHasHadTerrain()`, `getLoadState()`, `getLeafTexture()`
+(+ `shouldDownloadFromPBO()`). Rebuild inputs (§15): `MapProcessor.
+getWorldBlockTintProvider()` and the `MapUpdateFastConfig(MapProcessor)` ctor.
 `MapTile`: ctor/pool source, `setBlock`, `getBlock`,
 `setWorldInterpretationVersion(int)`, `setWrittenCave(int, int)`,
 `setWrittenOnce`, `setLoaded`. `MapBlock`: ctor, `prepareForWriting(int)`,
@@ -386,9 +396,9 @@ MapRegion,int,int,boolean)` (the createdTileChunk block), `MapProcessor.
 getCaveModeDepthConfig()` (setWrittenCave's live depth — mirroring the config
 avoids a spurious native rewrite delta), `MapTileChunk.includeInSave()`,
 `MapRegion.setChunk(int,int,MapTileChunk)`. Deliberately ABSENT:
-`updateBuffers`, `addToRefresh`, `BlockTintProvider`, `MapUpdateFastConfig`,
-`BiomeColorCalculator` (§1 — Xaero's own sweeps handle textures/refresh/save
-once the flags are set), and — since §14 — the ENTIRE shared load-pacing
+`addToRefresh`, `BiomeColorCalculator` (Xaero's own sweeps handle
+refresh/save; `updateBuffers` + its two input types were absent until §15
+made the rebuild ours), and — since §14 — the ENTIRE shared load-pacing
 surface: `shouldAllowAnotherRegionToLoad`/`getNextToLoadByViewing` (the
 branch-region monitor deadlock class, gone structurally) AND
 `setNextToLoadByViewing` (the 3-Opus fold: the loader never reads the token —
@@ -429,7 +439,10 @@ BUCKET per pump for region-scoped flavors, one per entry for tile-chunk-scoped
 DROPS, never attempts), `commit_failures` — split out because it is the only
 pre-death failure signal, unlike the benign drop flavors — `load_requests`,
 `queued` gauge, `regions_waiting` gauge — waiting regions as PROBED by the last
-pump, a lower bound under budget truncation) + `state` (active / unavailable
+pump, a lower bound under budget truncation; since §15 `buffer_updates` (texture
+rebuilds run), `pending_updates` gauge (rebuilds owed) and `dropped_updates`
+(owed rebuilds dropped: wrong dimension / unloaded or replaced tile chunk /
+a region that never rested for ~60 s)) + `state` (active / unavailable
 / dead / disabled), surfaced ONLY in the client `/lss diag` conditional line
 (comma-separated, the house style) — no exporter/soak schema churn. The
 `unavailable` state is the RESOLVE-FAILED case (Xaero present, internals
@@ -805,3 +818,101 @@ rigor) over the first cut. All findings folded; the decisive reshapes:
   requestLoad is impossible (remove+add(0) dedupe + canRequestReload guard);
   unbounded toLoad growth is impossible; the filter walk was ~1× not 9×
   isChunkLoaded per entry (nativelyWritable short-circuits on the center).
+
+## 15. Field-test round 3 (2026-08-23, the saver crash — AMENDS §1/§2.3/§4/§6 in place)
+
+Three client crashes in ~1 h on the lss-test-1.21.11 instance (Xaero WM 1.45.0,
+bridge `state=active`, `commit_failures=0` in every pre-crash diag), all the
+same shape and all off the MapRunner thread:
+`RuntimeException: Trying to save cache for a region with cache not prepared:
+(…) 1_-6 L0 xaero.map.region.MapRegion@… 2 64` (then `-11_9 … 3 64`,
+`-1_-7 … 2 64`) — `MapSaveLoad.run`'s cache section (1.45.0 line 1191). Three
+different regions, loadStates 2/3/2: not a corrupt region, a protocol race.
+
+**Mechanism (1.45.0 bytecode, javap — every claim below is from it):**
+
+- The render loop (`MapProcessor.onRenderProcess`, ALL `toProcess` regions each
+  frame, under the region monitor) queues a region for caching when
+  `shouldCache && recacheHasBeenRequested && isAllCachePrepared && !isRefreshing`
+  (`MapSaveLoad.requestCache`). The saver later pops it and THROWS if
+  `!isAllCachePrepared()` — there is no re-check, no requeue.
+- `MapTileChunk.updateBuffers` (the 64×64 texture rebuild; render-thread-only —
+  it throws "Wrong thread!" otherwise) ends with `region.setAllCachePrepared(false)`.
+  So any rebuild landing between the queueing and the pop crashes the saver.
+- What keeps the NATIVE writer out of that window: `MapRegion.isResting()` =
+  `loadState ∉ {1,3} && !recacheHasBeenRequested`, and `writeChunk` writes (and
+  rebuilds — `updateBuffers` directly on the written tile chunk at inside (3,3)
+  and on the bottom neighbor, both inside the same `isResting` gate) ONLY while
+  resting. A cache request implies `recacheHasBeenRequested`, so a native
+  rebuild can never flip a queued region. (Its right/bottom-right neighbors are
+  only FLAGGED — the same exposure, which is why this crash class exists
+  upstream at all; rare natively because those flags are consumed within a
+  frame for the player's own region.)
+- The bridge's v1 pattern (§1, "no direct updateBuffers needed") set
+  `setToUpdateBuffers(true)` on EVERY written tile chunk and left the rebuild to
+  `LeafRegionTexture.preUpload`. That sweep is gated by the writer-pause
+  monitors but NOT by `isResting` — and it runs under a per-frame upload
+  budget, so the flag can linger for frames. Sequence: commit (flag set,
+  `beingWritten`) → the saver saves the region (`recacheHasBeenRequested`,
+  `shouldCache`, `beingWritten=false`) → the render loop sees the textures
+  still prepared+uploaded from before, queues the cache → a later frame's sweep
+  consumes our flag → `updateBuffers` → `allCachePrepared=false` → the saver pops
+  → throw. At LOD scale (hundreds of regions written across many pumps, each
+  saved several times while still being written) the window is hit constantly.
+
+**Fix — the rebuild is OURS, like the native writer's, coalesced per tile chunk:**
+
+- The flag is never set. `commitPixels` leaves the tile chunk in the native
+  transient state (`changed=true`, unflagged — every non-(3,3) native chunk
+  write sits there too) and records it in `pendingUpdates` (keyed by tile-chunk
+  coords, last-touch ordered).
+- `flushPendingUpdates` runs at the top of every pump ladder pass (before the
+  commit drain; ALSO when the queue is empty and when the bridge was just
+  disabled — a rebuild owed to a written tile chunk must never be dropped).
+  A rebuild is DUE when its tile chunk went `UPDATE_IDLE_PUMPS` (40, ~2 s)
+  without a new tile, or it is the oldest beyond `PENDING_UPDATES_SOFT_CAP`
+  (256), or it stalled before. Each due rebuild re-runs the writer's own
+  region gates — `writerThreadPauseSync` + `!isWritingPaused()`, the region
+  monitor, `isResting()` — so it can never land inside the cache window (the
+  whole point); a not-resting region keeps the entry for a later pump (a
+  region that never rests for `UPDATE_MAX_STALL_PUMPS` ≈ 60 s drops it,
+  counted — the texture self-heals on reload); an unloaded (loadState≠2) or
+  replaced tile chunk drops it (a reload rebuilds its own textures); a wrong-
+  dimension entry drops it (the pixel recipe reads the CURRENT world). Then:
+  `setBeingWritten(true)` (a save may have reset it since the commit — the
+  rebuilt texture must reach the region cache, and the save path is what
+  requests the recache), `if (wasChanged()) { updateBuffers(mp,
+  getWorldBlockTintProvider(), getOverlayManager(), false /* the writer's
+  detailed-debug flag, log-only */, getBlockStateShortShapeCache(),
+  new MapUpdateFastConfig(mp)); setChanged(false); }` — exactly the native
+  call, args resolved once per flush like the native per-pass config snapshot.
+- Budgets: the rebuild phase has its own `UPDATE_NANOS_BUDGET` (2 ms, ≥1 per
+  pump) so the commit budget is untouched; at `PENDING_UPDATES_HARD_CAP` (1024)
+  owed rebuilds, COMMITS pause until the flush drains (never an unbounded set).
+  Cost model: a rebuild is the expensive half of a native write (4096 pixels
+  through `getPixelColour`, biome blending included); per-tile direct calls
+  would have been 16 rebuilds per tile chunk — coalescing over the spiral's
+  ~4-tiles-per-ring-per-tile-chunk delivery lands at ~1-4, on the same order as
+  what Xaero's own sweep was doing for the v1 flags, now on the pump's tick
+  budget instead of Xaero's frame budget. Cost is visible: `buffer_updates` /
+  `pending_updates` / `dropped_updates` in the diag line (§6).
+- Handles: `MapTileChunk.updateBuffers` (6-arg) + `wasChanged()`,
+  `MapProcessor.getWorldBlockTintProvider()`, `MapUpdateFastConfig(MapProcessor)`
+  — all verified against the 1.21.11 1.45.0 jar (FQN-identical on every line;
+  `setToUpdateBuffers` is no longer bound). The stub `updateBuffers` enforces
+  both region monitors and mirrors the `setAllCachePrepared(false)` side
+  effect, so the test pins assert the real invariant (the flip happens only
+  under the gates).
+- Pins (XaeroMapCompatTest, the rebuild-phase block): flag never set + no
+  rebuild at commit; rebuild after the idle window under the gates with
+  `beingWritten` re-armed and the change consumed after; per-tile-chunk
+  coalescing; not-resting waits, permanent stall drops; hard cap pauses
+  commits and the flush-before-drain order frees them; soft cap forces only
+  the overflow; unloaded/replaced drops; native-consumed change skips;
+  flush after disable and on an empty queue; session end clears; dimension
+  change drops; rebuild throws count toward the death latch.
+
+Owed: the live re-test on the lss-test-1.21.11 instance (the crash reproduced
+within ~20-40 min of map browsing each time; a clean hour with
+`buffer_updates` climbing and `commit_failures=0` closes it), then the port to
+every line (xplat-only + stubs/tests — no line flavor points).

--- a/docs/planning/xaero-map-bridge-plan.md
+++ b/docs/planning/xaero-map-bridge-plan.md
@@ -346,8 +346,9 @@ construction under it is proven — SectionConstructionPinTest et al.):
   ONE paced requestLoad with setBeingWritten(true) first and defers without
   burning deferral budget; ladder-ready deferral cap drops); commit-sequence
   order against a recording stub (worldInterpretationVersion before setTile;
-  setBeingWritten never cleared; setChanged + setToUpdateBuffers, no
-  updateBuffers call); latest-wins + bounds; config-off clears; throw latch
+  setBeingWritten never cleared; ~~setChanged + setToUpdateBuffers, no
+  updateBuffers call~~ — INVERTED by §15: no flag ever, the rebuild coalesced into
+  the pump's flush phase under the writer gates); latest-wins + bounds; config-off clears; throw latch
   kills after 5; a throwing commit NEVER escapes the consumer callback and
   NEVER reports ingest failure (pin: the report seam records zero calls).
 
@@ -536,7 +537,8 @@ version-before-setTile, slopeUnknown), handle-set corrections, the
 both-writers-skip window edge, tile-chunk creation details (setLoadState 2,
 setAllCachePrepared false, registerVisit, PBO gate). Verified: all needed
 members public; FQNs identical 26.2 ↔ 1.21.1; boundary self-heal both
-directions; no cache-prepared crash workaround needed.
+directions; ~~no cache-prepared crash workaround needed~~ (FALSIFIED live — §15: the
+flag-consuming sweep escapes `isResting`; the bridge now runs the rebuild itself).
 
 Reviewer B (project lens) — 2 MAJORs, both folded: dimension write-context
 pinning (resolved by mirroring the native mainStuffSync equality — wrong-
@@ -916,3 +918,51 @@ Owed: the live re-test on the lss-test-1.21.11 instance (the crash reproduced
 within ~20-40 min of map browsing each time; a clean hour with
 `buffer_updates` climbing and `commit_failures=0` closes it), then the port to
 every line (xplat-only + stubs/tests — no line flavor points).
+
+### 15.1 Review fold (2026-08-23, 2-Opus over PR #237 — review B landed first)
+
+Reviewer B (cost / handles / pins) verified the four new members against all nine
+Xaero jars on the box (1.44.2 + every 1.45.0 incl. the NeoForge 1.21.1 build —
+identical descriptors; 1.40.x/1.41.0 already failed the 5-arg `setTile` bind, so the
+floor is unchanged), traced the soft-cap/hard-cap/flush-before-drain pins as real,
+confirmed `updateBuffers` takes no cross-region monitor (`getNeighbourTileChunk`
+is called with `allowOtherRegions=false`) and does not arm our own `DEFERRED_TILE`
+(`setShouldDownloadFromPBO(false)`). Folded:
+
+- **MAJOR — the death latch pinned Xaero objects**: `pump()` returned before the
+  flush while `pendingUpdates` (≤1024 strong refs to regions + tile chunks, each
+  leaf texture a direct buffer) stayed populated until disconnect. A dead pump now
+  clears the map (main thread; the decode-side latch never touches it).
+- **MAJOR — per-tile-chunk gate re-probe**: the flush re-took the writer-pause +
+  region monitors for every owed entry — up to 64 per region, one verdict — the
+  per-entry-probe pattern §14 removed; and `NOT_READY` counted as budget progress,
+  so a not-resting prefix could burn the whole rebuild budget doing nothing while
+  the hard cap paused commits. Now a not-ready verdict is memoized per region per
+  flush (no monitors for its siblings) and only REMOVING outcomes count toward the
+  budget's forward-progress guard (the javadoc/constant wording corrected: "the
+  first removing outcome is exempt", not "one rebuild per pump").
+- MINOR — session identity: a server-initiated reconfiguration skips the disconnect
+  event and a `ResourceKey` is identity-stable across servers, so an old world's
+  entry could pass every gate on the NEW world's objects. `PendingUpdate` now
+  carries the `MapProcessor` identity + `getCurrentWorldId()`; a mismatch DROPS.
+- MINOR — foreign dimension: dropping at once left a stale texture for a quick
+  portal trip; entries now WAIT (NOT_READY, no probe) and drop only after the
+  60 s stall window — the same accepted residual as a never-resting region.
+- MINOR — age ceiling `UPDATE_MAX_DEFER_PUMPS` (160 ≈ 8 s from the FIRST commit):
+  a tile chunk trickled into more often than the idle window can no longer defer
+  its rebuild indefinitely; the flush walks past not-due entries instead of
+  breaking (the ceiling is not a touch-order prefix; ≤1024 cheap checks).
+- MINOR — accounting: `FAILED` now counts `dropped_updates` (owed and never
+  rebuilt), so `buffer_updates + dropped_updates` reconciles every entry.
+- MINOR — pins added: the zero-budget flush (one removing outcome per pump, resumes),
+  probed-ONCE-per-flush + no progress consumed (stub `gateProbes`), the stall-clock
+  reset on a re-touch under budget truncation (the only reachable path), a replaced
+  tile chunk gets a fresh entry, the trickle ceiling, session identity (processor
+  AND world id), the dead-latch release, and the exact `updateBuffers` argument
+  identities + `debug=false` (every parameter is Object-erased behind the handle —
+  a transposition would only surface live as a 5-failure latch).
+- Recorded, not changed: the accepted residual that a DROPPED rebuild (60 s stall /
+  long dimension absence / a previous session) leaves `changed=true` with a stale
+  texture that the region cache may hold until the next native write or reload
+  (Reviewer B's one unverifiable claim — the live hour on 1.21.11 is the check);
+  `describeRendersTheHouseStyle` remains a token-presence pin (pre-existing).

--- a/fabric/src/test/java/dev/vox/lss/compat/XaeroMapCompatTest.java
+++ b/fabric/src/test/java/dev/vox/lss/compat/XaeroMapCompatTest.java
@@ -837,6 +837,95 @@ class XaeroMapCompatTest {
         assertEquals(0, this.bridge.counterForTest("pending_updates"));
         assertEquals(1, tileChunk.bufferUpdates);
         assertTrue(events.contains("fastConfig.new"), "the native per-pass config snapshot");
+        // The exact native argument list — every parameter is Object-erased behind the
+        // handle, so a transposition compiles and only surfaces live (review B).
+        assertTrue(tileChunk.lastUpdateProcessor == this.processor);
+        assertTrue(tileChunk.lastUpdateTint == this.processor.tintProvider);
+        assertTrue(tileChunk.lastUpdateOverlay == this.processor.overlayManager);
+        assertTrue(tileChunk.lastUpdateCache == this.processor.shapeCache);
+        assertNotNull(tileChunk.lastUpdateConfig);
+        assertFalse(tileChunk.lastUpdateDebug, "the writer's detailed-debug flag is log-only: false");
+    }
+
+    @Test
+    void aZeroRebuildBudgetStillRebuildsOnePerPumpAndResumes() {
+        this.bridge.updateIdlePumps = 1;
+        this.bridge.updateNanosBudget = 0;
+        offer(64, 64);
+        offer(68, 64);
+        this.bridge.pump();
+        this.bridge.pump();
+        assertEquals(1, this.bridge.counterForTest("buffer_updates"),
+                "the first removing outcome is exempt from the budget — exactly one per pump");
+        assertEquals(1, this.bridge.counterForTest("pending_updates"));
+        this.bridge.pump();
+        assertEquals(2, this.bridge.counterForTest("buffer_updates"), "and the rest resumes next pump");
+        assertEquals(0, this.bridge.counterForTest("pending_updates"));
+    }
+
+    @Test
+    void aNotReadyRegionIsProbedOncePerFlushAndConsumesNoProgress() {
+        this.bridge.updateIdlePumps = 2;
+        this.bridge.updateNanosBudget = 0;
+        offer(64, 64);
+        offer(68, 64);
+        offer(72, 64); // three tile chunks of region (2,2)
+        this.bridge.pump(); // 1
+        offer(96, 64); // region (3,2), touched later — sits AFTER the three in touch order
+        this.bridge.pump(); // 2
+        var busy = this.processor.regions.get((2L << 32) | 2L);
+        var ready = this.processor.regions.get((3L << 32) | 2L);
+        assertNotNull(busy);
+        assertNotNull(ready);
+        busy.resting = false;
+        this.bridge.pump(); // 3: the three are due (stalled); (3,2) is not yet
+        assertEquals(0, this.bridge.counterForTest("buffer_updates"));
+        int probesBefore = busy.gateProbes;
+        this.bridge.pump(); // 4: all four due
+        assertEquals(1, busy.gateProbes - probesBefore,
+                "a not-ready region is probed ONCE per flush, not once per owed tile chunk"
+                        + " (the per-entry-probe pattern plan §14 removed)");
+        assertEquals(1, ready.getChunk(0, 0).bufferUpdates,
+                "not-ready verdicts consume no budget: the ready region behind them still"
+                        + " rebuilds in the same pump");
+        assertEquals(3, this.bridge.counterForTest("pending_updates"));
+    }
+
+    @Test
+    void aReTouchUnderBudgetTruncationResetsTheStallClock() {
+        // The only reachable re-touch of a STALLED entry: its region turns resting in a
+        // pump whose flush is truncated (budget) before reaching it, and the drain then
+        // commits into its tile chunk. The reset makes it wait a FRESH idle window.
+        this.bridge.updateIdlePumps = 3;
+        this.bridge.updateNanosBudget = 0; // one removing outcome per pump
+        offer(96, 64);            // F: tile chunk (24,16), region (3,2) — the OLDER entry
+        this.bridge.pump();       // pump 1
+        offer(64, 64);            // E: tile chunk (16,16), region (2,2)
+        this.bridge.pump();       // pump 2
+        var rF = this.processor.regions.get((3L << 32) | 2L);
+        var rE = this.processor.regions.get((2L << 32) | 2L);
+        assertNotNull(rF);
+        assertNotNull(rE);
+        rF.resting = false;
+        rE.resting = false;
+        this.bridge.pump();       // 3
+        this.bridge.pump();       // 4: F due → stalled
+        this.bridge.pump();       // 5: E due → stalled
+        assertEquals(0, this.bridge.counterForTest("buffer_updates"));
+        assertEquals(2, this.bridge.counterForTest("pending_updates"));
+        rF.resting = true;
+        rE.resting = true;
+        offer(65, 64);            // a second tile of E's tile chunk, for this pump's drain
+        this.bridge.pump();       // 6: flush rebuilds F (older) and stops; drain re-touches E
+        assertEquals(1, this.bridge.counterForTest("buffer_updates"));
+        assertEquals(1, this.bridge.counterForTest("pending_updates"));
+        this.bridge.pump();       // 7
+        this.bridge.pump();       // 8
+        assertEquals(1, this.bridge.counterForTest("buffer_updates"),
+                "the re-touch reset E's stall clock: it waits a fresh idle window instead of"
+                        + " rebuilding at once as a still-stalled entry would");
+        this.bridge.pump();       // 9: three pumps since the touch at 6
+        assertEquals(2, this.bridge.counterForTest("buffer_updates"));
     }
 
     @Test
@@ -998,17 +1087,107 @@ class XaeroMapCompatTest {
     }
 
     @Test
-    void aDimensionChangeDropsTheOtherDimensionsOwedRebuilds() {
+    void anotherDimensionsOwedRebuildsWaitForTheReturnAndDropAfterTheStallWindow() {
         this.bridge.updateIdlePumps = 1;
+        this.bridge.updateMaxStallPumps = 4;
         offer(64, 64);
         this.bridge.pump();
         this.processor.mapWorld.currentDimensionId = NETHER;
         this.clientDimension = NETHER;
-        pumpIdleWindow();
-        assertEquals(1, this.bridge.counterForTest("dropped_updates"),
-                "the pixel recipe reads the CURRENT world — a cross-dimension rebuild is wrong");
-        assertEquals(0, this.bridge.counterForTest("pending_updates"));
+        this.bridge.pump();
+        this.bridge.pump();
+        assertEquals(1, this.bridge.counterForTest("pending_updates"),
+                "the pixel recipe reads the CURRENT dimension's shading — wait, don't rebuild");
+        assertEquals(0, this.bridge.counterForTest("dropped_updates"));
         assertFalse(XaeroStubEvents.snapshot().stream().anyMatch(e -> e.startsWith("tileChunk.updateBuffers")));
+        // Back in time: the rebuild runs on return.
+        this.processor.mapWorld.currentDimensionId = OVERWORLD;
+        this.clientDimension = OVERWORLD;
+        this.bridge.pump();
+        assertEquals(1, this.bridge.counterForTest("buffer_updates"));
+        // Away past the stall window: dropped (counted) — the accepted residual.
+        offer(68, 64);
+        this.bridge.pump();
+        this.processor.mapWorld.currentDimensionId = NETHER;
+        this.clientDimension = NETHER;
+        for (int i = 0; i < 7; i++) this.bridge.pump();
+        assertEquals(1, this.bridge.counterForTest("dropped_updates"));
+        assertEquals(0, this.bridge.counterForTest("pending_updates"));
+        assertEquals(1, this.bridge.counterForTest("buffer_updates"));
+    }
+
+    @Test
+    void aPreviousXaeroSessionsOwedRebuildsDropOnProcessorOrWorldIdentity() {
+        // A server-initiated reconfiguration skips the disconnect event (ClientNetGlue's
+        // documented residual); a ResourceKey alone is identity-stable across servers.
+        this.bridge.updateIdlePumps = 1;
+        offer(64, 64);
+        this.bridge.pump();
+        this.processor.currentWorldId = "another-server";
+        pumpIdleWindow();
+        assertEquals(1, this.bridge.counterForTest("dropped_updates"));
+        assertEquals(0, this.bridge.counterForTest("pending_updates"));
+        this.processor.currentWorldId = "stub-world";
+        offer(68, 64);
+        this.bridge.pump();
+        var fresh = new MapProcessor();
+        fresh.world = this.worldToken;
+        fresh.mainWorld = this.worldToken;
+        fresh.mapWorld.currentDimensionId = OVERWORLD;
+        WorldMapSession.current.processor = fresh;
+        pumpIdleWindow();
+        assertEquals(2, this.bridge.counterForTest("dropped_updates"),
+                "a new MapProcessor = a new Xaero session: the old objects are never touched");
+        assertFalse(XaeroStubEvents.snapshot().stream().anyMatch(e -> e.startsWith("tileChunk.updateBuffers")));
+    }
+
+    @Test
+    void aReplacedTileChunkGetsAFreshOwedEntry() {
+        this.bridge.updateIdlePumps = 2;
+        offer(64, 64);
+        this.bridge.pump();
+        var region = theRegion();
+        MapTileChunk old = region.getChunk(0, 0);
+        var replacement = new MapTileChunk(region, 16, 16); // Xaero reloaded the region
+        replacement.loadState = 2;
+        region.setChunk(0, 0, replacement);
+        offer(65, 64);
+        this.bridge.pump();
+        pumpIdleWindow();
+        assertEquals(1, replacement.bufferUpdates, "the replacement is rebuilt");
+        assertEquals(0, old.bufferUpdates);
+        assertEquals(0, this.bridge.counterForTest("dropped_updates"),
+                "reusing the old entry would have failed its identity check and dropped");
+    }
+
+    @Test
+    void aContinuousTrickleStillRebuildsAtTheAgeCeiling() {
+        this.bridge.updateIdlePumps = 3;
+        this.bridge.updateMaxDeferPumps = 6;
+        for (int i = 0; i < 8; i++) {
+            offer(64 + (i & 3), 64 + (i >> 2)); // a new tile of tile chunk (16,16) every pump
+            this.bridge.pump();
+            if (i < 5) {
+                assertEquals(0, this.bridge.counterForTest("buffer_updates"),
+                        "re-touched inside the idle window: coalescing holds (pump " + (i + 1) + ")");
+            }
+        }
+        assertTrue(this.bridge.counterForTest("buffer_updates") >= 1,
+                "the age ceiling forces the rebuild — a written tile chunk must never stay blank");
+    }
+
+    @Test
+    void theDeathLatchReleasesOwedRebuilds() {
+        this.bridge.updateIdlePumps = 1000;
+        offer(64, 64);
+        this.bridge.pump();
+        assertEquals(1, this.bridge.counterForTest("pending_updates"));
+        latchTheBridgeDead();
+        assertTrue(this.bridge.deadForTest(), "premise");
+        this.bridge.pump();
+        assertEquals(0, this.bridge.counterForTest("pending_updates"),
+                "a dead bridge must not pin Xaero's regions/tile chunks (direct texture buffers)"
+                        + " for the rest of the session");
     }
 
     @Test
@@ -1027,6 +1206,10 @@ class XaeroMapCompatTest {
         this.bridge.pump();
         assertTrue(this.bridge.deadForTest(), "a throwing rebuild is a commit-side failure");
         assertTrue(this.bridge.counterForTest("commit_failures") >= XaeroMapCompat.THROW_LATCH);
+        assertEquals(XaeroMapCompat.THROW_LATCH, this.bridge.counterForTest("dropped_updates"),
+                "owed and never rebuilt: buffer_updates + dropped_updates accounts for every entry");
+        this.bridge.pump();
+        assertEquals(0, this.bridge.counterForTest("pending_updates"));
     }
 
     @Test

--- a/fabric/src/test/java/dev/vox/lss/compat/XaeroMapCompatTest.java
+++ b/fabric/src/test/java/dev/vox/lss/compat/XaeroMapCompatTest.java
@@ -42,8 +42,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  *       DEFERS (entries retained), a stale-dimension entry DROPS, a loaded chunk
  *       SKIPS; the region-level save-race gate defers too;</li>
  *   <li>the decompiled commit sequence order, incl. setChanged(true) before
- *       setTile, worldInterpretationVersion before setTile, the flag-then-consume
- *       buffers pattern (no updateBuffers handle exists at all), the faithful
+ *       setTile, worldInterpretationVersion before setTile, NO setToUpdateBuffers
+ *       flag ever (Xaero's sweep consumes it outside isResting — the
+ *       cache-not-prepared crash, plan §15) with the texture rebuild coalesced
+ *       into the pump's flush phase under the writer gates, the faithful
  *       prepare→overlays→write per-pixel order (the stub's prepareForWriting
  *       clears overlays like the real one, so a wrong order wipes them), and
  *       {@code setBeingWritten} set-and-NEVER-cleared;</li>
@@ -82,10 +84,12 @@ class XaeroMapCompatTest {
     private final List<dev.vox.lss.api.VoxelColumnConsumer> registered = new ArrayList<>();
     private XaeroMapCompat bridge;
 
+    private ResourceKey<Level> clientDimension = OVERWORLD;
+
     private final XaeroMapCompat.LevelOps fakeLevelOps = new XaeroMapCompat.LevelOps() {
         @Override
         public Object dimension(Object world) {
-            return OVERWORLD;
+            return clientDimension;
         }
 
         @Override
@@ -122,6 +126,7 @@ class XaeroMapCompatTest {
                 this.registered::add,
                 this.registered::remove);
         this.bridge.pumpNanosBudget = Long.MAX_VALUE; // neutralize MethodHandle warmup
+        this.bridge.updateNanosBudget = Long.MAX_VALUE;
         this.bridge.maybeRegister();
     }
 
@@ -769,12 +774,259 @@ class XaeroMapCompatTest {
                         && writtenOnce > setTile && loaded > writtenOnce,
                 "commit order must mirror the decompiled writeChunk: " + events);
 
-        // Buffers: flag-then-consume, never a direct updateBuffers (no handle exists).
-        int toUpdate = events.lastIndexOf("tileChunk.setToUpdateBuffers true");
+        // Buffers: NO setToUpdateBuffers flag (Xaero's preUpload sweep consumes it with
+        // no isResting check — the "cache not prepared" saver crash, plan §15) and no
+        // rebuild at commit either: the change stays MARKED for the coalesced rebuild
+        // phase, which consumes it (pinned in the rebuild-phase tests below).
+        assertFalse(events.stream().anyMatch(e -> e.startsWith("tileChunk.setToUpdateBuffers")),
+                "the flag must never be set: " + events);
+        assertFalse(events.stream().anyMatch(e -> e.startsWith("tileChunk.updateBuffers")),
+                "no rebuild inside the commit (coalesced per tile chunk): " + events);
+        assertFalse(events.contains("tileChunk.setChanged false"),
+                "the change is consumed by the rebuild, not the commit: " + events);
+    }
+
+    // ---- the rebuild phase (plan §15: the cache-not-prepared crash) ----
+
+    private void pumpIdleWindow() {
+        for (int i = 0; i <= this.bridge.updateIdlePumps; i++) {
+            this.bridge.pump();
+        }
+    }
+
+    private MapRegion theRegion() {
+        assertEquals(1, this.processor.regions.size(), "one region in play");
+        return this.processor.regions.values().iterator().next();
+    }
+
+    private static long count(List<String> events, String event) {
+        return events.stream().filter(event::equals).count();
+    }
+
+    @Test
+    void theRebuildRunsUnderTheWriterGatesAfterTheIdleWindowAndReArmsBeingWritten() {
+        this.bridge.updateIdlePumps = 3;
+        offer(64, 64);
+        this.bridge.pump();
+        assertEquals(1, this.bridge.counterForTest("written"));
+        assertEquals(1, this.bridge.counterForTest("pending_updates"));
+        var region = theRegion();
+        MapTileChunk tileChunk = region.getChunk(0, 0);
+        assertTrue(tileChunk.wasChanged(), "the native transient: changed, unflagged");
+        this.bridge.pump();
+        assertFalse(XaeroStubEvents.snapshot().contains("tileChunk.updateBuffers 16,16"),
+                "inside the coalescing window nothing rebuilds yet");
+
+        // The saver reset beingWritten between the commit and the rebuild.
+        region.beingWritten = false;
+        pumpIdleWindow();
+        var events = XaeroStubEvents.snapshot();
+        int rebuilt = events.lastIndexOf("tileChunk.updateBuffers 16,16");
         int consumed = events.lastIndexOf("tileChunk.setChanged false");
-        assertTrue(toUpdate > loaded && consumed > toUpdate,
-                "buffers are flagged for Xaero's preUpload sweep, then the change is"
-                        + " consumed (the native neighbor pattern): " + events);
+        assertTrue(rebuilt >= 0 && consumed > rebuilt,
+                "rebuild (under both region monitors — the stub enforces), then the change"
+                        + " is consumed: " + events);
+        assertEquals(Boolean.TRUE, region.beingWritten,
+                "re-armed before the rebuild: the rebuilt texture must reach the cache, and"
+                        + " the save path is what requests it");
+        assertFalse(events.contains("region.setBeingWritten false"));
+        assertFalse(tileChunk.wasChanged());
+        assertFalse(region.allCachePrepared,
+                "the rebuild un-prepares the region — the flip the saver races on");
+        assertEquals(1, this.bridge.counterForTest("buffer_updates"));
+        assertEquals(0, this.bridge.counterForTest("pending_updates"));
+        assertEquals(1, tileChunk.bufferUpdates);
+        assertTrue(events.contains("fastConfig.new"), "the native per-pass config snapshot");
+    }
+
+    @Test
+    void rebuildsCoalescePerTileChunkAcrossPumps() {
+        this.bridge.updateIdlePumps = 3;
+        offer(64, 64);
+        offer(65, 64);
+        this.bridge.pump();
+        offer(66, 65);
+        offer(67, 67); // tile chunk (16,16) touched again — its window restarts
+        this.bridge.pump();
+        offer(68, 64); // tile chunk (17,16)
+        this.bridge.pump();
+        assertEquals(5, this.bridge.counterForTest("written"));
+        assertEquals(2, this.bridge.counterForTest("pending_updates"));
+        pumpIdleWindow();
+        var events = XaeroStubEvents.snapshot();
+        assertEquals(1, count(events, "tileChunk.updateBuffers 16,16"),
+                "four tiles of one tile chunk → ONE rebuild: " + events);
+        assertEquals(1, count(events, "tileChunk.updateBuffers 17,16"));
+        assertEquals(2, this.bridge.counterForTest("buffer_updates"));
+        assertEquals(0, this.bridge.counterForTest("pending_updates"));
+    }
+
+    @Test
+    void aRebuildWaitsForARestingRegionAndAPermanentStallDrops() {
+        this.bridge.updateIdlePumps = 1;
+        this.bridge.updateMaxStallPumps = 3;
+        offer(64, 64);
+        this.bridge.pump();
+        var region = theRegion();
+        region.resting = false; // recache requested / being saved — the crash window
+        this.bridge.pump();
+        this.bridge.pump();
+        assertFalse(XaeroStubEvents.snapshot().contains("tileChunk.updateBuffers 16,16"),
+                "never un-prepare a region that may be queued for caching");
+        assertEquals(1, this.bridge.counterForTest("pending_updates"));
+        region.resting = true;
+        this.bridge.pump();
+        assertTrue(XaeroStubEvents.snapshot().contains("tileChunk.updateBuffers 16,16"));
+        assertEquals(0, this.bridge.counterForTest("pending_updates"));
+        assertEquals(0, this.bridge.counterForTest("dropped_updates"));
+
+        offer(68, 64);
+        this.bridge.pump();
+        region.resting = false;
+        for (int i = 0; i < 6; i++) {
+            this.bridge.pump();
+        }
+        assertFalse(XaeroStubEvents.snapshot().contains("tileChunk.updateBuffers 17,16"));
+        assertEquals(1, this.bridge.counterForTest("dropped_updates"),
+                "a region that never rests drops its owed rebuild, counted (its texture"
+                        + " self-heals on reload)");
+        assertEquals(0, this.bridge.counterForTest("pending_updates"));
+    }
+
+    @Test
+    void theHardCapPausesCommitsUntilRebuildsDrain() {
+        this.bridge.updateIdlePumps = 1;
+        this.bridge.pendingUpdatesHardCap = 2;
+        offer(64, 64);
+        offer(68, 64);
+        this.bridge.pump();
+        assertEquals(2, this.bridge.counterForTest("written"));
+        var region = theRegion();
+        region.resting = false;
+        offer(72, 64);
+        this.bridge.pump();
+        assertEquals(2, this.bridge.counterForTest("written"),
+                "at the hard cap commits pause — the owed set must never grow unbounded");
+        assertEquals(1, this.bridge.queuedForTest(), "the entry stays queued, not dropped");
+        assertEquals(0, this.bridge.counterForTest("dropped_expired"));
+        region.resting = true;
+        this.bridge.pump();
+        assertEquals(3, this.bridge.counterForTest("written"),
+                "the flush runs before the drain: drained rebuilds free the commit");
+        assertEquals(2, this.bridge.counterForTest("buffer_updates"));
+    }
+
+    @Test
+    void theSoftCapMakesTheOldestOwedRebuildDueAtOnce() {
+        this.bridge.updateIdlePumps = 1000;
+        this.bridge.pendingUpdatesSoftCap = 1;
+        offer(64, 64);
+        this.bridge.pump();
+        this.bridge.pump();
+        assertFalse(XaeroStubEvents.snapshot().contains("tileChunk.updateBuffers 16,16"),
+                "at the cap nothing is over it");
+        offer(68, 64);
+        this.bridge.pump(); // commits (17,16) — the flush ran before, saw 1 pending
+        this.bridge.pump(); // now 2 pending → the oldest is over the cap
+        var events = XaeroStubEvents.snapshot();
+        assertTrue(events.contains("tileChunk.updateBuffers 16,16"), events.toString());
+        assertFalse(events.contains("tileChunk.updateBuffers 17,16"),
+                "only the overflow is forced; the youngest keeps its window");
+        assertEquals(1, this.bridge.counterForTest("pending_updates"));
+    }
+
+    @Test
+    void anUnloadedOrReplacedTileChunkDropsItsOwedRebuild() {
+        this.bridge.updateIdlePumps = 1;
+        offer(64, 64);
+        this.bridge.pump();
+        var region = theRegion();
+        region.setChunk(0, 0, new MapTileChunk(region, 16, 16)); // replaced
+        this.bridge.pump();
+        this.bridge.pump();
+        assertEquals(1, this.bridge.counterForTest("dropped_updates"));
+        offer(68, 64);
+        this.bridge.pump();
+        region.loadState = 0; // unloaded
+        this.bridge.pump();
+        this.bridge.pump();
+        assertEquals(2, this.bridge.counterForTest("dropped_updates"));
+        assertEquals(0, this.bridge.counterForTest("pending_updates"));
+        assertFalse(XaeroStubEvents.snapshot().stream().anyMatch(e -> e.startsWith("tileChunk.updateBuffers")),
+                "a reload rebuilds its own textures — never touch a foreign tile chunk");
+    }
+
+    @Test
+    void aChangeTheNativeWriterAlreadyConsumedNeedsNoRebuild() {
+        this.bridge.updateIdlePumps = 1;
+        offer(64, 64);
+        this.bridge.pump();
+        theRegion().getChunk(0, 0).changed = false; // native bottom-neighbor consumption
+        pumpIdleWindow();
+        assertFalse(XaeroStubEvents.snapshot().stream().anyMatch(e -> e.startsWith("tileChunk.updateBuffers")));
+        assertEquals(0, this.bridge.counterForTest("buffer_updates"));
+        assertEquals(0, this.bridge.counterForTest("pending_updates"));
+    }
+
+    @Test
+    void owedRebuildsFlushEvenAfterTheBridgeIsDisabledOrTheQueueEmpties() {
+        this.bridge.updateIdlePumps = 1;
+        offer(64, 64);
+        this.bridge.pump();
+        offer(68, 64); // queued, never committed
+        this.enabled = false;
+        this.bridge.pump();
+        this.bridge.pump();
+        assertEquals(0, this.bridge.queuedForTest(), "the live toggle still drops the backlog");
+        assertTrue(XaeroStubEvents.snapshot().contains("tileChunk.updateBuffers 16,16"),
+                "a rebuild owed to an already-written tile chunk still runs — dropping it"
+                        + " would leave written tiles invisible until a reload");
+        assertEquals(0, this.bridge.counterForTest("pending_updates"));
+    }
+
+    @Test
+    void sessionEndClearsOwedRebuilds() {
+        this.bridge.updateIdlePumps = 1;
+        offer(64, 64);
+        this.bridge.pump();
+        assertEquals(1, this.bridge.counterForTest("pending_updates"));
+        this.bridge.onSessionEnd();
+        assertEquals(0, this.bridge.counterForTest("pending_updates"));
+        pumpIdleWindow();
+        assertFalse(XaeroStubEvents.snapshot().stream().anyMatch(e -> e.startsWith("tileChunk.updateBuffers")),
+                "the old world's tile chunks are never touched again");
+    }
+
+    @Test
+    void aDimensionChangeDropsTheOtherDimensionsOwedRebuilds() {
+        this.bridge.updateIdlePumps = 1;
+        offer(64, 64);
+        this.bridge.pump();
+        this.processor.mapWorld.currentDimensionId = NETHER;
+        this.clientDimension = NETHER;
+        pumpIdleWindow();
+        assertEquals(1, this.bridge.counterForTest("dropped_updates"),
+                "the pixel recipe reads the CURRENT world — a cross-dimension rebuild is wrong");
+        assertEquals(0, this.bridge.counterForTest("pending_updates"));
+        assertFalse(XaeroStubEvents.snapshot().stream().anyMatch(e -> e.startsWith("tileChunk.updateBuffers")));
+    }
+
+    @Test
+    void rebuildFailuresCountTowardTheDeathLatch() {
+        this.bridge.updateIdlePumps = 1;
+        for (int i = 0; i < XaeroMapCompat.THROW_LATCH; i++) {
+            offer(64 + 4 * i, 64); // five tile chunks of region (2,2)
+        }
+        this.bridge.pump();
+        assertEquals(XaeroMapCompat.THROW_LATCH, this.bridge.counterForTest("written"));
+        var region = theRegion();
+        for (int i = 0; i < XaeroMapCompat.THROW_LATCH; i++) {
+            region.getChunk(i, 0).updateBuffersThrows = true;
+        }
+        this.bridge.pump();
+        this.bridge.pump();
+        assertTrue(this.bridge.deadForTest(), "a throwing rebuild is a commit-side failure");
+        assertTrue(this.bridge.counterForTest("commit_failures") >= XaeroMapCompat.THROW_LATCH);
     }
 
     @Test
@@ -1037,7 +1289,8 @@ class XaeroMapCompatTest {
         assertTrue(line.startsWith("XaeroMap: state=active, queued="), line);
         assertTrue(line.contains(", written=") && line.contains(", defer_events=")
                 && line.contains(", dropped=") && line.contains(", commit_failures=")
-                && line.contains(", regions_waiting="), line);
+                && line.contains(", regions_waiting=") && line.contains(", buffer_updates=")
+                && line.contains(", pending_updates=") && line.contains(", dropped_updates="), line);
         this.enabled = false;
         assertTrue(this.bridge.describe().contains("state=disabled"));
     }

--- a/fabric/src/test/java/dev/vox/lss/compat/XaeroMapCompatTest.java
+++ b/fabric/src/test/java/dev/vox/lss/compat/XaeroMapCompatTest.java
@@ -845,12 +845,64 @@ class XaeroMapCompatTest {
         assertTrue(tileChunk.lastUpdateCache == this.processor.shapeCache);
         assertNotNull(tileChunk.lastUpdateConfig);
         assertFalse(tileChunk.lastUpdateDebug, "the writer's detailed-debug flag is log-only: false");
+        assertFalse(events.stream().anyMatch(e -> e.startsWith("tileChunk.setToUpdateBuffers")),
+                "the rebuild phase never sets the flag either (the §15 invariant in both phases)");
+    }
+
+    @Test
+    void owedRegionsAreKeptVisitedSoXaeroCannotParkThem() {
+        // LeafRegionTexture.postUpload parks a region (loadState 3, tiles released) once it
+        // is not being written, 1 s passed since its last visit and no tile chunk carries
+        // the flag — the flag WAS the park guard (review A MAJOR); the visit is ours now.
+        this.bridge.updateIdlePumps = 1000;
+        offer(64, 64);
+        offer(68, 64);
+        this.bridge.pump();
+        var region = theRegion();
+        int visits = region.visits;
+        this.bridge.pump();
+        this.bridge.pump();
+        assertEquals(2, region.visits - visits, "one visit per owed REGION per pump, not per entry");
+        region.loadState = 0; // unloaded: never visit a region that is not loaded
+        visits = region.visits;
+        this.bridge.pump();
+        assertEquals(0, region.visits - visits);
+    }
+
+    @Test
+    void theFlushBorrowsTheCommitBudgetOnlyWhenTheQueueIsEmptyOrTheSetIsPastTheSoftCap() {
+        this.bridge.updateIdlePumps = 1;
+        this.bridge.updateNanosBudget = 0;
+        this.bridge.updateBorrowNanos = Long.MAX_VALUE;
+        this.bridge.pendingUpdatesSoftCap = 100;
+        offer(64, 64);
+        offer(68, 64);
+        offer(72, 64);
+        this.bridge.pump();
+        offer(96, 64); // a queued entry the drain will NOT reach: its region is busy
+        var other = new MapRegion();
+        other.resting = false;
+        this.processor.regions.put((3L << 32) | 2L, other);
+        this.bridge.pump(); // queue non-empty, set under the soft cap: budget 0 → one rebuild
+        assertEquals(1, this.bridge.counterForTest("buffer_updates"));
+        this.bridge.pendingUpdatesSoftCap = 1; // past the soft cap: half the borrow → all
+        this.bridge.pump();
+        assertEquals(3, this.bridge.counterForTest("buffer_updates"),
+                "past the soft cap the flush borrows half the commit budget (Long.MAX_VALUE/2):"
+                        + " both remaining entries rebuild in one pump");
+        offer(76, 64);
+        this.bridge.pendingUpdatesSoftCap = 100;
+        this.bridge.pump(); // commits (19,16)
+        this.bridge.queueLockedClearForTest();
+        this.bridge.pump(); // queue EMPTY: the whole borrow → everything due rebuilds
+        assertEquals(0, this.bridge.counterForTest("pending_updates"));
     }
 
     @Test
     void aZeroRebuildBudgetStillRebuildsOnePerPumpAndResumes() {
         this.bridge.updateIdlePumps = 1;
         this.bridge.updateNanosBudget = 0;
+        this.bridge.updateBorrowNanos = 0; // pin truncation: no borrowing
         offer(64, 64);
         offer(68, 64);
         this.bridge.pump();
@@ -867,6 +919,7 @@ class XaeroMapCompatTest {
     void aNotReadyRegionIsProbedOncePerFlushAndConsumesNoProgress() {
         this.bridge.updateIdlePumps = 2;
         this.bridge.updateNanosBudget = 0;
+        this.bridge.updateBorrowNanos = 0; // pin truncation: no borrowing
         offer(64, 64);
         offer(68, 64);
         offer(72, 64); // three tile chunks of region (2,2)
@@ -898,6 +951,7 @@ class XaeroMapCompatTest {
         // commits into its tile chunk. The reset makes it wait a FRESH idle window.
         this.bridge.updateIdlePumps = 3;
         this.bridge.updateNanosBudget = 0; // one removing outcome per pump
+        this.bridge.updateBorrowNanos = 0; // pin truncation: no borrowing
         offer(96, 64);            // F: tile chunk (24,16), region (3,2) — the OLDER entry
         this.bridge.pump();       // pump 1
         offer(64, 64);            // E: tile chunk (16,16), region (2,2)
@@ -1033,13 +1087,21 @@ class XaeroMapCompatTest {
         region.setChunk(0, 0, new MapTileChunk(region, 16, 16)); // replaced
         this.bridge.pump();
         this.bridge.pump();
-        assertEquals(1, this.bridge.counterForTest("dropped_updates"));
+        assertEquals(1, this.bridge.counterForTest("dropped_unloaded"));
         offer(68, 64);
         this.bridge.pump();
         region.loadState = 0; // unloaded
         this.bridge.pump();
         this.bridge.pump();
-        assertEquals(2, this.bridge.counterForTest("dropped_updates"));
+        assertEquals(2, this.bridge.counterForTest("dropped_unloaded"));
+        region.loadState = 2;
+        offer(72, 64);
+        this.bridge.pump();
+        region.getChunk(2, 0).loadState = 0; // a tile-chunk-only teardown (deleteTexturesAndBuffers)
+        this.bridge.pump();
+        this.bridge.pump();
+        assertEquals(3, this.bridge.counterForTest("dropped_unloaded"));
+        assertEquals(0, this.bridge.counterForTest("dropped_updates"), "its own counter — a parking race must be tellable apart");
         assertEquals(0, this.bridge.counterForTest("pending_updates"));
         assertFalse(XaeroStubEvents.snapshot().stream().anyMatch(e -> e.startsWith("tileChunk.updateBuffers")),
                 "a reload rebuilds its own textures — never touch a foreign tile chunk");
@@ -1081,6 +1143,7 @@ class XaeroMapCompatTest {
         assertEquals(1, this.bridge.counterForTest("pending_updates"));
         this.bridge.onSessionEnd();
         assertEquals(0, this.bridge.counterForTest("pending_updates"));
+        assertEquals(1, this.bridge.counterForTest("dropped_updates"), "lost, counted");
         pumpIdleWindow();
         assertFalse(XaeroStubEvents.snapshot().stream().anyMatch(e -> e.startsWith("tileChunk.updateBuffers")),
                 "the old world's tile chunks are never touched again");
@@ -1204,7 +1267,12 @@ class XaeroMapCompatTest {
         }
         this.bridge.pump();
         this.bridge.pump();
-        assertTrue(this.bridge.deadForTest(), "a throwing rebuild is a commit-side failure");
+        assertTrue(this.bridge.deadForTest(), "a throwing rebuild is a commit-side failure"
+                + " (commit_failures=" + this.bridge.counterForTest("commit_failures")
+                + " dropped_updates=" + this.bridge.counterForTest("dropped_updates")
+                + " dropped_unloaded=" + this.bridge.counterForTest("dropped_unloaded")
+                + " pending=" + this.bridge.counterForTest("pending_updates")
+                + " buffer_updates=" + this.bridge.counterForTest("buffer_updates") + ")");
         assertTrue(this.bridge.counterForTest("commit_failures") >= XaeroMapCompat.THROW_LATCH);
         assertEquals(XaeroMapCompat.THROW_LATCH, this.bridge.counterForTest("dropped_updates"),
                 "owed and never rebuilt: buffer_updates + dropped_updates accounts for every entry");
@@ -1473,7 +1541,8 @@ class XaeroMapCompatTest {
         assertTrue(line.contains(", written=") && line.contains(", defer_events=")
                 && line.contains(", dropped=") && line.contains(", commit_failures=")
                 && line.contains(", regions_waiting=") && line.contains(", buffer_updates=")
-                && line.contains(", pending_updates=") && line.contains(", dropped_updates="), line);
+                && line.contains(", pending_updates=") && line.contains(", dropped_updates=")
+                && line.contains(", dropped_unloaded="), line);
         this.enabled = false;
         assertTrue(this.bridge.describe().contains("state=disabled"));
     }

--- a/fabric/src/test/java/xaero/map/MapProcessor.java
+++ b/fabric/src/test/java/xaero/map/MapProcessor.java
@@ -1,5 +1,6 @@
 package xaero.map;
 
+import xaero.map.biome.BlockTintProvider;
 import xaero.map.cache.BlockStateShortShapeCache;
 import xaero.map.file.MapSaveLoad;
 import xaero.map.highlight.MapRegionHighlightsPreparer;
@@ -27,6 +28,7 @@ public class MapProcessor {
     public MapTilePool tilePool = new MapTilePool();
     public OverlayManager overlayManager = new OverlayManager();
     public BlockStateShortShapeCache shapeCache = new BlockStateShortShapeCache();
+    public BlockTintProvider tintProvider = new BlockTintProvider();
     public MapRegionHighlightsPreparer highlightsPreparer = new MapRegionHighlightsPreparer();
     public final java.util.Map<Long, MapRegion> regions = new java.util.HashMap<>();
     public boolean leafMapRegionReturnsNull;
@@ -80,6 +82,8 @@ public class MapProcessor {
     public OverlayManager getOverlayManager() { return this.overlayManager; }
 
     public BlockStateShortShapeCache getBlockStateShortShapeCache() { return this.shapeCache; }
+
+    public BlockTintProvider getWorldBlockTintProvider() { return this.tintProvider; }
 
     public MapRegionHighlightsPreparer getMapRegionHighlightsPreparer() { return this.highlightsPreparer; }
 

--- a/fabric/src/test/java/xaero/map/biome/BlockTintProvider.java
+++ b/fabric/src/test/java/xaero/map/biome/BlockTintProvider.java
@@ -1,0 +1,5 @@
+package xaero.map.biome;
+
+/** Tier-1 stub — an opaque rebuild input ({@code MapProcessor.getWorldBlockTintProvider}). */
+public class BlockTintProvider {
+}

--- a/fabric/src/test/java/xaero/map/region/MapRegion.java
+++ b/fabric/src/test/java/xaero/map/region/MapRegion.java
@@ -27,7 +27,12 @@ public class MapRegion extends LeveledRegion<Object> {
         }
     }
 
+    /** Gate probes (writer-pause monitor acquisitions) — the flush must probe a
+     *  not-ready region ONCE per pump, not once per owed tile chunk. */
+    public int gateProbes;
+
     public boolean isWritingPaused() {
+        this.gateProbes++;
         if (!Thread.holdsLock(this.writerThreadPauseSync)) {
             throw new IllegalStateException("region.isWritingPaused outside"
                     + " writerThreadPauseSync — the save-race exclusion's monitor");

--- a/fabric/src/test/java/xaero/map/region/MapRegion.java
+++ b/fabric/src/test/java/xaero/map/region/MapRegion.java
@@ -16,6 +16,8 @@ public class MapRegion extends LeveledRegion<Object> {
     public boolean canRequestReload = true;
     public int visits;
     public Boolean beingWritten; // null until first set — pins "set true, never cleared"
+    /** The saver's cache precondition (real: LeveledRegion) — a rebuild flips it false. */
+    public boolean allCachePrepared = true;
     public final MapTileChunk[][] chunks = new MapTileChunk[8][8];
 
     private void requireRegionMonitor(String site) {
@@ -72,6 +74,7 @@ public class MapRegion extends LeveledRegion<Object> {
     }
 
     public void setAllCachePrepared(boolean prepared) {
+        this.allCachePrepared = prepared;
         dev.vox.lss.compat.XaeroStubEvents.record("region.setAllCachePrepared " + prepared);
     }
 

--- a/fabric/src/test/java/xaero/map/region/MapTileChunk.java
+++ b/fabric/src/test/java/xaero/map/region/MapTileChunk.java
@@ -78,9 +78,14 @@ public class MapTileChunk {
     }
 
     /** FAITHFUL side effect (decompiled): the leaf texture is re-marked to upload and
-     *  the region's cache flag drops — exactly the flip the saver throws on when it
-     *  lands after a cache request. The real method also hard-throws off the render
-     *  thread; the native writer calls it under BOTH region monitors. */
+     *  the region's cache flag drops (near the START of the real method, before the
+     *  4096-pixel pass) — exactly the flip the saver throws on when it lands after a
+     *  cache request. The real method also hard-throws off the render thread. The
+     *  monitor pin is the BRIDGE's chosen tightening, not Xaero's contract: the
+     *  native writer holds only writerThreadPauseSync at its updateBuffers calls
+     *  (the region monitor is released after the write) — the bridge additionally
+     *  holds the region monitor, which is safe (review A: the only nesting orders in
+     *  the jar are both render-thread-only). */
     public void updateBuffers(MapProcessor processor, BlockTintProvider tint,
                               OverlayManager overlayManager, boolean detailedDebug,
                               BlockStateShortShapeCache cache, MapUpdateFastConfig config) {

--- a/fabric/src/test/java/xaero/map/region/MapTileChunk.java
+++ b/fabric/src/test/java/xaero/map/region/MapTileChunk.java
@@ -20,6 +20,12 @@ public class MapTileChunk {
     public boolean setTileThrows; // arms the throw-latch tests
     public boolean updateBuffersThrows; // arms the rebuild-side latch tests
     public int bufferUpdates;
+    public MapProcessor lastUpdateProcessor;
+    public BlockTintProvider lastUpdateTint;
+    public OverlayManager lastUpdateOverlay;
+    public boolean lastUpdateDebug;
+    public BlockStateShortShapeCache lastUpdateCache;
+    public MapUpdateFastConfig lastUpdateConfig;
 
     public MapTileChunk(MapRegion region, int tileChunkX, int tileChunkZ) {
         this.region = region;
@@ -84,6 +90,12 @@ public class MapTileChunk {
         }
         if (this.updateBuffersThrows) throw new IllegalStateException("armed updateBuffers throw");
         this.bufferUpdates++;
+        this.lastUpdateProcessor = processor;
+        this.lastUpdateTint = tint;
+        this.lastUpdateOverlay = overlayManager;
+        this.lastUpdateDebug = detailedDebug;
+        this.lastUpdateCache = cache;
+        this.lastUpdateConfig = config;
         this.region.setAllCachePrepared(false);
         dev.vox.lss.compat.XaeroStubEvents.record("tileChunk.updateBuffers " + this.tileChunkX
                 + "," + this.tileChunkZ + (detailedDebug ? " debug" : ""));

--- a/fabric/src/test/java/xaero/map/region/MapTileChunk.java
+++ b/fabric/src/test/java/xaero/map/region/MapTileChunk.java
@@ -1,6 +1,7 @@
 package xaero.map.region;
 
 import xaero.map.MapProcessor;
+import xaero.map.biome.BlockTintProvider;
 import xaero.map.cache.BlockStateShortShapeCache;
 import xaero.map.region.texture.LeafRegionTexture;
 
@@ -17,6 +18,8 @@ public class MapTileChunk {
     public final LeafRegionTexture leafTexture = new LeafRegionTexture();
     public final MapTile[][] tiles = new MapTile[4][4];
     public boolean setTileThrows; // arms the throw-latch tests
+    public boolean updateBuffersThrows; // arms the rebuild-side latch tests
+    public int bufferUpdates;
 
     public MapTileChunk(MapRegion region, int tileChunkX, int tileChunkZ) {
         this.region = region;
@@ -66,5 +69,23 @@ public class MapTileChunk {
         if (this.setTileThrows) throw new IllegalStateException("armed setTile throw");
         this.tiles[x][z] = tile;
         dev.vox.lss.compat.XaeroStubEvents.record("tileChunk.setTile " + x + "," + z);
+    }
+
+    /** FAITHFUL side effect (decompiled): the leaf texture is re-marked to upload and
+     *  the region's cache flag drops — exactly the flip the saver throws on when it
+     *  lands after a cache request. The real method also hard-throws off the render
+     *  thread; the native writer calls it under BOTH region monitors. */
+    public void updateBuffers(MapProcessor processor, BlockTintProvider tint,
+                              OverlayManager overlayManager, boolean detailedDebug,
+                              BlockStateShortShapeCache cache, MapUpdateFastConfig config) {
+        if (!Thread.holdsLock(this.region.writerThreadPauseSync) || !Thread.holdsLock(this.region)) {
+            throw new IllegalStateException("updateBuffers outside the writer-pause + region"
+                    + " monitors — the native writer rebuilds under both");
+        }
+        if (this.updateBuffersThrows) throw new IllegalStateException("armed updateBuffers throw");
+        this.bufferUpdates++;
+        this.region.setAllCachePrepared(false);
+        dev.vox.lss.compat.XaeroStubEvents.record("tileChunk.updateBuffers " + this.tileChunkX
+                + "," + this.tileChunkZ + (detailedDebug ? " debug" : ""));
     }
 }

--- a/fabric/src/test/java/xaero/map/region/MapUpdateFastConfig.java
+++ b/fabric/src/test/java/xaero/map/region/MapUpdateFastConfig.java
@@ -1,0 +1,10 @@
+package xaero.map.region;
+
+import xaero.map.MapProcessor;
+
+/** Tier-1 stub — the per-pass settings snapshot the native onRender builds once. */
+public class MapUpdateFastConfig {
+    public MapUpdateFastConfig(MapProcessor processor) {
+        dev.vox.lss.compat.XaeroStubEvents.record("fastConfig.new");
+    }
+}

--- a/xplat/src/main/java/dev/vox/lss/compat/XaeroMapCompat.java
+++ b/xplat/src/main/java/dev/vox/lss/compat/XaeroMapCompat.java
@@ -122,11 +122,20 @@ final class XaeroMapCompat {
     /** At this many owed rebuilds COMMITS pause until the flush drains — a region
      *  that never rests (a stuck saver) must not grow the set without bound. */
     static final int PENDING_UPDATES_HARD_CAP = 1024;
-    /** A due rebuild whose region stays not-resting this long (~60 s) is dropped,
-     *  counted: the texture self-heals on the region's next reload. */
+    /** A due rebuild whose region stays not-ready this long (~60 s — not resting,
+     *  writer-paused, or the player is in another dimension) is dropped, counted.
+     *  Accepted residual: the tile chunk keeps its stale texture (changed=true,
+     *  unflagged) until the region's next native write or reload. */
     static final int UPDATE_MAX_STALL_PUMPS = 1200;
-    /** Rebuild budget per pump, separate from the commit budget; at least one
-     *  rebuild runs per pump so the set always drains. */
+    /** Absolute ceiling on coalescing: a tile chunk re-touched more often than the
+     *  idle window (a slow trickle) still rebuilds this many pumps (~8 s) after its
+     *  FIRST commit — the map must never show a written tile chunk blank
+     *  indefinitely (review B). */
+    static final int UPDATE_MAX_DEFER_PUMPS = 4 * UPDATE_IDLE_PUMPS;
+    /** Rebuild budget per pump, separate from the commit budget; the first REMOVING
+     *  outcome (rebuilt/dropped/failed) of a pump is exempt from it, so the set
+     *  always drains — not-ready verdicts are memoized per region and cost no
+     *  budget. */
     static final long UPDATE_NANOS_BUDGET = 2_000_000L;
     /** Consecutive failures (commit-side or extraction-side) before the bridge
      *  latches dead for the SESSION (re-armed at disconnect). */
@@ -278,6 +287,7 @@ final class XaeroMapCompat {
     int pendingUpdatesSoftCap = PENDING_UPDATES_SOFT_CAP;
     int pendingUpdatesHardCap = PENDING_UPDATES_HARD_CAP;
     int updateMaxStallPumps = UPDATE_MAX_STALL_PUMPS;
+    int updateMaxDeferPumps = UPDATE_MAX_DEFER_PUMPS;
     /** Tile chunks committed but not yet texture-rebuilt, keyed by tile-chunk
      *  coords and ordered by LAST TOUCH (a re-touch re-inserts at the tail, so
      *  idle-due entries are always a prefix). Main thread only. */
@@ -294,24 +304,33 @@ final class XaeroMapCompat {
      *  commit loop never reached are unknown). */
     private volatile int regionsWaiting;
 
-    /** A committed tile chunk owed its texture rebuild (plan §15). */
+    /** A committed tile chunk owed its texture rebuild (plan §15). Bound to the
+     *  Xaero session that produced it (processor identity + world id — review B:
+     *  a server-initiated reconfiguration skips the disconnect event, and a
+     *  {@code ResourceKey} alone is identity-stable across servers). */
     private static final class PendingUpdate {
+        final Object processor;
+        final String worldId;
         final Object dimension;
         final Object region;
         final Object tileChunk;
         final int localTcX;
         final int localTcZ;
+        final long firstTouchPump;
         long lastTouchPump;
-        /** Pump at which a DUE rebuild first found its region not resting; -1 = never. */
+        /** Pump at which a DUE rebuild first found its region not ready; -1 = never. */
         long stalledSincePump = -1;
 
-        PendingUpdate(Object dimension, Object region, Object tileChunk,
-                      int localTcX, int localTcZ, long pump) {
+        PendingUpdate(Object processor, String worldId, Object dimension, Object region,
+                      Object tileChunk, int localTcX, int localTcZ, long pump) {
+            this.processor = processor;
+            this.worldId = worldId;
             this.dimension = dimension;
             this.region = region;
             this.tileChunk = tileChunk;
             this.localTcX = localTcX;
             this.localTcZ = localTcZ;
+            this.firstTouchPump = pump;
             this.lastTouchPump = pump;
         }
     }
@@ -566,7 +585,15 @@ final class XaeroMapCompat {
 
     void pump() {
         maybeRegister();
-        if (this.dead) return;
+        if (this.dead) {
+            // A dead bridge must not pin Xaero's regions/tile chunks (each leaf
+            // texture holds a direct buffer) for the rest of the session (review B).
+            if (!this.pendingUpdates.isEmpty()) {
+                this.pendingUpdates.clear();
+                this.pendingUpdatesGauge = 0;
+            }
+            return;
+        }
         this.pumpCount++;
         if (!this.enabled.getAsBoolean()) {
             clearQueue(); // the live toggle: flipping off drops the backlog immediately
@@ -1030,14 +1057,15 @@ final class XaeroMapCompat {
         // isResting() check, i.e. possibly after the region was queued for
         // cache-saving on prepared textures — the saver then throws ("Trying to
         // save cache for a region with cache not prepared", 3 crashes/hour live).
-        notePendingUpdate(dimensionId, region, tileChunk, localTcX, localTcZ,
+        notePendingUpdate(mp, dimensionId, region, tileChunk, localTcX, localTcZ,
                 tile.chunkX() >> 2, tile.chunkZ() >> 2);
     }
 
     // ---- the rebuild phase (plan §15) ----
 
-    private void notePendingUpdate(Object dimensionId, Object region, Object tileChunk,
-                                   int localTcX, int localTcZ, int tileChunkX, int tileChunkZ) {
+    private void notePendingUpdate(Object mp, Object dimensionId, Object region, Object tileChunk,
+                                   int localTcX, int localTcZ, int tileChunkX, int tileChunkZ)
+            throws Throwable {
         long key = ((long) tileChunkX << 32) | (tileChunkZ & 0xFFFFFFFFL);
         var existing = this.pendingUpdates.remove(key); // re-insert at the tail = last touch
         if (existing != null && existing.tileChunk == tileChunk) {
@@ -1045,7 +1073,10 @@ final class XaeroMapCompat {
             existing.stalledSincePump = -1; // the commit gate just passed: the stall ended
             this.pendingUpdates.put(key, existing);
         } else {
-            this.pendingUpdates.put(key, new PendingUpdate(dimensionId, region, tileChunk,
+            // A replaced tile chunk (Xaero reloaded the region) gets a FRESH entry —
+            // the old object's rebuild would fail its identity check and drop.
+            this.pendingUpdates.put(key, new PendingUpdate(mp,
+                    (String) this.h.getCurrentWorldId.invoke(mp), dimensionId, region, tileChunk,
                     localTcX, localTcZ, this.pumpCount));
         }
         this.pendingUpdatesGauge = this.pendingUpdates.size();
@@ -1054,25 +1085,35 @@ final class XaeroMapCompat {
     private enum UpdateResult { DONE, NOT_READY, DROPPED, FAILED }
 
     /** The per-flush rebuild inputs, resolved once (the native onRender builds one
-     *  {@code MapUpdateFastConfig} per pass the same way). */
+     *  {@code MapUpdateFastConfig} per pass the same way), plus the per-flush memo
+     *  of regions already found not ready — up to 64 tile chunks share one region
+     *  and one verdict, and re-taking the writer-pause + region monitors per tile
+     *  chunk is the per-entry-probe pattern plan §14 removed (review B MAJOR). */
     private static final class RebuildArgs {
         Object tint;
         Object overlayManager;
         Object shapeCache;
         Object fastConfig;
+        final java.util.Set<Object> notReadyRegions =
+                java.util.Collections.newSetFromMap(new java.util.IdentityHashMap<>());
     }
 
     /**
      * Run the owed rebuilds that are DUE — idle for {@link #updateIdlePumps}, or
-     * the oldest beyond the soft cap, or previously stalled — oldest-touch first,
-     * within {@link #updateNanosBudget} (at least one per pump). Each rebuild
-     * re-runs the writer's region gates ({@code writerThreadPauseSync} +
-     * {@code !isWritingPaused()}, the region monitor, {@code isResting()}): a
-     * not-resting region (being saved / cache pending — exactly the state the
-     * flag-consuming sweep ignored) keeps the entry for a later pump; an
-     * unloaded or replaced tile chunk drops it (a reload rebuilds its own
-     * textures); a rebuild on the wrong dimension drops it (the pixel recipe
-     * reads the CURRENT world). A tile chunk the native writer already consumed
+     * older than {@link #updateMaxDeferPumps} (the trickle ceiling), or the oldest
+     * beyond the soft cap, or previously stalled — oldest-touch first, within
+     * {@link #updateNanosBudget} (the first removing outcome of a pump is exempt,
+     * so the set always drains). Each rebuild re-runs the writer's region gates
+     * ({@code writerThreadPauseSync} + {@code !isWritingPaused()}, the region
+     * monitor, {@code isResting()}) — ONCE per region per flush for a not-ready
+     * verdict (memoized, no budget): a not-resting region (being saved / cache
+     * pending — exactly the state the flag-consuming sweep ignored) keeps its
+     * entries for a later pump, as does another dimension's region (the pixel
+     * recipe reads the CURRENT dimension's shading; the entries wait for the
+     * player's return); either drops after {@link #updateMaxStallPumps}. An
+     * unloaded or replaced tile chunk, or an entry from a previous Xaero session
+     * (processor identity / world id), drops at once — a reload rebuilds its own
+     * textures. A tile chunk the native writer already consumed
      * ({@code !wasChanged()}) needs nothing.
      */
     private void flushPendingUpdates(Object mp, Object dimensionId) {
@@ -1082,28 +1123,41 @@ final class XaeroMapCompat {
         }
         long start = System.nanoTime();
         var args = new RebuildArgs();
-        int done = 0;
+        String worldId;
+        try {
+            worldId = (String) this.h.getCurrentWorldId.invoke(mp);
+        } catch (Throwable t) {
+            if (t instanceof Error err && !(t instanceof AssertionError)) throw err;
+            noteFailure(t);
+            return;
+        }
+        int removed = 0;
         int overflow = this.pendingUpdates.size() - this.pendingUpdatesSoftCap;
         var it = this.pendingUpdates.values().iterator();
         while (it.hasNext()) {
-            if (done > 0 && System.nanoTime() - start > this.updateNanosBudget) break;
+            if (removed > 0 && System.nanoTime() - start > this.updateNanosBudget) break;
             var pu = it.next();
             boolean due = overflow-- > 0
                     || this.pumpCount - pu.lastTouchPump >= this.updateIdlePumps
+                    || this.pumpCount - pu.firstTouchPump >= this.updateMaxDeferPumps
                     || pu.stalledSincePump >= 0;
-            if (!due) break; // touch order: nothing after this one is idle-due either
-            if (pu.dimension != dimensionId) {
-                it.remove();
-                this.droppedUpdates.incrementAndGet();
-                continue;
+            if (!due) continue; // touch order makes idle-due a prefix, but the age ceiling is not
+            UpdateResult result;
+            if (pu.processor != mp || !java.util.Objects.equals(pu.worldId, worldId)) {
+                result = UpdateResult.DROPPED; // a previous Xaero session's objects
+            } else if (pu.dimension != dimensionId) {
+                result = UpdateResult.NOT_READY;
+            } else {
+                result = rebuildTileChunk(mp, pu, args);
             }
-            switch (rebuildTileChunk(mp, pu, args)) {
+            switch (result) {
                 case DONE -> {
                     it.remove();
-                    done++;
+                    removed++;
                 }
                 case DROPPED -> {
                     it.remove();
+                    removed++;
                     this.droppedUpdates.incrementAndGet();
                 }
                 case NOT_READY -> {
@@ -1111,11 +1165,15 @@ final class XaeroMapCompat {
                         pu.stalledSincePump = this.pumpCount;
                     } else if (this.pumpCount - pu.stalledSincePump >= this.updateMaxStallPumps) {
                         it.remove();
+                        removed++;
                         this.droppedUpdates.incrementAndGet();
                     }
-                    done++; // budget-counted progress: a stalled prefix must not spin the loop
                 }
-                case FAILED -> it.remove();
+                case FAILED -> {
+                    it.remove();
+                    removed++;
+                    this.droppedUpdates.incrementAndGet(); // owed, never rebuilt
+                }
             }
             if (this.dead) break;
         }
@@ -1123,10 +1181,12 @@ final class XaeroMapCompat {
     }
 
     private UpdateResult rebuildTileChunk(Object mp, PendingUpdate pu, RebuildArgs args) {
+        if (args.notReadyRegions.contains(pu.region)) return UpdateResult.NOT_READY;
         try {
             Object writerPause = this.h.writerThreadPauseSync.invoke(pu.region);
             synchronized (writerPause) {
                 if ((boolean) this.h.regionIsWritingPaused.invoke(pu.region)) {
+                    args.notReadyRegions.add(pu.region);
                     return UpdateResult.NOT_READY;
                 }
                 synchronized (pu.region) {
@@ -1136,6 +1196,7 @@ final class XaeroMapCompat {
                         return UpdateResult.DROPPED;
                     }
                     if (!(boolean) this.h.isResting.invoke(pu.region)) {
+                        args.notReadyRegions.add(pu.region);
                         return UpdateResult.NOT_READY;
                     }
                     if ((boolean) this.h.tileChunkWasChanged.invoke(pu.tileChunk)) {

--- a/xplat/src/main/java/dev/vox/lss/compat/XaeroMapCompat.java
+++ b/xplat/src/main/java/dev/vox/lss/compat/XaeroMapCompat.java
@@ -62,8 +62,13 @@ import java.util.function.BooleanSupplier;
  * called (the loader itself never reads it — it is purely the pacing token of
  * the four native consumers, and pointing it at a far bridge region vetoed all
  * four; left alone, native requests front-insert AHEAD of our batch, the right
- * priority). GPU work stays Xaero's: the bridge only flags
- * {@code setToUpdateBuffers}, never calls {@code updateBuffers}.
+ * priority). Texture rebuilds ({@code MapTileChunk.updateBuffers} — the
+ * expensive half of a native write) are OURS to run, exactly like the native
+ * writer's: coalesced per tile chunk by {@link #flushPendingUpdates} under the
+ * same gates (plan §15, the cache-not-prepared crash). The
+ * {@code setToUpdateBuffers} flag is NEVER set: Xaero's preUpload sweep consumes
+ * it with no {@code isResting()} check, i.e. possibly after the region was queued
+ * for cache-saving on prepared textures — the saver then throws.
  *
  * <p><b>Registration lifecycle</b> (review MAJOR): the consumer is what holds the
  * handshake's CAPABILITY_VOXEL_COLUMNS bit ({@code LSSApi.hasVoxelConsumers()}),
@@ -103,6 +108,26 @@ final class XaeroMapCompat {
      *  most one window per pump; requests are idempotent (an already-queued
      *  region answers not-requestable), so the excess is bounded and harmless. */
     static final int MAX_OUTSTANDING_LOADS = 8;
+    /** Buffer-update coalescing (plan §15). A committed tile chunk's texture rebuild
+     *  ({@code MapTileChunk.updateBuffers} — a 64×64-pixel recolor, the expensive
+     *  half of a native write) is deferred until its tiles stop arriving for this
+     *  many pumps (~2 s), so the 16 spiral-delivered tiles of a tile chunk cost
+     *  ~1-4 rebuilds instead of 16. Meanwhile the tile chunk sits in the native
+     *  writer's own transient state (changed=true, no flag — the (3,3) rule leaves
+     *  every non-final chunk write there too). */
+    static final int UPDATE_IDLE_PUMPS = 40;
+    /** Above this many owed rebuilds the oldest become due at once (bounds the
+     *  stale-texture window under a flood). */
+    static final int PENDING_UPDATES_SOFT_CAP = 256;
+    /** At this many owed rebuilds COMMITS pause until the flush drains — a region
+     *  that never rests (a stuck saver) must not grow the set without bound. */
+    static final int PENDING_UPDATES_HARD_CAP = 1024;
+    /** A due rebuild whose region stays not-resting this long (~60 s) is dropped,
+     *  counted: the texture self-heals on the region's next reload. */
+    static final int UPDATE_MAX_STALL_PUMPS = 1200;
+    /** Rebuild budget per pump, separate from the commit budget; at least one
+     *  rebuild runs per pump so the set always drains. */
+    static final long UPDATE_NANOS_BUDGET = 2_000_000L;
     /** Consecutive failures (commit-side or extraction-side) before the bridge
      *  latches dead for the SESSION (re-armed at disconnect). */
     static final int THROW_LATCH = 5;
@@ -247,6 +272,20 @@ final class XaeroMapCompat {
     private final AtomicInteger consecutiveExtractFailures = new AtomicInteger();
     /** The per-pump time budget — a field so tests can neutralize MethodHandle warmup. */
     long pumpNanosBudget = PUMP_NANOS_BUDGET;
+    /** The rebuild-phase seams (plan §15) — fields so tests can drive the windows. */
+    long updateNanosBudget = UPDATE_NANOS_BUDGET;
+    int updateIdlePumps = UPDATE_IDLE_PUMPS;
+    int pendingUpdatesSoftCap = PENDING_UPDATES_SOFT_CAP;
+    int pendingUpdatesHardCap = PENDING_UPDATES_HARD_CAP;
+    int updateMaxStallPumps = UPDATE_MAX_STALL_PUMPS;
+    /** Tile chunks committed but not yet texture-rebuilt, keyed by tile-chunk
+     *  coords and ordered by LAST TOUCH (a re-touch re-inserts at the tail, so
+     *  idle-due entries are always a prefix). Main thread only. */
+    private final LinkedHashMap<Long, PendingUpdate> pendingUpdates = new LinkedHashMap<>();
+    private long pumpCount; // main thread only
+    private final AtomicLong bufferUpdates = new AtomicLong();
+    private final AtomicLong droppedUpdates = new AtomicLong();
+    private volatile int pendingUpdatesGauge;
     /** Rotating drain start (the IncomingRequestRouter M4 precedent): without it a
      *  permanently-deferring queue prefix starves committable entries forever. */
     private int drainRotation; // main thread only
@@ -254,6 +293,28 @@ final class XaeroMapCompat {
      *  pump — a diag gauge, and a lower bound under budget truncation (buckets the
      *  commit loop never reached are unknown). */
     private volatile int regionsWaiting;
+
+    /** A committed tile chunk owed its texture rebuild (plan §15). */
+    private static final class PendingUpdate {
+        final Object dimension;
+        final Object region;
+        final Object tileChunk;
+        final int localTcX;
+        final int localTcZ;
+        long lastTouchPump;
+        /** Pump at which a DUE rebuild first found its region not resting; -1 = never. */
+        long stalledSincePump = -1;
+
+        PendingUpdate(Object dimension, Object region, Object tileChunk,
+                      int localTcX, int localTcZ, long pump) {
+            this.dimension = dimension;
+            this.region = region;
+            this.tileChunk = tileChunk;
+            this.localTcX = localTcX;
+            this.localTcZ = localTcZ;
+            this.lastTouchPump = pump;
+        }
+    }
 
     private static final class Entry {
         volatile XaeroTileExtractor.PreparedTile tile; // replaced under queueLock (latest wins)
@@ -305,6 +366,8 @@ final class XaeroMapCompat {
      */
     void onSessionEnd() {
         clearQueue();
+        this.pendingUpdates.clear(); // the old world's tile chunks — never touch them again
+        this.pendingUpdatesGauge = 0;
         this.regionsWaiting = 0;
         this.dead = false;
         this.consecutiveFailures = 0;
@@ -475,6 +538,9 @@ final class XaeroMapCompat {
             case "dropped_expired" -> this.droppedExpired.get();
             case "commit_failures" -> this.commitFailures.get();
             case "load_requests" -> this.loadRequests.get();
+            case "buffer_updates" -> this.bufferUpdates.get();
+            case "dropped_updates" -> this.droppedUpdates.get();
+            case "pending_updates" -> this.pendingUpdatesGauge;
             default -> throw new IllegalArgumentException(name);
         };
     }
@@ -490,7 +556,10 @@ final class XaeroMapCompat {
                 + ", dropped=" + dropped
                 + ", commit_failures=" + this.commitFailures.get()
                 + ", load_requests=" + this.loadRequests.get()
-                + ", regions_waiting=" + this.regionsWaiting;
+                + ", regions_waiting=" + this.regionsWaiting
+                + ", buffer_updates=" + this.bufferUpdates.get()
+                + ", pending_updates=" + this.pendingUpdatesGauge
+                + ", dropped_updates=" + this.droppedUpdates.get();
     }
 
     // ---- the pump (main client thread) ----
@@ -498,14 +567,18 @@ final class XaeroMapCompat {
     void pump() {
         maybeRegister();
         if (this.dead) return;
+        this.pumpCount++;
         if (!this.enabled.getAsBoolean()) {
             clearQueue(); // the live toggle: flipping off drops the backlog immediately
-            return;
-        }
-        synchronized (this.queueLock) {
-            if (this.queue.isEmpty()) {
-                this.regionsWaiting = 0;
-                return;
+            // ...but rebuilds already OWED to committed tile chunks still flush —
+            // dropping them would leave written tiles invisible until a reload.
+            if (this.pendingUpdates.isEmpty()) return;
+        } else {
+            synchronized (this.queueLock) {
+                if (this.queue.isEmpty() && this.pendingUpdates.isEmpty()) {
+                    this.regionsWaiting = 0;
+                    return;
+                }
             }
         }
         try {
@@ -555,6 +628,8 @@ final class XaeroMapCompat {
                 dimensionId = this.h.getCurrentDimensionId.invoke(mapWorld);
                 if (this.levelOps.dimension(world) != dimensionId) return;
             }
+            flushPendingUpdates(mp, dimensionId);
+            if (this.dead) return;
             drainEntries(mp, saveLoad, world, dimensionId);
         }
     }
@@ -612,6 +687,11 @@ final class XaeroMapCompat {
             Long regionKey = bucketKeys.get((startIndex + n) % size);
             var bucket = buckets.get(regionKey);
             for (var pending : bucket) {
+                if (this.pendingUpdates.size() >= this.pendingUpdatesHardCap) {
+                    // Owed rebuilds at the hard cap (plan §15): commits pause until
+                    // the flush drains — the set must never grow without bound.
+                    break bucketLoop;
+                }
                 if (progressed && (commits >= MAX_COMMITS_PER_PUMP
                         || System.nanoTime() - start > this.pumpNanosBudget)) {
                     break bucketLoop;
@@ -634,7 +714,7 @@ final class XaeroMapCompat {
                     continue;
                 }
                 progressed = true;
-                var outcome = commitEntry(mp, pending.tile());
+                var outcome = commitEntry(mp, dimensionId, pending.tile());
                 switch (outcome) {
                     case COMMITTED -> {
                         removeIfCurrent(pending.key(), pending.entry(), pending.tile());
@@ -822,7 +902,8 @@ final class XaeroMapCompat {
      * here, classified from {@code canRequestReload_unsynced()} + loadState in the
      * same monitor read.
      */
-    private Outcome commitEntry(Object mp, XaeroTileExtractor.PreparedTile tile) {
+    private Outcome commitEntry(Object mp, Object dimensionId,
+                                XaeroTileExtractor.PreparedTile tile) {
         try {
             int chunkX = tile.chunkX();
             int chunkZ = tile.chunkZ();
@@ -881,7 +962,7 @@ final class XaeroMapCompat {
                     return Outcome.DEFERRED_TILE;
                 }
 
-                commitPixels(mp, region, tileChunk, createdTileChunk,
+                commitPixels(mp, dimensionId, region, tileChunk, createdTileChunk,
                         localTcX, localTcZ, tile);
                 return Outcome.COMMITTED;
             }
@@ -893,7 +974,7 @@ final class XaeroMapCompat {
     }
 
     /** The decompiled per-tile commit sequence, verbatim order (plan §1). */
-    private void commitPixels(Object mp, Object region, Object tileChunk,
+    private void commitPixels(Object mp, Object dimensionId, Object region, Object tileChunk,
                               boolean createdTileChunk, int localTcX, int localTcZ,
                               XaeroTileExtractor.PreparedTile tile) throws Throwable {
         int insideX = tile.chunkX() & 3;
@@ -941,10 +1022,148 @@ final class XaeroMapCompat {
             Object highlights = this.h.getMapRegionHighlightsPreparer.invoke(mp);
             this.h.highlightsPrepare.invoke(highlights, region, localTcX, localTcZ, false);
         }
-        // No direct updateBuffers (GPU work stays in Xaero's preUpload sweep) — the
-        // native right/bottom-right neighbor pattern: flag, then consume the change.
-        this.h.setToUpdateBuffers.invoke(tileChunk, true);
-        this.h.tileChunkSetChanged.invoke(tileChunk, false);
+        // The native writer ends a write by rebuilding the tile chunk's texture
+        // INSIDE this gate (updateBuffers, then setChanged(false)); ours is
+        // coalesced per tile chunk (plan §15) — the change stays marked and the
+        // rebuild runs from flushPendingUpdates under these same gates. NEVER the
+        // setToUpdateBuffers flag: Xaero's preUpload sweep consumes it with no
+        // isResting() check, i.e. possibly after the region was queued for
+        // cache-saving on prepared textures — the saver then throws ("Trying to
+        // save cache for a region with cache not prepared", 3 crashes/hour live).
+        notePendingUpdate(dimensionId, region, tileChunk, localTcX, localTcZ,
+                tile.chunkX() >> 2, tile.chunkZ() >> 2);
+    }
+
+    // ---- the rebuild phase (plan §15) ----
+
+    private void notePendingUpdate(Object dimensionId, Object region, Object tileChunk,
+                                   int localTcX, int localTcZ, int tileChunkX, int tileChunkZ) {
+        long key = ((long) tileChunkX << 32) | (tileChunkZ & 0xFFFFFFFFL);
+        var existing = this.pendingUpdates.remove(key); // re-insert at the tail = last touch
+        if (existing != null && existing.tileChunk == tileChunk) {
+            existing.lastTouchPump = this.pumpCount;
+            existing.stalledSincePump = -1; // the commit gate just passed: the stall ended
+            this.pendingUpdates.put(key, existing);
+        } else {
+            this.pendingUpdates.put(key, new PendingUpdate(dimensionId, region, tileChunk,
+                    localTcX, localTcZ, this.pumpCount));
+        }
+        this.pendingUpdatesGauge = this.pendingUpdates.size();
+    }
+
+    private enum UpdateResult { DONE, NOT_READY, DROPPED, FAILED }
+
+    /** The per-flush rebuild inputs, resolved once (the native onRender builds one
+     *  {@code MapUpdateFastConfig} per pass the same way). */
+    private static final class RebuildArgs {
+        Object tint;
+        Object overlayManager;
+        Object shapeCache;
+        Object fastConfig;
+    }
+
+    /**
+     * Run the owed rebuilds that are DUE — idle for {@link #updateIdlePumps}, or
+     * the oldest beyond the soft cap, or previously stalled — oldest-touch first,
+     * within {@link #updateNanosBudget} (at least one per pump). Each rebuild
+     * re-runs the writer's region gates ({@code writerThreadPauseSync} +
+     * {@code !isWritingPaused()}, the region monitor, {@code isResting()}): a
+     * not-resting region (being saved / cache pending — exactly the state the
+     * flag-consuming sweep ignored) keeps the entry for a later pump; an
+     * unloaded or replaced tile chunk drops it (a reload rebuilds its own
+     * textures); a rebuild on the wrong dimension drops it (the pixel recipe
+     * reads the CURRENT world). A tile chunk the native writer already consumed
+     * ({@code !wasChanged()}) needs nothing.
+     */
+    private void flushPendingUpdates(Object mp, Object dimensionId) {
+        if (this.pendingUpdates.isEmpty()) {
+            this.pendingUpdatesGauge = 0;
+            return;
+        }
+        long start = System.nanoTime();
+        var args = new RebuildArgs();
+        int done = 0;
+        int overflow = this.pendingUpdates.size() - this.pendingUpdatesSoftCap;
+        var it = this.pendingUpdates.values().iterator();
+        while (it.hasNext()) {
+            if (done > 0 && System.nanoTime() - start > this.updateNanosBudget) break;
+            var pu = it.next();
+            boolean due = overflow-- > 0
+                    || this.pumpCount - pu.lastTouchPump >= this.updateIdlePumps
+                    || pu.stalledSincePump >= 0;
+            if (!due) break; // touch order: nothing after this one is idle-due either
+            if (pu.dimension != dimensionId) {
+                it.remove();
+                this.droppedUpdates.incrementAndGet();
+                continue;
+            }
+            switch (rebuildTileChunk(mp, pu, args)) {
+                case DONE -> {
+                    it.remove();
+                    done++;
+                }
+                case DROPPED -> {
+                    it.remove();
+                    this.droppedUpdates.incrementAndGet();
+                }
+                case NOT_READY -> {
+                    if (pu.stalledSincePump < 0) {
+                        pu.stalledSincePump = this.pumpCount;
+                    } else if (this.pumpCount - pu.stalledSincePump >= this.updateMaxStallPumps) {
+                        it.remove();
+                        this.droppedUpdates.incrementAndGet();
+                    }
+                    done++; // budget-counted progress: a stalled prefix must not spin the loop
+                }
+                case FAILED -> it.remove();
+            }
+            if (this.dead) break;
+        }
+        this.pendingUpdatesGauge = this.pendingUpdates.size();
+    }
+
+    private UpdateResult rebuildTileChunk(Object mp, PendingUpdate pu, RebuildArgs args) {
+        try {
+            Object writerPause = this.h.writerThreadPauseSync.invoke(pu.region);
+            synchronized (writerPause) {
+                if ((boolean) this.h.regionIsWritingPaused.invoke(pu.region)) {
+                    return UpdateResult.NOT_READY;
+                }
+                synchronized (pu.region) {
+                    if ((byte) this.h.getLoadState.invoke(pu.region) != 2
+                            || this.h.regionGetChunk.invoke(pu.region, pu.localTcX, pu.localTcZ)
+                            != pu.tileChunk) {
+                        return UpdateResult.DROPPED;
+                    }
+                    if (!(boolean) this.h.isResting.invoke(pu.region)) {
+                        return UpdateResult.NOT_READY;
+                    }
+                    if ((boolean) this.h.tileChunkWasChanged.invoke(pu.tileChunk)) {
+                        // A save may have reset beingWritten since the commit; the
+                        // rebuilt texture must still reach the region's cache, and
+                        // the save path is what requests it (set-never-clear, as
+                        // in the commit).
+                        this.h.setBeingWritten.invoke(pu.region, true);
+                        if (args.fastConfig == null) {
+                            args.tint = this.h.getWorldBlockTintProvider.invoke(mp);
+                            args.overlayManager = this.h.getOverlayManager.invoke(mp);
+                            args.shapeCache = this.h.getBlockStateShortShapeCache.invoke(mp);
+                            args.fastConfig = this.h.newMapUpdateFastConfig.invoke(mp);
+                        }
+                        // The boolean is the writer's detailed-debug flag (log-only).
+                        this.h.tileChunkUpdateBuffers.invoke(pu.tileChunk, mp, args.tint,
+                                args.overlayManager, false, args.shapeCache, args.fastConfig);
+                        this.h.tileChunkSetChanged.invoke(pu.tileChunk, false);
+                        this.bufferUpdates.incrementAndGet();
+                    }
+                    return UpdateResult.DONE;
+                }
+            }
+        } catch (Throwable t) {
+            if (t instanceof Error err && !(t instanceof AssertionError)) throw err;
+            noteFailure(t);
+            return UpdateResult.FAILED;
+        }
     }
 
     private void noteFailure(Throwable t) {
@@ -1015,7 +1234,10 @@ final class XaeroMapCompat {
         final MethodHandle tileChunkGetLoadState;
         final MethodHandle tileChunkSetLoadState;
         final MethodHandle tileChunkSetChanged;
-        final MethodHandle setToUpdateBuffers;
+        final MethodHandle tileChunkWasChanged;
+        final MethodHandle tileChunkUpdateBuffers;
+        final MethodHandle getWorldBlockTintProvider;
+        final MethodHandle newMapUpdateFastConfig;
         final MethodHandle setHasHadTerrain;
         final MethodHandle includeInSave;
         final MethodHandle getLeafTexture;
@@ -1059,6 +1281,8 @@ final class XaeroMapCompat {
             Class<?> leafTextureClass = resolver.resolve("xaero.map.region.texture.LeafRegionTexture");
             Class<?> shapeCacheClass = resolver.resolve("xaero.map.cache.BlockStateShortShapeCache");
             Class<?> highlightsClass = resolver.resolve("xaero.map.highlight.MapRegionHighlightsPreparer");
+            Class<?> tintProviderClass = resolver.resolve("xaero.map.biome.BlockTintProvider");
+            Class<?> fastConfigClass = resolver.resolve("xaero.map.region.MapUpdateFastConfig");
 
             this.getCurrentSession = lookup.findStatic(sessionClass, "getCurrentSession",
                     MethodType.methodType(sessionClass)).asType(MethodType.methodType(Object.class));
@@ -1105,6 +1329,12 @@ final class XaeroMapCompat {
                     MethodType.methodType(highlightsClass), Object.class);
             this.getCaveModeDepthConfig = virtual(lookup, processorClass, "getCaveModeDepthConfig",
                     MethodType.methodType(int.class), int.class);
+            this.getWorldBlockTintProvider = virtual(lookup, processorClass,
+                    "getWorldBlockTintProvider",
+                    MethodType.methodType(tintProviderClass), Object.class);
+            this.newMapUpdateFastConfig = lookup.findConstructor(fastConfigClass,
+                            MethodType.methodType(void.class, processorClass))
+                    .asType(MethodType.methodType(Object.class, Object.class));
 
             this.isCacheOnlyMode = virtual(lookup, mapWorldClass, "isCacheOnlyMode",
                     MethodType.methodType(boolean.class), boolean.class);
@@ -1156,9 +1386,14 @@ final class XaeroMapCompat {
             this.tileChunkSetChanged = lookup.findVirtual(tileChunkClass, "setChanged",
                             MethodType.methodType(void.class, boolean.class))
                     .asType(MethodType.methodType(void.class, Object.class, boolean.class));
-            this.setToUpdateBuffers = lookup.findVirtual(tileChunkClass, "setToUpdateBuffers",
-                            MethodType.methodType(void.class, boolean.class))
-                    .asType(MethodType.methodType(void.class, Object.class, boolean.class));
+            this.tileChunkWasChanged = virtual(lookup, tileChunkClass, "wasChanged",
+                    MethodType.methodType(boolean.class), boolean.class);
+            this.tileChunkUpdateBuffers = lookup.findVirtual(tileChunkClass, "updateBuffers",
+                            MethodType.methodType(void.class, processorClass, tintProviderClass,
+                                    overlayManagerClass, boolean.class, shapeCacheClass,
+                                    fastConfigClass))
+                    .asType(MethodType.methodType(void.class, Object.class, Object.class,
+                            Object.class, Object.class, boolean.class, Object.class, Object.class));
             this.setHasHadTerrain = virtual(lookup, tileChunkClass, "setHasHadTerrain",
                     MethodType.methodType(void.class), void.class);
             this.includeInSave = virtual(lookup, tileChunkClass, "includeInSave",

--- a/xplat/src/main/java/dev/vox/lss/compat/XaeroMapCompat.java
+++ b/xplat/src/main/java/dev/vox/lss/compat/XaeroMapCompat.java
@@ -135,8 +135,17 @@ final class XaeroMapCompat {
     /** Rebuild budget per pump, separate from the commit budget; the first REMOVING
      *  outcome (rebuilt/dropped/failed) of a pump is exempt from it, so the set
      *  always drains — not-ready verdicts are memoized per region and cost no
-     *  budget. */
+     *  budget. The flush BORROWS on top of it (review A: a rebuild is the
+     *  expensive half of a native write, and a budget that cannot keep up parks
+     *  commits at the hard cap): the whole {@link #UPDATE_BORROW_NANOS} once the
+     *  queue is empty (commits need nothing), half of it while the owed set is
+     *  past the soft cap. Steady state needs ~1-4 rebuilds per 16 delivered tiles
+     *  (the spiral coalesces harder the faster rings arrive), so at ~1000
+     *  columns/s the load is ~2-3 rebuilds per pump; if the live counters show
+     *  {@code pending_updates} pinned at the hard cap with {@code written} flat,
+     *  the next lever is a per-FRAME flush hook (Xaero's own sweep runs per frame). */
     static final long UPDATE_NANOS_BUDGET = 2_000_000L;
+    static final long UPDATE_BORROW_NANOS = PUMP_NANOS_BUDGET;
     /** Consecutive failures (commit-side or extraction-side) before the bridge
      *  latches dead for the SESSION (re-armed at disconnect). */
     static final int THROW_LATCH = 5;
@@ -288,6 +297,7 @@ final class XaeroMapCompat {
     int pendingUpdatesHardCap = PENDING_UPDATES_HARD_CAP;
     int updateMaxStallPumps = UPDATE_MAX_STALL_PUMPS;
     int updateMaxDeferPumps = UPDATE_MAX_DEFER_PUMPS;
+    long updateBorrowNanos = UPDATE_BORROW_NANOS;
     /** Tile chunks committed but not yet texture-rebuilt, keyed by tile-chunk
      *  coords and ordered by LAST TOUCH (a re-touch re-inserts at the tail, so
      *  idle-due entries are always a prefix). Main thread only. */
@@ -295,6 +305,10 @@ final class XaeroMapCompat {
     private long pumpCount; // main thread only
     private final AtomicLong bufferUpdates = new AtomicLong();
     private final AtomicLong droppedUpdates = new AtomicLong();
+    /** Owed rebuilds whose region/tile chunk Xaero unloaded, parked or replaced
+     *  first — its own counter (review A) so the live test can tell a parking race
+     *  from the stall/dimension/session drops. */
+    private final AtomicLong droppedUnloaded = new AtomicLong();
     private volatile int pendingUpdatesGauge;
     /** Rotating drain start (the IncomingRequestRouter M4 precedent): without it a
      *  permanently-deferring queue prefix starves committable entries forever. */
@@ -385,7 +399,12 @@ final class XaeroMapCompat {
      */
     void onSessionEnd() {
         clearQueue();
-        this.pendingUpdates.clear(); // the old world's tile chunks — never touch them again
+        // The old world's tile chunks are never touched again; the rebuilds they were
+        // owed are lost (counted — Xaero's world is going away under us, so no
+        // best-effort flush here). The last ≤2 s of commits before a disconnect can
+        // thus reach the region cache with a stale texture (review A N5, accepted).
+        this.droppedUpdates.addAndGet(this.pendingUpdates.size());
+        this.pendingUpdates.clear();
         this.pendingUpdatesGauge = 0;
         this.regionsWaiting = 0;
         this.dead = false;
@@ -517,6 +536,10 @@ final class XaeroMapCompat {
         }
     }
 
+    void queueLockedClearForTest() {
+        clearQueue();
+    }
+
     int queuedForTest() {
         synchronized (this.queueLock) {
             return this.queue.size();
@@ -559,6 +582,7 @@ final class XaeroMapCompat {
             case "load_requests" -> this.loadRequests.get();
             case "buffer_updates" -> this.bufferUpdates.get();
             case "dropped_updates" -> this.droppedUpdates.get();
+            case "dropped_unloaded" -> this.droppedUnloaded.get();
             case "pending_updates" -> this.pendingUpdatesGauge;
             default -> throw new IllegalArgumentException(name);
         };
@@ -578,7 +602,8 @@ final class XaeroMapCompat {
                 + ", regions_waiting=" + this.regionsWaiting
                 + ", buffer_updates=" + this.bufferUpdates.get()
                 + ", pending_updates=" + this.pendingUpdatesGauge
-                + ", dropped_updates=" + this.droppedUpdates.get();
+                + ", dropped_updates=" + this.droppedUpdates.get()
+                + ", dropped_unloaded=" + this.droppedUnloaded.get();
     }
 
     // ---- the pump (main client thread) ----
@@ -709,6 +734,7 @@ final class XaeroMapCompat {
         boolean progressed = false;
         int size = bucketKeys.size();
         int startIndex = size == 0 ? 0 : Math.floorMod(this.drainRotation++, size);
+        boolean capped = false;
         bucketLoop:
         for (int n = 0; n < size; n++) {
             Long regionKey = bucketKeys.get((startIndex + n) % size);
@@ -717,6 +743,7 @@ final class XaeroMapCompat {
                 if (this.pendingUpdates.size() >= this.pendingUpdatesHardCap) {
                     // Owed rebuilds at the hard cap (plan §15): commits pause until
                     // the flush drains — the set must never grow without bound.
+                    capped = true;
                     break bucketLoop;
                 }
                 if (progressed && (commits >= MAX_COMMITS_PER_PUMP
@@ -792,7 +819,9 @@ final class XaeroMapCompat {
                 }
             }
         }
-        this.regionsWaiting = waiting.size();
+        if (!capped) {
+            this.regionsWaiting = waiting.size(); // a capped pass probed nothing: keep the last gauge
+        }
         grantLoads(mp, saveLoad, waiting);
     }
 
@@ -1122,10 +1151,19 @@ final class XaeroMapCompat {
             return;
         }
         long start = System.nanoTime();
+        boolean queueEmpty;
+        synchronized (this.queueLock) {
+            queueEmpty = this.queue.isEmpty();
+        }
+        long borrow = queueEmpty ? this.updateBorrowNanos
+                : this.pendingUpdates.size() > this.pendingUpdatesSoftCap ? this.updateBorrowNanos / 2 : 0;
+        long budget = borrow > Long.MAX_VALUE - this.updateNanosBudget
+                ? Long.MAX_VALUE : this.updateNanosBudget + borrow; // saturating (the seams take MAX)
         var args = new RebuildArgs();
         String worldId;
         try {
             worldId = (String) this.h.getCurrentWorldId.invoke(mp);
+            keepOwedRegionsVisited(mp, worldId, dimensionId);
         } catch (Throwable t) {
             if (t instanceof Error err && !(t instanceof AssertionError)) throw err;
             noteFailure(t);
@@ -1135,7 +1173,7 @@ final class XaeroMapCompat {
         int overflow = this.pendingUpdates.size() - this.pendingUpdatesSoftCap;
         var it = this.pendingUpdates.values().iterator();
         while (it.hasNext()) {
-            if (removed > 0 && System.nanoTime() - start > this.updateNanosBudget) break;
+            if (removed > 0 && System.nanoTime() - start > budget) break;
             var pu = it.next();
             boolean due = overflow-- > 0
                     || this.pumpCount - pu.lastTouchPump >= this.updateIdlePumps
@@ -1158,7 +1196,9 @@ final class XaeroMapCompat {
                 case DROPPED -> {
                     it.remove();
                     removed++;
-                    this.droppedUpdates.incrementAndGet();
+                    if (pu.processor != mp || !java.util.Objects.equals(pu.worldId, worldId)) {
+                        this.droppedUpdates.incrementAndGet(); // the session-identity drop
+                    } // else: the rebuild counted dropped_unloaded itself
                 }
                 case NOT_READY -> {
                     if (pu.stalledSincePump < 0) {
@@ -1180,6 +1220,32 @@ final class XaeroMapCompat {
         this.pendingUpdatesGauge = this.pendingUpdates.size();
     }
 
+    /**
+     * The park guard the flag used to be (review A MAJOR): {@code LeafRegionTexture.
+     * postUpload} parks a region — loadState 3, tile chunks {@code clean()}ed, their
+     * tiles released — once it is not being written, ONE second has passed since its
+     * last visit, and no tile chunk is flagged {@code toUpdateBuffers}. The native
+     * writer's flag held that off until the texture was built; ours is never set, so
+     * the bridge keeps every region with an owed rebuild VISITED each pump (the
+     * writer's own "someone is working here" signal, {@code registerVisit} — what the
+     * commit does too), once per region, under the region monitor. Same-session
+     * entries only; foreign ones are skipped.
+     */
+    private void keepOwedRegionsVisited(Object mp, String worldId, Object dimensionId) throws Throwable {
+        var seen = java.util.Collections.newSetFromMap(new java.util.IdentityHashMap<>());
+        for (var pu : this.pendingUpdates.values()) {
+            if (pu.processor != mp || !java.util.Objects.equals(pu.worldId, worldId)
+                    || pu.dimension != dimensionId || !seen.add(pu.region)) {
+                continue;
+            }
+            synchronized (pu.region) {
+                if ((byte) this.h.getLoadState.invoke(pu.region) == 2) {
+                    this.h.registerVisit.invoke(pu.region);
+                }
+            }
+        }
+    }
+
     private UpdateResult rebuildTileChunk(Object mp, PendingUpdate pu, RebuildArgs args) {
         if (args.notReadyRegions.contains(pu.region)) return UpdateResult.NOT_READY;
         try {
@@ -1190,9 +1256,14 @@ final class XaeroMapCompat {
                     return UpdateResult.NOT_READY;
                 }
                 synchronized (pu.region) {
+                    // Region unloaded/parked, tile chunk replaced, or a tile-chunk-only
+                    // teardown (deleteTexturesAndBuffers sets ITS loadState 0 without
+                    // touching the region's — review A N3): a reload rebuilds its own.
                     if ((byte) this.h.getLoadState.invoke(pu.region) != 2
                             || this.h.regionGetChunk.invoke(pu.region, pu.localTcX, pu.localTcZ)
-                            != pu.tileChunk) {
+                            != pu.tileChunk
+                            || (int) this.h.tileChunkGetLoadState.invoke(pu.tileChunk) != 2) {
+                        this.droppedUnloaded.incrementAndGet();
                         return UpdateResult.DROPPED;
                     }
                     if (!(boolean) this.h.isResting.invoke(pu.region)) {
@@ -1237,6 +1308,8 @@ final class XaeroMapCompat {
         if (++this.consecutiveFailures >= THROW_LATCH) {
             this.dead = true;
             clearQueue();
+            // pendingUpdates is NOT cleared here: noteFailure runs inside the flush's own
+            // iteration (a throwing rebuild) — the next pump's dead path clears it.
             LSSLogger.error("Xaero map bridge: " + THROW_LATCH + " consecutive failures — "
                     + "disabling the bridge for this session (LODs are unaffected)", t);
         }


### PR DESCRIPTION
## The crash

Three client crashes per hour on the lss-test-1.21.11 instance with the Xaero map bridge active (`commit_failures=0` every time): `RuntimeException: Trying to save cache for a region with cache not prepared` thrown by Xaero's saver thread (`MapSaveLoad.run`, 1.45.0 line 1191) — three different regions, loadStates 2/3/2.

## Root cause (1.45.0 bytecode — xaero-map-bridge-plan.md §15 has the pc-level record)

- Xaero's render loop queues a region for caching when `shouldCache && recacheHasBeenRequested && isAllCachePrepared && !isRefreshing`; the saver later pops it and THROWS if the region is no longer prepared — no re-check, no requeue.
- `MapTileChunk.updateBuffers` (the texture rebuild) ends with `region.setAllCachePrepared(false)`.
- The native writer only ever rebuilds inside its `isResting()` gate (`isResting` = loadState∉{1,3} ∧ ¬recacheHasBeenRequested), so a native rebuild can never flip a queued region.
- The bridge's v1 pattern set `setToUpdateBuffers(true)` per written tile chunk and left the rebuild to `LeafRegionTexture.preUpload` — a sweep gated by the writer-pause monitors but NOT by `isResting`, running under a per-frame upload budget. The flag lingers, the region gets saved (`recacheHasBeenRequested`, `beingWritten=false`), the loop queues the cache on the still-prepared textures, the sweep consumes our flag → unprepared → the saver throws. At LOD scale (hundreds of regions written across many pumps, each saved several times while still being written) the window is hit constantly.

## The fix

The flag is never set. `commitPixels` leaves the tile chunk in the native transient (`changed=true`, unflagged — every non-(3,3) native chunk write sits there too) and records it in a per-tile-chunk `pendingUpdates` map; `flushPendingUpdates` (top of every pump ladder pass, before the commit drain — also on an empty queue and after a disable) runs `MapTileChunk.updateBuffers` itself under the writer gates + region monitor + `isResting`, coalesced per tile chunk (idle 40 pumps / soft cap 256 / hard cap 1024 pauses commits / ~60 s stall drop), re-arming `setBeingWritten(true)` before the rebuild so a save that intervened still re-caches the rebuilt texture; unloaded/replaced/wrong-dimension entries drop; a native-consumed change (`!wasChanged`) needs nothing. Own 2 ms budget (≥1 rebuild per pump). New handles: `updateBuffers` (6-arg) + `wasChanged`, `getWorldBlockTintProvider`, `MapUpdateFastConfig(MapProcessor)`; `setToUpdateBuffers` is unbound. Diag: `buffer_updates` / `pending_updates` / `dropped_updates`.

Cost model: a rebuild is the expensive half of a native write (4096 px through `getPixelColour`); per-tile direct calls would be 16 per tile chunk — coalescing over the spiral's delivery lands at ~1-4, on the order of what Xaero's sweep did for the v1 flags, now on the pump's tick budget.

## Tests

`XaeroMapCompatTest` +12 rebuild-phase pins (the stub `updateBuffers` enforces BOTH region monitors and mirrors the `setAllCachePrepared(false)` flip): flag never set + no rebuild at commit; rebuild after the idle window with `beingWritten` re-armed and the change consumed after; per-tile-chunk coalescing; not-resting waits / permanent stall drops; hard cap pauses commits, flush-before-drain frees them; soft cap forces only the overflow; unloaded/replaced drops; native-consumed change skips; flush after disable / empty queue; session end clears; dimension change drops; rebuild throws count toward the death latch. Fabric T1 1941/0, NeoForge build + contracts green.

Owed: the live re-test on the 1.21.11 instance (a clean hour with `buffer_updates` climbing closes it), then the port to every line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)