### PR TITLE
fix(xaero): frame-slice texture rebuilds — the map-fill stutter

### DIFF
--- a/docs/planning/release-tag-v0.12.1-mc1.21.1.txt
+++ b/docs/planning/release-tag-v0.12.1-mc1.21.1.txt
@@ -1,6 +1,6 @@
 ### Bug Fixes
 
-- **Fixes a client crash when writing LODs to Xaero's World Map** — Map writes could crash Xaero's map saver ("Trying to save cache for a region with cache not prepared"), about three times an hour on a busy client. The bridge now rebuilds map textures itself, only while the map region is idle.
+- **Fixes a client crash when writing LODs to Xaero's World Map** — Map writes could crash Xaero's map saver ("Trying to save cache for a region with cache not prepared"), about three times an hour on a busy client. The bridge now rebuilds map textures itself — one per rendered frame, on Xaero's own update cadence, so a busy map fill cannot stutter the client — and only while the map region is idle.
 - **Map tiles can no longer leak between servers** — A tile still being prepared at the moment you disconnected could be written into the next server's saved map. It is now discarded with the rest of the session.
 - **Disconnecting abruptly no longer risks a client hang** — A timeout, connection reset or server crash tore the map bridge down from the network thread while the client was still using it. Teardown now completes on the main thread.
 - **The map bridge stops when Xaero has crashed internally** — It no longer keeps writing behind a map that Xaero has already given up on.

--- a/docs/planning/release-tag-v0.12.1-mc1.21.10.txt
+++ b/docs/planning/release-tag-v0.12.1-mc1.21.10.txt
@@ -1,6 +1,6 @@
 ### Bug Fixes
 
-- **Fixes a client crash when writing LODs to Xaero's World Map** — Map writes could crash Xaero's map saver ("Trying to save cache for a region with cache not prepared"), about three times an hour on a busy client. The bridge now rebuilds map textures itself, only while the map region is idle.
+- **Fixes a client crash when writing LODs to Xaero's World Map** — Map writes could crash Xaero's map saver ("Trying to save cache for a region with cache not prepared"), about three times an hour on a busy client. The bridge now rebuilds map textures itself — one per rendered frame, on Xaero's own update cadence, so a busy map fill cannot stutter the client — and only while the map region is idle.
 - **Map tiles can no longer leak between servers** — A tile still being prepared at the moment you disconnected could be written into the next server's saved map. It is now discarded with the rest of the session.
 - **Disconnecting abruptly no longer risks a client hang** — A timeout, connection reset or server crash tore the map bridge down from the network thread while the client was still using it. Teardown now completes on the main thread.
 - **The map bridge stops when Xaero has crashed internally** — It no longer keeps writing behind a map that Xaero has already given up on.

--- a/docs/planning/release-tag-v0.12.1-mc1.21.11.txt
+++ b/docs/planning/release-tag-v0.12.1-mc1.21.11.txt
@@ -1,6 +1,6 @@
 ### Bug Fixes
 
-- **Fixes a client crash when writing LODs to Xaero's World Map** — Map writes could crash Xaero's map saver ("Trying to save cache for a region with cache not prepared"), about three times an hour on a busy client. The bridge now rebuilds map textures itself, only while the map region is idle.
+- **Fixes a client crash when writing LODs to Xaero's World Map** — Map writes could crash Xaero's map saver ("Trying to save cache for a region with cache not prepared"), about three times an hour on a busy client. The bridge now rebuilds map textures itself — one per rendered frame, on Xaero's own update cadence, so a busy map fill cannot stutter the client — and only while the map region is idle.
 - **Map tiles can no longer leak between servers** — A tile still being prepared at the moment you disconnected could be written into the next server's saved map. It is now discarded with the rest of the session.
 - **Disconnecting abruptly no longer risks a client hang** — A timeout, connection reset or server crash tore the map bridge down from the network thread while the client was still using it. Teardown now completes on the main thread.
 - **The map bridge stops when Xaero has crashed internally** — It no longer keeps writing behind a map that Xaero has already given up on.

--- a/docs/planning/release-tag-v0.12.1-mc26.1.txt
+++ b/docs/planning/release-tag-v0.12.1-mc26.1.txt
@@ -1,6 +1,6 @@
 ### Bug Fixes
 
-- **Fixes a client crash when writing LODs to Xaero's World Map** — Map writes could crash Xaero's map saver ("Trying to save cache for a region with cache not prepared"), about three times an hour on a busy client. The bridge now rebuilds map textures itself, only while the map region is idle.
+- **Fixes a client crash when writing LODs to Xaero's World Map** — Map writes could crash Xaero's map saver ("Trying to save cache for a region with cache not prepared"), about three times an hour on a busy client. The bridge now rebuilds map textures itself — one per rendered frame, on Xaero's own update cadence, so a busy map fill cannot stutter the client — and only while the map region is idle.
 - **Map tiles can no longer leak between servers** — A tile still being prepared at the moment you disconnected could be written into the next server's saved map. It is now discarded with the rest of the session.
 - **Disconnecting abruptly no longer risks a client hang** — A timeout, connection reset or server crash tore the map bridge down from the network thread while the client was still using it. Teardown now completes on the main thread.
 - **The map bridge stops when Xaero has crashed internally** — It no longer keeps writing behind a map that Xaero has already given up on.

--- a/docs/planning/release-tag-v0.12.1.txt
+++ b/docs/planning/release-tag-v0.12.1.txt
@@ -1,6 +1,6 @@
 ### Bug Fixes
 
-- **Fixes a client crash when writing LODs to Xaero's World Map** — Map writes could crash Xaero's map saver ("Trying to save cache for a region with cache not prepared"), about three times an hour on a busy client. The bridge now rebuilds map textures itself, only while the map region is idle.
+- **Fixes a client crash when writing LODs to Xaero's World Map** — Map writes could crash Xaero's map saver ("Trying to save cache for a region with cache not prepared"), about three times an hour on a busy client. The bridge now rebuilds map textures itself — one per rendered frame, on Xaero's own update cadence, so a busy map fill cannot stutter the client — and only while the map region is idle.
 - **Map tiles can no longer leak between servers** — A tile still being prepared at the moment you disconnected could be written into the next server's saved map. It is now discarded with the rest of the session.
 - **Disconnecting abruptly no longer risks a client hang** — A timeout, connection reset or server crash tore the map bridge down from the network thread while the client was still using it. Teardown now completes on the main thread.
 - **The map bridge stops when Xaero has crashed internally** — It no longer keeps writing behind a map that Xaero has already given up on.

--- a/docs/planning/xaero-map-bridge-plan.md
+++ b/docs/planning/xaero-map-bridge-plan.md
@@ -1244,3 +1244,63 @@ undiscovered-structure highlight (cosmetic; re-prepared on the next native
 write/reload); decode-thread extraction still runs while writing is off / a cave
 layer renders (a volatile "off" flag for `offerColumn` if it shows live); the
 `getCurrentCaveLayer`-unbound path stays Tier-1-unreachable.
+
+## 17. The frame slice (2026-08-24) — rebuild cadence moved off the tick
+
+The first live session on the §15 build (1.21.11, the v0.12.1 staging) reported
+the saver crash gone and "really bad stuttering" in its place. Mechanism, from
+the §16 record's own cost note: §15 moved the texture rebuilds onto the CLIENT
+TICK — commit budget (2 ms) + rebuild budget (2 ms) + borrow (up to another
+2 ms once the queue empties) + the one-rebuild overshoot ≈ 5-7+ ms on a single
+tick, every tick, for the duration of a map fill. v0.12.0 never stuttered
+because the flag path handed the same recolors to Xaero's own sweep, which runs
+per FRAME in idle frame time. Review A's recorded escalation lever ("the next
+lever is a per-FRAME flush hook") is now pulled — as the default, not as a
+cap-pinned escalation.
+
+The change:
+
+- `XaeroMapCompat.renderFrame()` (static facade → `frameFlush()`): a per-frame
+  entry that fast-outs on dead / session-end-pending / no-owed-rebuilds, then
+  runs `frameLadder()` — the pump ladder's gate envelope verbatim down to the
+  `mainStuffSync` dimension equality (a rebuild must never run under weaker
+  gates than the pump's flush did). The settings and cave-layer gates sit BELOW
+  the flush in the pump ladder (rebuilds are owed debt to already-committed
+  tile chunks, not new writes) and are skipped for the same reason. A crashed
+  Xaero returns untouched (the pump owns the `xaero_crashed` diag flag); a
+  changed world id returns (the pump owns the queue drop). Shares the pump's
+  containment + death latch.
+- The frame flush runs `flushPendingUpdates` with `maxRebuilds =
+  FRAME_MAX_REBUILDS` (1) and NO region visits: one 64×64 recolor per frame is
+  Xaero's own sweep grain — at 60-120 fps that is 60-120 tile chunks/s
+  (~1000-2000 coalesced tiles/s of drain), above the serve rate, while a frame
+  never pays more than one recolor.
+- The tick pump's flush (`tickFlush`) consumes a `frameFlushRan` marker: with a
+  frame flush since the previous pump it passes `maxRebuilds = 0` —
+  session-identity drops and wrong-dimension stall bookkeeping only, never
+  `rebuildTileChunk`. With NO frame since the last pump (loading screens,
+  hidden window, headless test JVMs — and every pre-§17 T1 test, which is why
+  the §15 suite runs unchanged) it falls back to the full §15 behavior,
+  budget-with-borrow included. `keepOwedRegionsVisited` stays tick-side
+  unconditionally (the 1 s park guard needs only pump cadence).
+- Wiring: `ClientNetGlue.onRenderFrame()` → `ModCompat.renderFrame()`. Fabric
+  registers a level-render event (26.2: `LevelRenderEvents.END_MAIN` —
+  `WorldRenderEvents` no longer exists there; the 1.21.x/26.1 ports use
+  `WorldRenderEvents.END`; the event CLASS is line flavor and any end-of-frame
+  point works — the slice renders nothing, so unlike surfaces row 15 there is
+  no ordering invariant to verify on a port). NeoForge registers
+  `RenderFrameEvent.Post`.
+- Instruments (diag): `frame_flushes` (the scheduler is alive — absent-live it
+  means the render hook is not firing and the tick fallback is doing the work),
+  `rebuild_ms` (total inside `updateBuffers`), `rebuild_max_us` (worst single
+  recolor).
+- Pins: three behavioral tests (frame does the rebuild + the tick stands down;
+  the one-per-frame cap; the gate envelope + no frame-side visits) and the
+  wiring pins in `XaeroWiringContractTest` (glue forwarders + the Fabric
+  registration by CALL — the event name deliberately unpinned) and
+  `NeoForgeLoaderSeamContractTest` (the `RenderFrameEvent.Post` listener).
+
+Worst-case pump during a fill returns to the §14 commit ceiling; the rebuild
+cost amortizes at ≤1 recolor per frame. The trade: below 20 fps the drain rate
+drops under what the tick fallback would have managed — accepted, the map
+trails instead of the client hitching.

--- a/docs/planning/xaero-map-bridge-plan.md
+++ b/docs/planning/xaero-map-bridge-plan.md
@@ -1301,6 +1301,87 @@ The change:
   `NeoForgeLoaderSeamContractTest` (the `RenderFrameEvent.Post` listener).
 
 Worst-case pump during a fill returns to the §14 commit ceiling; the rebuild
-cost amortizes at ≤1 recolor per frame. The trade: below 20 fps the drain rate
-drops under what the tick fallback would have managed — accepted, the map
-trails instead of the client hitching.
+cost amortizes across frames. (The original closing claim here — "below 20 fps
+the drain drops and the tick fallback rescues it" — was INVERTED; §17.1 has the
+corrected scheduling analysis and the throughput fixes.)
+
+### 17.1 Review fold (2026-08-24, 2-Opus — lock-invariants lens + adversarial scheduling lens)
+
+Both reviewers converged on one core MAJOR family, from opposite ends:
+
+- **The tick fallback was unreachable at fps ≥ 20** (scheduling lens M1): MC runs
+  client ticks INSIDE the frame loop (ticks first, then render), so every pump is
+  preceded by a gate-passing frame and the boolean marker suppressed the fallback
+  at every pump. Drain was fps-proportional and NON-monotonic: ~20-30 recolors/s
+  in the 20-40 fps band (vs ~40-80/s pre-§17 saturated), recovering only BELOW
+  20 fps where multi-tick frames leave later pumps unmarked. Consequence chain
+  (invariants lens M1, the §15.2 valve disarmed): pendingUpdates → hard cap →
+  commits pause (`drainEntries` breaks) → queue (8192) overflows → dropped tiles
+  that LSS never re-serves (the consumer ingested them; by design no ingest
+  failure is reported for map problems) — permanent session map holes.
+- **No wall ceiling at high fps** (scheduling M2): one recolor per frame × 144-240
+  fps could burn 30-50% of EVERY frame budget during a fill — the same complaint
+  at a different grain.
+
+The fold (one mechanism answers both, keeping the no-tick-bunching goal):
+
+- **Interval allowance**: the §15.2 budget-with-borrow, re-armed at each pump and
+  metered by MEASURED recolor nanos (`rebuildSpentSinceLastPumpNanos`). Frames
+  stop recoloring once spent ≥ the allowance (fast-out, marker still armed) — the
+  high-fps wall ceiling equals what the tick fallback would have paid, spread one
+  recolor per frame. The `spent == 0` case always falls through: the first
+  recolor of an interval is never blocked, or a degenerate zero budget would
+  stand the tick down forever and void the §15 always-drains exemption (pinned).
+- **Scarce-frame pressure cap**: the per-frame cap is base 1, +1 past the soft
+  cap, +1 past half the hard cap — but the bumps apply ONLY while frames are
+  scarce (≤1 since the last pump, i.e. fps ≲ 2× tick rate, where a 25-50 ms
+  frame absorbs a few recolors and the fps × 1 drain would under-run the serve
+  rate). At high fps the cap stays 1 (one per frame already outruns the serve
+  rate; a multi-recolor 144 Hz frame would miss vsync). The frame flush budget is
+  the allowance's REMAINDER, so a multi-rebuild frame stays inside the interval
+  wall rate. The invariants lens's alternative — re-engaging the tick fallback
+  past the soft cap — was REJECTED: it re-creates the reported tick bunching
+  under exactly the fill pressure that triggers it.
+- **Marker consumed at the top of `pump()`** into `frameActiveThisPump`
+  (invariants m3): a pump that returns at a ladder gate no longer leaves a stale
+  marker for a later pump.
+- **Nothing-due head fast-out** (invariants m2): below the soft cap, the HEAD
+  entry (oldest last-touch — touch order) is checked for idle/age/stall due-ness
+  before the reflective ladder; most frames of the ~2 s coalescing window skip
+  the ~22 handle invokes + 2 monitors and just arm the marker (safe: a
+  nothing-due tick flush is a no-op either way). Accepted slack: a NON-head entry
+  due by age or stall waits at most one idle window (~2 s) extra.
+- **Probe floor** (scheduling m4, reconciled with the §15 pin
+  `aNotReadyRegionIsProbedOncePerFlushAndConsumesNoProgress`, which caught the
+  first cut of this fix): not-ready region probes stay budget-exempt up to
+  `FLUSH_PROBE_EXEMPT_FLOOR` (8) distinct regions per flush; past it the budget
+  applies even with zero removals, so a fully-not-ready set cannot walk hundreds
+  of region monitors unbounded at frame cadence.
+- **Instruments/pins**: `rebuild_nanos_total`/`rebuild_nanos_max` in
+  `counterForTest`, the three new diag tokens in the house-style pin,
+  `rebuild_max_us` session-scoped (reset at `settleSessionEnd`; the total stays
+  lifetime), and the Fabric wiring pin is now a regex requiring a RENDER event
+  (`RenderEvents.*.register(... onRenderFrame ...)`) — a tick-attached
+  registration no longer passes (scheduling m6). New tests: fallback re-engages
+  one pump after frames stop; a gated frame leaves the fallback armed; the
+  pressure cap; the allowance exhaust/re-arm cycle.
+
+Recorded, not changed:
+
+- **The overflow-holes chain is pre-existing and stays accepted**: at the hard
+  cap commits pause and queue overflow drops tiles permanently for the session
+  (healed by a dirty broadcast, rejoin re-serves after cache loss, or
+  `/lss reset`). The fold restores drain to ≈ the pre-§17 saturated wall rate at
+  every fps, so exposure is no worse than the §15 build; the flag-era build
+  (v0.12.0) had the same queue and the same drop path.
+- **Client-tick catch-up bursts** (≤10 ticks in one frame after a hitch): later
+  ticks of the burst see no intervening frame and each takes a full fallback
+  flush — up to ~10 × budget of recolors added to an already-late frame. The
+  §15 build behaved identically; gating it would starve the headless fallback.
+- **A renderer stack that fires no level-render event** degrades to the tick
+  fallback silently — i.e. exactly the §15/§16 build. The live detector is
+  `frame_flushes` climbing in `/lss diag`; the owed live check for this round is
+  explicitly: frame_flushes climbing WITH Sodium (+Iris if available) installed,
+  on at least one line.
+- **Iris shadow-pass double-fire** can run the frame slice twice per frame —
+  each invocation is capped and allowance-metered, so the ceiling holds.

--- a/fabric/src/main/java/dev/vox/lss/networking/client/LSSClientNetworking.java
+++ b/fabric/src/main/java/dev/vox/lss/networking/client/LSSClientNetworking.java
@@ -161,5 +161,14 @@ public class LSSClientNetworking {
 
     private static void registerTickHandler() {
         ClientTickEvents.END_CLIENT_TICK.register(client -> ClientNetGlue.onEndClientTick());
+        // The Xaero bridge's per-frame rebuild slice (plan §17). A level-render event
+        // fires only while a world renders — exactly when map rebuilds matter; anywhere
+        // it does not (loading screens, hidden window) the tick pump's fallback
+        // rebuilds. PER-LINE: the event CLASS is line flavor (26.2 = LevelRenderEvents;
+        // the 1.21.x/26.1 lines = WorldRenderEvents.END) — any end-of-frame point
+        // works, the slice renders nothing (unlike surfaces row 15 there is no
+        // ordering invariant to verify on a port).
+        net.fabricmc.fabric.api.client.rendering.v1.level.LevelRenderEvents
+                .END_MAIN.register(context -> ClientNetGlue.onRenderFrame());
     }
 }

--- a/fabric/src/test/java/dev/vox/lss/compat/XaeroMapCompatTest.java
+++ b/fabric/src/test/java/dev/vox/lss/compat/XaeroMapCompatTest.java
@@ -806,32 +806,35 @@ class XaeroMapCompatTest {
         }
     }
 
-    // ---- the frame slice (plan §17 — the stutter round) ----
+    // ---- the frame slice (plan §17 + the §17.1 review fold — the stutter round) ----
 
     @Test
     void rebuildsRunOnTheFrameAndTheTickFallbackStandsDown() {
         this.bridge.updateIdlePumps = 1;
         offer(64, 64);
         this.bridge.pump(); // commit; the rebuild is owed
-        this.bridge.frameFlush(); // not due yet — but the frame scheduler is now known alive
-        assertEquals(1, this.bridge.counterForTest("frame_flushes"));
-        assertEquals(0, this.bridge.counterForTest("buffer_updates"));
-        assertEquals(1, this.bridge.counterForTest("pending_updates"));
+        this.bridge.frameFlush(); // not due yet: the cheap fast-out arms the marker
+        assertEquals(0, this.bridge.counterForTest("frame_flushes"),
+                "a nothing-due frame skips the reflective ladder");
         this.bridge.pump(); // due now, but a frame ran since the last pump
         assertEquals(0, this.bridge.counterForTest("buffer_updates"),
                 "the tick fallback must stand down while frames are flushing");
         assertEquals(1, this.bridge.counterForTest("pending_updates"));
         this.bridge.frameFlush(); // the frame does the rebuild
+        assertEquals(1, this.bridge.counterForTest("frame_flushes"));
         assertEquals(1, this.bridge.counterForTest("buffer_updates"));
         assertEquals(0, this.bridge.counterForTest("pending_updates"));
         this.bridge.pump(); // marker consumed + nothing owed: no double rebuild
         assertEquals(1, this.bridge.counterForTest("buffer_updates"));
-        assertTrue(this.bridge.describe().contains("frame_flushes=2"),
+        assertTrue(this.bridge.describe().contains("frame_flushes=1"),
                 "the live diag must show the frame scheduler firing");
+        assertTrue(this.bridge.counterForTest("rebuild_nanos_total")
+                        >= this.bridge.counterForTest("rebuild_nanos_max"),
+                "the stutter instruments meter the recolor");
     }
 
     @Test
-    void aFrameRebuildsAtMostOneTileChunk() {
+    void aFrameRebuildsAtMostOneTileChunkWithoutPressure() {
         this.bridge.updateIdlePumps = 1;
         offer(64, 64);
         offer(96, 64); // a second tile chunk in a second region
@@ -841,7 +844,7 @@ class XaeroMapCompatTest {
         assertEquals(0, this.bridge.counterForTest("buffer_updates"));
         this.bridge.frameFlush();
         assertEquals(1, this.bridge.counterForTest("buffer_updates"),
-                "one recolor per frame — the whole point of the frame slice");
+                "one recolor per frame without backlog pressure");
         assertEquals(1, this.bridge.counterForTest("pending_updates"));
         this.bridge.frameFlush();
         assertEquals(2, this.bridge.counterForTest("buffer_updates"));
@@ -849,33 +852,90 @@ class XaeroMapCompatTest {
     }
 
     @Test
+    void thePerFrameCapRisesWithBacklogPressureWhileFramesAreScarce() {
+        this.bridge.updateIdlePumps = 1;
+        this.bridge.pendingUpdatesSoftCap = 1;
+        this.bridge.pendingUpdatesHardCap = 4;
+        offer(64, 64);
+        offer(96, 64);
+        offer(128, 64); // three tile chunks in three regions
+        this.bridge.pump(); // all commit; pending 3 > soft cap AND > hardCap/2
+        this.bridge.frameFlush(); // overflow past the soft cap makes the oldest two due
+        assertEquals(2, this.bridge.counterForTest("buffer_updates"),
+                "cap 3 under scarce-frame pressure: both due entries recolor in ONE frame");
+        this.bridge.pump(); // stands down; the third becomes idle-due
+        this.bridge.frameFlush();
+        assertEquals(3, this.bridge.counterForTest("buffer_updates"),
+                "pressure gone (pending 1 <= soft cap): back to one per frame");
+        assertEquals(0, this.bridge.counterForTest("pending_updates"));
+    }
+
+    @Test
+    void theAllowanceStopsFrameRebuildsUntilTheNextPumpRearmsIt() {
+        this.bridge.updateIdlePumps = 1;
+        this.bridge.updateNanosBudget = 0; // degenerate interval allowance
+        this.bridge.updateBorrowNanos = 0;
+        offer(64, 64);
+        offer(96, 64);
+        this.bridge.pump(); // both commit
+        this.bridge.frameFlush(); // not due: fast-out arms the marker
+        this.bridge.pump(); // stands down; both due; the interval allowance re-arms
+        this.bridge.frameFlush(); // spent==0 must fall through the allowance gate
+        assertEquals(1, this.bridge.counterForTest("buffer_updates"),
+                "the first recolor of an interval always runs (the always-drains rule)");
+        this.bridge.frameFlush(); // spent > 0 and >= the zero allowance: fast-out
+        assertEquals(1, this.bridge.counterForTest("buffer_updates"),
+                "past the allowance the frame slice stops recoloring");
+        this.bridge.pump(); // stands down (the fast-out armed the marker); re-arms
+        this.bridge.frameFlush();
+        assertEquals(2, this.bridge.counterForTest("buffer_updates"),
+                "the next pump re-arms the interval allowance");
+    }
+
+    @Test
+    void theTickFallbackReengagesOnePumpAfterFramesStop() {
+        this.bridge.updateIdlePumps = 1;
+        offer(64, 64);
+        offer(96, 64);
+        this.bridge.pump();
+        this.bridge.frameFlush(); // arms
+        this.bridge.pump(); // stands down; both due
+        this.bridge.frameFlush(); // rebuild #1 on the frame
+        assertEquals(1, this.bridge.counterForTest("buffer_updates"));
+        this.bridge.pump(); // marker from that frame: still stands down
+        assertEquals(1, this.bridge.counterForTest("buffer_updates"));
+        this.bridge.pump(); // NO frame since the last pump: the fallback rebuilds
+        assertEquals(2, this.bridge.counterForTest("buffer_updates"),
+                "frames stopped (loading screen, hidden window): the tick must take over");
+    }
+
+    @Test
     void theFrameSliceRespectsTheGateEnvelopeAndNeverVisitsRegions() {
-        this.bridge.updateIdlePumps = 1000; // rebuilds stay owed all test
+        this.bridge.updateIdlePumps = 1;
         offer(64, 64);
         offer(68, 64); // same region, two owed tile chunks
-        this.bridge.pump();
+        this.bridge.pump(); // commit
+        this.bridge.frameFlush(); // arms (nothing due)
+        this.bridge.pump(); // stands down; both due
         var region = theRegion();
         int visits = region.visits;
-        this.bridge.frameFlush();
-        this.bridge.frameFlush();
+        this.bridge.frameFlush(); // rebuild #1
+        assertEquals(1, this.bridge.counterForTest("frame_flushes"));
+        assertEquals(1, this.bridge.counterForTest("buffer_updates"));
         assertEquals(0, region.visits - visits,
                 "the park guard is tick-side: frames must not add region visits");
-        assertEquals(2, this.bridge.counterForTest("frame_flushes"));
-        // A crashed Xaero is never touched — and the frame marker must not arm.
+        this.bridge.pump(); // consumes that frame's marker
+        // A crashed Xaero is never touched — and a GATED frame must NOT arm the marker.
         xaero.map.WorldMap.crashHandler.crashedBy = new RuntimeException("armed");
         this.bridge.frameFlush();
-        assertEquals(2, this.bridge.counterForTest("frame_flushes"));
+        assertEquals(1, this.bridge.counterForTest("frame_flushes"),
+                "gated: the ladder defers before flushing");
+        assertEquals(1, this.bridge.counterForTest("buffer_updates"));
         xaero.map.WorldMap.crashHandler.crashedBy = null;
-        this.processor.writingPaused = true;
-        this.bridge.frameFlush();
-        assertEquals(2, this.bridge.counterForTest("frame_flushes"),
-                "writer-paused: the frame slice defers exactly like the pump ladder");
-        this.processor.writingPaused = false;
-        assertEquals(0, this.bridge.counterForTest("commit_failures"),
-                "gates defer, never fail");
-        this.bridge.frameFlush();
-        assertEquals(3, this.bridge.counterForTest("frame_flushes"),
-                "gates clear again: the slice resumes");
+        this.bridge.pump(); // no armed marker from the gated frame: the fallback rebuilds
+        assertEquals(2, this.bridge.counterForTest("buffer_updates"),
+                "a gated frame leaves the tick fallback armed — else closed gates wedge the set");
+        assertEquals(0, this.bridge.counterForTest("commit_failures"), "gates defer, never fail");
     }
 
     private MapRegion theRegion() {
@@ -1922,7 +1982,8 @@ class XaeroMapCompatTest {
                 && line.contains(", regions_waiting=") && line.contains(", buffer_updates=")
                 && line.contains(", pending_updates=") && line.contains(", dropped_updates=")
                 && line.contains(", dropped_unloaded=") && line.contains(", skipped_settings=")
-                && line.contains(", cave_layer_waits="), line);
+                && line.contains(", cave_layer_waits=") && line.contains(", frame_flushes=")
+                && line.contains(", rebuild_ms=") && line.contains(", rebuild_max_us="), line);
         assertFalse(line.contains("xaero_crashed"), "the crash token appears only while latched");
         assertFalse(line.contains("optional_unbound"), "every optional group binds against the stubs");
         this.enabled = false;

--- a/fabric/src/test/java/dev/vox/lss/compat/XaeroMapCompatTest.java
+++ b/fabric/src/test/java/dev/vox/lss/compat/XaeroMapCompatTest.java
@@ -806,6 +806,78 @@ class XaeroMapCompatTest {
         }
     }
 
+    // ---- the frame slice (plan §17 — the stutter round) ----
+
+    @Test
+    void rebuildsRunOnTheFrameAndTheTickFallbackStandsDown() {
+        this.bridge.updateIdlePumps = 1;
+        offer(64, 64);
+        this.bridge.pump(); // commit; the rebuild is owed
+        this.bridge.frameFlush(); // not due yet — but the frame scheduler is now known alive
+        assertEquals(1, this.bridge.counterForTest("frame_flushes"));
+        assertEquals(0, this.bridge.counterForTest("buffer_updates"));
+        assertEquals(1, this.bridge.counterForTest("pending_updates"));
+        this.bridge.pump(); // due now, but a frame ran since the last pump
+        assertEquals(0, this.bridge.counterForTest("buffer_updates"),
+                "the tick fallback must stand down while frames are flushing");
+        assertEquals(1, this.bridge.counterForTest("pending_updates"));
+        this.bridge.frameFlush(); // the frame does the rebuild
+        assertEquals(1, this.bridge.counterForTest("buffer_updates"));
+        assertEquals(0, this.bridge.counterForTest("pending_updates"));
+        this.bridge.pump(); // marker consumed + nothing owed: no double rebuild
+        assertEquals(1, this.bridge.counterForTest("buffer_updates"));
+        assertTrue(this.bridge.describe().contains("frame_flushes=2"),
+                "the live diag must show the frame scheduler firing");
+    }
+
+    @Test
+    void aFrameRebuildsAtMostOneTileChunk() {
+        this.bridge.updateIdlePumps = 1;
+        offer(64, 64);
+        offer(96, 64); // a second tile chunk in a second region
+        this.bridge.pump(); // both commit
+        this.bridge.frameFlush(); // arms the marker; nothing due yet
+        this.bridge.pump(); // ages both to due; the tick stands down
+        assertEquals(0, this.bridge.counterForTest("buffer_updates"));
+        this.bridge.frameFlush();
+        assertEquals(1, this.bridge.counterForTest("buffer_updates"),
+                "one recolor per frame — the whole point of the frame slice");
+        assertEquals(1, this.bridge.counterForTest("pending_updates"));
+        this.bridge.frameFlush();
+        assertEquals(2, this.bridge.counterForTest("buffer_updates"));
+        assertEquals(0, this.bridge.counterForTest("pending_updates"));
+    }
+
+    @Test
+    void theFrameSliceRespectsTheGateEnvelopeAndNeverVisitsRegions() {
+        this.bridge.updateIdlePumps = 1000; // rebuilds stay owed all test
+        offer(64, 64);
+        offer(68, 64); // same region, two owed tile chunks
+        this.bridge.pump();
+        var region = theRegion();
+        int visits = region.visits;
+        this.bridge.frameFlush();
+        this.bridge.frameFlush();
+        assertEquals(0, region.visits - visits,
+                "the park guard is tick-side: frames must not add region visits");
+        assertEquals(2, this.bridge.counterForTest("frame_flushes"));
+        // A crashed Xaero is never touched — and the frame marker must not arm.
+        xaero.map.WorldMap.crashHandler.crashedBy = new RuntimeException("armed");
+        this.bridge.frameFlush();
+        assertEquals(2, this.bridge.counterForTest("frame_flushes"));
+        xaero.map.WorldMap.crashHandler.crashedBy = null;
+        this.processor.writingPaused = true;
+        this.bridge.frameFlush();
+        assertEquals(2, this.bridge.counterForTest("frame_flushes"),
+                "writer-paused: the frame slice defers exactly like the pump ladder");
+        this.processor.writingPaused = false;
+        assertEquals(0, this.bridge.counterForTest("commit_failures"),
+                "gates defer, never fail");
+        this.bridge.frameFlush();
+        assertEquals(3, this.bridge.counterForTest("frame_flushes"),
+                "gates clear again: the slice resumes");
+    }
+
     private MapRegion theRegion() {
         assertEquals(1, this.processor.regions.size(), "one region in play");
         return this.processor.regions.values().iterator().next();

--- a/fabric/src/test/java/dev/vox/lss/compat/XaeroWiringContractTest.java
+++ b/fabric/src/test/java/dev/vox/lss/compat/XaeroWiringContractTest.java
@@ -81,13 +81,17 @@ class XaeroWiringContractTest {
                         + " rebuild slice");
         String fabricGlue = Files.readString(SourcePaths.mainSource(
                 "dev/vox/lss/networking/client/LSSClientNetworking.java"));
-        // The event CLASS is per-line flavor (26.2 = LevelRenderEvents.END_MAIN, the
-        // 1.21.x/26.1 lines = WorldRenderEvents.END) — the invariant is that SOME
-        // frame-cadence event drives onRenderFrame.
-        assertTrue(fabricGlue.contains(".register(context -> ClientNetGlue.onRenderFrame())"),
-                "the Fabric per-frame registration is gone — rebuilds silently bunch back"
-                        + " onto the client tick (the NeoForge twin is pinned in"
-                        + " NeoForgeLoaderSeamContractTest)");
+        // The event CLASS is per-line flavor (26.2 = level.LevelRenderEvents.END_MAIN,
+        // the 1.21.x/26.1 lines = a WorldRenderEvents member) — the invariant is that a
+        // RENDER event drives onRenderFrame (§17.1 review fold: a bare call-site match
+        // would also pass on a tick registration, the exact regression this pin exists
+        // to catch; the lambda parameter name is not pinned).
+        assertTrue(java.util.regex.Pattern.compile(
+                        "RenderEvents\\s*\\.\\s*\\w+\\.register\\(\\s*\\w+ -> ClientNetGlue\\.onRenderFrame\\(\\)\\)")
+                        .matcher(fabricGlue).find(),
+                "the Fabric per-frame registration is gone or moved off a render event —"
+                        + " rebuilds silently bunch back onto the client tick (the NeoForge"
+                        + " twin is pinned in NeoForgeLoaderSeamContractTest)");
     }
 
     /**

--- a/fabric/src/test/java/dev/vox/lss/compat/XaeroWiringContractTest.java
+++ b/fabric/src/test/java/dev/vox/lss/compat/XaeroWiringContractTest.java
@@ -58,9 +58,36 @@ class XaeroWiringContractTest {
                 "init must initialize the bridge");
         assertTrue(modCompat.contains("XaeroMapCompat.clientTick()"),
                 "clientTick must forward to the bridge's pump");
+        assertTrue(modCompat.contains("XaeroMapCompat.renderFrame()"),
+                "renderFrame must forward to the bridge's frame rebuild slice (plan §17)");
         assertTrue(modCompat.contains("XaeroMapCompat.onDisconnect()"),
                 "onDisconnect must forward to the bridge's session teardown");
 
+    }
+
+    /**
+     * The frame slice (plan §17) is the FOURTH wiring leg: without it every rebuild
+     * falls back to tick cadence — all behavioral tests stay green (the fallback IS
+     * the test path) while the live client stutters exactly like the pre-§17 build.
+     */
+    @Test
+    void theRenderFrameGlueDrivesTheRebuildSlice() throws IOException {
+        String glue = Files.readString(SourcePaths.mainSource(
+                "dev/vox/lss/networking/client/ClientNetGlue.java"));
+        int frameBody = glue.indexOf("public static void onRenderFrame()");
+        assertTrue(frameBody >= 0, "onRenderFrame moved — retarget this pin");
+        assertTrue(glue.indexOf("ModCompat.renderFrame()", frameBody) > frameBody,
+                "onRenderFrame must call ModCompat.renderFrame() — the frame-cadence"
+                        + " rebuild slice");
+        String fabricGlue = Files.readString(SourcePaths.mainSource(
+                "dev/vox/lss/networking/client/LSSClientNetworking.java"));
+        // The event CLASS is per-line flavor (26.2 = LevelRenderEvents.END_MAIN, the
+        // 1.21.x/26.1 lines = WorldRenderEvents.END) — the invariant is that SOME
+        // frame-cadence event drives onRenderFrame.
+        assertTrue(fabricGlue.contains(".register(context -> ClientNetGlue.onRenderFrame())"),
+                "the Fabric per-frame registration is gone — rebuilds silently bunch back"
+                        + " onto the client tick (the NeoForge twin is pinned in"
+                        + " NeoForgeLoaderSeamContractTest)");
     }
 
     /**

--- a/neoforge/src/main/java/dev/vox/lss/neoforge/LSSNeoClientBootstrap.java
+++ b/neoforge/src/main/java/dev/vox/lss/neoforge/LSSNeoClientBootstrap.java
@@ -13,6 +13,7 @@ import net.minecraft.network.chat.Component;
 import net.neoforged.neoforge.client.event.ClientPlayerNetworkEvent;
 import net.neoforged.neoforge.client.event.ClientTickEvent;
 import net.neoforged.neoforge.client.event.RegisterClientCommandsEvent;
+import net.neoforged.neoforge.client.event.RenderFrameEvent;
 import net.neoforged.neoforge.common.NeoForge;
 
 import java.util.function.Consumer;
@@ -45,6 +46,10 @@ public final class LSSNeoClientBootstrap {
                 e -> ClientNetGlue.onDisconnect());
         NeoForge.EVENT_BUS.addListener(ClientTickEvent.Post.class,
                 e -> ClientNetGlue.onEndClientTick());
+        // The Xaero bridge's per-frame rebuild slice (plan §17); fires every frame,
+        // cheap no-op without owed rebuilds.
+        NeoForge.EVENT_BUS.addListener(RenderFrameEvent.Post.class,
+                e -> ClientNetGlue.onRenderFrame());
         NeoForge.EVENT_BUS.addListener(RegisterClientCommandsEvent.class,
                 LSSNeoClientBootstrap::registerClientCommands);
 

--- a/neoforge/src/test/java/dev/vox/lss/neoforge/NeoForgeLoaderSeamContractTest.java
+++ b/neoforge/src/test/java/dev/vox/lss/neoforge/NeoForgeLoaderSeamContractTest.java
@@ -140,6 +140,9 @@ class NeoForgeLoaderSeamContractTest {
                 "the disconnect settle must be registered on ClientPlayerNetworkEvent.LoggingOut");
         assertTrue(Pattern.compile("ClientPlayerNetworkEvent\\.LoggingIn\\.class,\\s*e -> ClientNetGlue\\.onJoin\\(\\)").matcher(boot).find(),
                 "the join hook must be registered on ClientPlayerNetworkEvent.LoggingIn");
+        assertTrue(Pattern.compile("RenderFrameEvent\\.Post\\.class,\\s*e -> ClientNetGlue\\.onRenderFrame\\(\\)").matcher(boot).find(),
+                "the per-frame Xaero rebuild slice must stay registered (plan §17) — without it"
+                        + " rebuilds silently bunch back onto the client tick and stutter");
         assertTrue(boot.contains("ModCompat.init();"), "the compat ladder (Xaero, Voxy) must be initialized");
     }
 }

--- a/xplat/src/main/java/dev/vox/lss/compat/ModCompat.java
+++ b/xplat/src/main/java/dev/vox/lss/compat/ModCompat.java
@@ -27,6 +27,12 @@ public final class ModCompat {
         XaeroMapCompat.clientTick();
     }
 
+    /** Per-frame forwarder (render thread) — the Xaero bridge's texture-rebuild
+     *  slice: one recolor per frame (xaero-map-bridge-plan.md §17). */
+    public static void renderFrame() {
+        XaeroMapCompat.renderFrame();
+    }
+
     /** Disconnect forwarder — a session's queued map tiles never outlive it. */
     public static void onDisconnect() {
         XaeroMapCompat.onDisconnect();

--- a/xplat/src/main/java/dev/vox/lss/compat/XaeroMapCompat.java
+++ b/xplat/src/main/java/dev/vox/lss/compat/XaeroMapCompat.java
@@ -152,8 +152,21 @@ final class XaeroMapCompat {
      *  commit budget doubled the pump ceiling — visible stutter during map fills.
      *  One rebuild per frame is Xaero's own sweep grain: at 60-120 fps that is
      *  60-120 tile chunks/s ≈ 1000-2000 coalesced tiles/s of drain — above the
-     *  serve rate — while a frame never pays more than one recolor. */
+     *  serve rate. This is the BASE of the per-frame cap (§17.1 review fold): under
+     *  backlog pressure while frames are SCARCE (≤1 since the last pump, fps ≲ 2×
+     *  tick rate — a long frame absorbs a few recolors) it rises to 2 past the soft
+     *  cap and 3 past half the hard cap, and the interval ALLOWANCE (the §15.2
+     *  budget-with-borrow per pump, metered by measured recolor nanos) is the
+     *  wall-rate ceiling either way — a 144 Hz client pays the same rate the tick
+     *  fallback would, spread across frames. */
     static final int FRAME_MAX_REBUILDS = 1;
+    /** Not-ready region probes exempt from the flush budget (§17.1): under the
+     *  production 2 ms budget the floor never binds (a probe is ~µs); it exists so a
+     *  fully-not-ready owed set cannot walk hundreds of region monitors per FRAME
+     *  with the budget never consulted (no removing outcome = the §15 exemption
+     *  never disarms). Under a degenerate zero budget, ready work behind more than
+     *  this many not-ready regions waits for the tick fallback — accepted. */
+    static final int FLUSH_PROBE_EXEMPT_FLOOR = 8;
     /** Consecutive failures (commit-side or extraction-side) before the bridge
      *  latches dead for the SESSION (re-armed at disconnect). */
     static final int THROW_LATCH = 5;
@@ -329,9 +342,21 @@ final class XaeroMapCompat {
      *  — the live stutter instruments (diag {@code rebuild_ms=}/{@code rebuild_max_us=}). */
     private final AtomicLong rebuildNanos = new AtomicLong();
     private volatile long rebuildNanosMax;
-    /** A frame flush ran since the last pump — that pump skips its rebuild fallback.
-     *  Main thread only (frames and ticks share the render thread). */
+    /** A frame flush ran (or fast-out-armed) since the last pump — consumed into
+     *  {@link #frameActiveThisPump} at the TOP of {@code pump()} (§17.1: a pump that
+     *  returns at a ladder gate must not leave it armed for a later one). Main
+     *  thread only (frames and ticks share the render thread). */
     private boolean frameFlushRan;
+    /** The marker's per-pump snapshot — the value {@code tickFlush} acts on. */
+    private boolean frameActiveThisPump;
+    /** Nanos of {@code updateBuffers} the frame slice spent since the last pump —
+     *  the interval's allowance meter (§17.1): frames stop recoloring once it
+     *  reaches the budget-with-borrow, so a high-fps client pays the same wall
+     *  rate the tick fallback would. Main thread only. */
+    private long rebuildSpentSinceLastPumpNanos;
+    /** Frames seen since the last pump — the per-frame cap's pressure bumps apply
+     *  only while frames are SCARCE (≤1 per tick). Main thread only. */
+    private int framesSinceLastPump;
     private final AtomicLong droppedUpdates = new AtomicLong();
     /** Owed rebuilds whose region/tile chunk Xaero unloaded, parked or replaced
      *  first — its own counter (review A) so the live test can tell a parking race
@@ -477,6 +502,10 @@ final class XaeroMapCompat {
         this.regionsWaiting = 0;
         this.consecutiveFailures = 0;
         this.frameFlushRan = false;
+        this.frameActiveThisPump = false;
+        this.rebuildSpentSinceLastPumpNanos = 0;
+        this.framesSinceLastPump = 0;
+        this.rebuildNanosMax = 0; // session-scoped worst recolor; the total stays lifetime
         this.lastWorldId = null;
         if (this.registered && !this.enabled.getAsBoolean()) {
             this.deregistrar.accept(this.consumer);
@@ -665,6 +694,8 @@ final class XaeroMapCompat {
             case "load_requests" -> this.loadRequests.get();
             case "buffer_updates" -> this.bufferUpdates.get();
             case "frame_flushes" -> this.frameFlushes.get();
+            case "rebuild_nanos_total" -> this.rebuildNanos.get();
+            case "rebuild_nanos_max" -> this.rebuildNanosMax;
             case "dropped_updates" -> this.droppedUpdates.get();
             case "dropped_unloaded" -> this.droppedUnloaded.get();
             case "skipped_settings" -> this.skippedSettings.get();
@@ -716,6 +747,12 @@ final class XaeroMapCompat {
             return;
         }
         this.pumpCount++;
+        // §17.1 (review fold): the frame marker is consumed HERE, once per pump — and
+        // the interval allowance / frame-scarcity meters re-arm.
+        this.frameActiveThisPump = this.frameFlushRan;
+        this.frameFlushRan = false;
+        this.rebuildSpentSinceLastPumpNanos = 0;
+        this.framesSinceLastPump = 0;
         if (!this.enabled.getAsBoolean()) {
             clearQueue(); // the live toggle: flipping off drops the backlog immediately
             // ...but rebuilds already OWED to committed tile chunks still flush —
@@ -847,25 +884,57 @@ final class XaeroMapCompat {
     }
 
     /**
-     * Per-frame flush (plan §17): the texture-rebuild phase runs at FRAME cadence —
-     * Xaero's own sweep scheduling — instead of bunched on the client tick, at most
-     * {@link #frameMaxRebuilds} recolor(s) per call. Mirrors the pump ladder's gate
-     * envelope exactly down to the dimension equality (a rebuild must never run under
-     * weaker gates than the pump's flush did); the settings and cave-layer gates sit
-     * BELOW the flush in the pump ladder (rebuilds are owed debt to already-committed
-     * tile chunks, not new writes) and are skipped here for the same reason. Never
-     * drains commits, never grants loads, never visits regions (tick-side — the 1 s
-     * park guard needs only pump cadence), and defers the world-change queue drop to
-     * the pump (it returns instead). Shares the pump's containment + death latch.
+     * Per-frame flush (plan §17/§17.1): the texture-rebuild phase runs at FRAME
+     * cadence — Xaero's own sweep scheduling — instead of bunched on the client
+     * tick, at most a pressure-capped few recolors per call (base
+     * {@link #frameMaxRebuilds}; scarce-frame bumps; allowance-bounded). Mirrors the
+     * pump ladder's gate envelope exactly down to the dimension equality (a rebuild
+     * must never run under weaker gates than the pump's flush did); the settings and
+     * cave-layer gates sit BELOW the flush in the pump ladder (rebuilds are owed
+     * debt to already-committed tile chunks, not new writes) and are skipped here
+     * for the same reason. Never drains commits, never grants loads, never visits
+     * regions (tick-side — the 1 s park guard needs only pump cadence), and defers
+     * the world-change queue drop to the pump (it returns instead). Shares the
+     * pump's containment + death latch.
      */
     void frameFlush() {
         if (this.dead || this.sessionEndPending || this.pendingUpdates.isEmpty()) return;
+        this.framesSinceLastPump++;
+        // §17.1 fast-outs, both arming the stand-down marker WITHOUT the reflective
+        // ladder (safe: a tick flush with nothing due — or after this interval's
+        // allowance was spent on real recolors — is a no-op either way):
+        // (1) nothing can be due yet;
+        if (nothingDueAtHead()) {
+            this.frameFlushRan = true;
+            return;
+        }
+        // (2) the interval's allowance is spent — but only after a REAL recolor this
+        // interval (spent == 0 must fall through, or a degenerate zero budget would
+        // stand the tick down forever and void the always-drains exemption).
+        if (this.rebuildSpentSinceLastPumpNanos > 0
+                && this.rebuildSpentSinceLastPumpNanos >= rebuildBudgetWithBorrow()) {
+            this.frameFlushRan = true;
+            return;
+        }
         try {
             frameLadder();
         } catch (Throwable t) {
             if (t instanceof Error err && !(t instanceof AssertionError)) throw err;
             noteFailure(t);
         }
+    }
+
+    /** True when no owed rebuild can be due this pump, judged from the HEAD entry
+     *  (touch order makes it the oldest last-touch, so its idle window binds first)
+     *  — the frame slice's cheap pre-ladder skip for the ~2 s coalescing window
+     *  (§17.1). The age/stall legs also read only the head: a non-head entry due by
+     *  age or stall waits at most one idle window extra — accepted slack. */
+    private boolean nothingDueAtHead() {
+        if (this.pendingUpdates.size() > this.pendingUpdatesSoftCap) return false;
+        var head = this.pendingUpdates.values().iterator().next();
+        return this.pumpCount - head.lastTouchPump < this.updateIdlePumps
+                && this.pumpCount - head.firstTouchPump < this.updateMaxDeferPumps
+                && head.stalledSincePump < 0;
     }
 
     private void frameLadder() throws Throwable {
@@ -902,10 +971,24 @@ final class XaeroMapCompat {
                 if (this.levelOps.dimension(world) != dimensionId) return;
             }
             // Past every gate the pump's flush would have run under: the tick's
-            // rebuild fallback stands down until the next pump.
+            // rebuild fallback stands down until the next pump. §17.1: the per-frame
+            // cap grows under backlog pressure ONLY while frames are scarce (a long
+            // frame absorbs a few recolors; at high fps one per frame already outruns
+            // the serve rate), and the flush budget is the interval allowance's
+            // remainder, so a multi-rebuild frame stays inside the wall rate the
+            // tick fallback would have paid.
             this.frameFlushRan = true;
             this.frameFlushes.incrementAndGet();
-            flushPendingUpdates(mp, dimensionId, this.updateNanosBudget, this.frameMaxRebuilds, false);
+            int pending = this.pendingUpdates.size();
+            boolean scarce = this.framesSinceLastPump <= 1;
+            int cap = this.frameMaxRebuilds
+                    + (scarce && pending > this.pendingUpdatesSoftCap ? 1 : 0)
+                    + (scarce && pending > this.pendingUpdatesHardCap / 2 ? 1 : 0);
+            long remaining = Math.max(1L,
+                    rebuildBudgetWithBorrow() - this.rebuildSpentSinceLastPumpNanos);
+            long rebuildNanosBefore = this.rebuildNanos.get();
+            flushPendingUpdates(mp, dimensionId, remaining, cap, false);
+            this.rebuildSpentSinceLastPumpNanos += this.rebuildNanos.get() - rebuildNanosBefore;
         }
     }
 
@@ -1383,6 +1466,7 @@ final class XaeroMapCompat {
         Object shapeCache;
         Object fastConfig;
         int rebuilt; // actual updateBuffers calls this flush (the frame cap's meter)
+        int probes; // rebuildTileChunk entries past the memo — the scan-bound meter
         final java.util.Set<Object> notReadyRegions =
                 java.util.Collections.newSetFromMap(new java.util.IdentityHashMap<>());
     }
@@ -1408,26 +1492,28 @@ final class XaeroMapCompat {
      * textures. A tile chunk the native writer already consumed
      * ({@code !wasChanged()}) needs nothing.
      */
-    /** The tick pump's flush call: consumes the frame marker — with frames flushing,
-     *  the tick runs ZERO rebuilds (drops/bookkeeping only); with no frame since the
-     *  last pump (loading screens, hidden window, headless test JVMs) it falls back
-     *  to the full pre-§17 budget-with-borrow rebuild behavior. */
-    private void tickFlush(Object mp, Object dimensionId) {
-        boolean frameActive = this.frameFlushRan;
-        this.frameFlushRan = false;
-        long budget;
-        if (frameActive) {
-            budget = this.updateNanosBudget; // bounds the cheap-class scan only
-        } else {
-            boolean queueEmpty;
-            synchronized (this.queueLock) {
-                queueEmpty = this.queue.isEmpty();
-            }
-            long borrow = queueEmpty ? this.updateBorrowNanos
-                    : this.pendingUpdates.size() > this.pendingUpdatesSoftCap ? this.updateBorrowNanos / 2 : 0;
-            budget = borrow > Long.MAX_VALUE - this.updateNanosBudget
-                    ? Long.MAX_VALUE : this.updateNanosBudget + borrow; // saturating (the seams take MAX)
+    /** The interval's rebuild allowance: the §15.2 budget-with-borrow math, shared
+     *  by the tick fallback and the frame slice's allowance ceiling (§17.1). */
+    private long rebuildBudgetWithBorrow() {
+        boolean queueEmpty;
+        synchronized (this.queueLock) {
+            queueEmpty = this.queue.isEmpty();
         }
+        long borrow = queueEmpty ? this.updateBorrowNanos
+                : this.pendingUpdates.size() > this.pendingUpdatesSoftCap ? this.updateBorrowNanos / 2 : 0;
+        return borrow > Long.MAX_VALUE - this.updateNanosBudget
+                ? Long.MAX_VALUE : this.updateNanosBudget + borrow; // saturating (the seams take MAX)
+    }
+
+    /** The tick pump's flush call: with frames flushing (the marker consumed at the
+     *  top of {@link #pump}) the tick runs ZERO rebuilds — drops/bookkeeping only,
+     *  never a recolor bunched onto the tick; with no frame since the last pump
+     *  (loading screens, hidden window, headless test JVMs) it falls back to the
+     *  full §15 budget-with-borrow rebuild behavior. */
+    private void tickFlush(Object mp, Object dimensionId) {
+        boolean frameActive = this.frameActiveThisPump;
+        long budget = frameActive ? this.updateNanosBudget // bounds the cheap-class scan only
+                : rebuildBudgetWithBorrow();
         flushPendingUpdates(mp, dimensionId, budget, frameActive ? 0 : Integer.MAX_VALUE, true);
     }
 
@@ -1452,7 +1538,14 @@ final class XaeroMapCompat {
         int overflow = this.pendingUpdates.size() - this.pendingUpdatesSoftCap;
         var it = this.pendingUpdates.values().iterator();
         while (it.hasNext()) {
-            if (removed > 0 && System.nanoTime() - start > budget) break;
+            // The §15 exemption: removing outcomes arm the budget check, and not-ready
+            // probes stay FREE up to a small floor (memoized per region, so the floor
+            // is distinct regions — the pin: ready work behind a not-ready region must
+            // not starve). Past the floor the budget applies even with zero removals
+            // (§17.1, review B m4: an all-not-ready set must not walk hundreds of
+            // region monitors unbounded at frame cadence on the render thread).
+            if ((removed > 0 || args.probes > FLUSH_PROBE_EXEMPT_FLOOR)
+                    && System.nanoTime() - start > budget) break;
             var pu = it.next();
             boolean due = overflow-- > 0
                     || this.pumpCount - pu.lastTouchPump >= this.updateIdlePumps
@@ -1530,6 +1623,7 @@ final class XaeroMapCompat {
 
     private UpdateResult rebuildTileChunk(Object mp, PendingUpdate pu, RebuildArgs args) {
         if (args.notReadyRegions.contains(pu.region)) return UpdateResult.NOT_READY;
+        args.probes++; // §17.1: probes past FLUSH_PROBE_EXEMPT_FLOOR arm the budget check
         try {
             Object writerPause = this.h.writerThreadPauseSync.invoke(pu.region);
             synchronized (writerPause) {

--- a/xplat/src/main/java/dev/vox/lss/compat/XaeroMapCompat.java
+++ b/xplat/src/main/java/dev/vox/lss/compat/XaeroMapCompat.java
@@ -132,20 +132,28 @@ final class XaeroMapCompat {
      *  FIRST commit — the map must never show a written tile chunk blank
      *  indefinitely (review B). */
     static final int UPDATE_MAX_DEFER_PUMPS = 4 * UPDATE_IDLE_PUMPS;
-    /** Rebuild budget per pump, separate from the commit budget; the first REMOVING
-     *  outcome (rebuilt/dropped/failed) of a pump is exempt from it, so the set
-     *  always drains — not-ready verdicts are memoized per region and cost no
-     *  budget. The flush BORROWS on top of it (review A: a rebuild is the
-     *  expensive half of a native write, and a budget that cannot keep up parks
-     *  commits at the hard cap): the whole {@link #UPDATE_BORROW_NANOS} once the
-     *  queue is empty (commits need nothing), half of it while the owed set is
-     *  past the soft cap. Steady state needs ~1-4 rebuilds per 16 delivered tiles
-     *  (the spiral coalesces harder the faster rings arrive), so at ~1000
-     *  columns/s the load is ~2-3 rebuilds per pump; if the live counters show
-     *  {@code pending_updates} pinned at the hard cap with {@code written} flat,
-     *  the next lever is a per-FRAME flush hook (Xaero's own sweep runs per frame). */
+    /** Rebuild budget for the TICK-side flush — the FALLBACK path only since the
+     *  frame round (plan §17): rebuilds normally run on the per-frame hook
+     *  ({@link #renderFrame} — review A's recorded lever, pulled after the fix's
+     *  first live session stuttered), and a pump that saw a frame flush since the
+     *  previous pump runs its flush with ZERO rebuilds (cheap drops/bookkeeping
+     *  only). With no frames flushing (loading screens, hidden window, headless
+     *  test JVMs) the tick flush rebuilds under this budget exactly as before:
+     *  the first REMOVING outcome of a pump is exempt, so the set always drains
+     *  — not-ready verdicts are memoized per region and cost no budget — and it
+     *  BORROWS on top (review A: a budget that cannot keep up parks commits at
+     *  the hard cap): the whole {@link #UPDATE_BORROW_NANOS} once the queue is
+     *  empty (commits need nothing), half of it while the owed set is past the
+     *  soft cap. */
     static final long UPDATE_NANOS_BUDGET = 2_000_000L;
     static final long UPDATE_BORROW_NANOS = PUMP_NANOS_BUDGET;
+    /** Texture rebuilds per FRAME (plan §17 — the stutter round): a rebuild is a
+     *  64×64-pixel recolor (~0.5-4 ms), and several per TICK bunched with the
+     *  commit budget doubled the pump ceiling — visible stutter during map fills.
+     *  One rebuild per frame is Xaero's own sweep grain: at 60-120 fps that is
+     *  60-120 tile chunks/s ≈ 1000-2000 coalesced tiles/s of drain — above the
+     *  serve rate — while a frame never pays more than one recolor. */
+    static final int FRAME_MAX_REBUILDS = 1;
     /** Consecutive failures (commit-side or extraction-side) before the bridge
      *  latches dead for the SESSION (re-armed at disconnect). */
     static final int THROW_LATCH = 5;
@@ -234,6 +242,12 @@ final class XaeroMapCompat {
         if (bridge != null) bridge.pump();
     }
 
+    /** Per-frame body (render thread) — the rebuild phase's scheduler (plan §17). */
+    static void renderFrame() {
+        var bridge = instance;
+        if (bridge != null) bridge.frameFlush();
+    }
+
     /** Disconnect body — session teardown (queue, latches, registration). */
     static void onDisconnect() {
         var bridge = instance;
@@ -300,12 +314,24 @@ final class XaeroMapCompat {
     int updateMaxStallPumps = UPDATE_MAX_STALL_PUMPS;
     int updateMaxDeferPumps = UPDATE_MAX_DEFER_PUMPS;
     long updateBorrowNanos = UPDATE_BORROW_NANOS;
+    int frameMaxRebuilds = FRAME_MAX_REBUILDS;
     /** Tile chunks committed but not yet texture-rebuilt, keyed by tile-chunk
      *  coords and ordered by LAST TOUCH (a re-touch re-inserts at the tail, so
      *  idle-due entries are always a prefix). Main thread only. */
     private final LinkedHashMap<PendingKey, PendingUpdate> pendingUpdates = new LinkedHashMap<>();
     private long pumpCount; // main thread only
     private final AtomicLong bufferUpdates = new AtomicLong();
+    /** Frame flushes that passed the gate ladder — the per-frame scheduler is alive
+     *  (its absence in a live diag means the render hook is not firing and the tick
+     *  fallback is doing the rebuilds). */
+    private final AtomicLong frameFlushes = new AtomicLong();
+    /** Total nanos inside {@code MapTileChunk.updateBuffers} + the single worst call
+     *  — the live stutter instruments (diag {@code rebuild_ms=}/{@code rebuild_max_us=}). */
+    private final AtomicLong rebuildNanos = new AtomicLong();
+    private volatile long rebuildNanosMax;
+    /** A frame flush ran since the last pump — that pump skips its rebuild fallback.
+     *  Main thread only (frames and ticks share the render thread). */
+    private boolean frameFlushRan;
     private final AtomicLong droppedUpdates = new AtomicLong();
     /** Owed rebuilds whose region/tile chunk Xaero unloaded, parked or replaced
      *  first — its own counter (review A) so the live test can tell a parking race
@@ -450,6 +476,7 @@ final class XaeroMapCompat {
         this.pendingUpdatesGauge = 0;
         this.regionsWaiting = 0;
         this.consecutiveFailures = 0;
+        this.frameFlushRan = false;
         this.lastWorldId = null;
         if (this.registered && !this.enabled.getAsBoolean()) {
             this.deregistrar.accept(this.consumer);
@@ -637,6 +664,7 @@ final class XaeroMapCompat {
             case "commit_failures" -> this.commitFailures.get();
             case "load_requests" -> this.loadRequests.get();
             case "buffer_updates" -> this.bufferUpdates.get();
+            case "frame_flushes" -> this.frameFlushes.get();
             case "dropped_updates" -> this.droppedUpdates.get();
             case "dropped_unloaded" -> this.droppedUnloaded.get();
             case "skipped_settings" -> this.skippedSettings.get();
@@ -660,6 +688,9 @@ final class XaeroMapCompat {
                 + ", load_requests=" + this.loadRequests.get()
                 + ", regions_waiting=" + this.regionsWaiting
                 + ", buffer_updates=" + this.bufferUpdates.get()
+                + ", frame_flushes=" + this.frameFlushes.get()
+                + ", rebuild_ms=" + (this.rebuildNanos.get() / 1_000_000)
+                + ", rebuild_max_us=" + (this.rebuildNanosMax / 1_000)
                 + ", pending_updates=" + this.pendingUpdatesGauge
                 + ", dropped_updates=" + this.droppedUpdates.get()
                 + ", dropped_unloaded=" + this.droppedUnloaded.get()
@@ -796,11 +827,11 @@ final class XaeroMapCompat {
                 if (!loadNew && !update) {
                     this.skippedSettings.addAndGet(clearQueue());
                     this.regionsWaiting = 0;
-                    flushPendingUpdates(mp, dimensionId);
+                    tickFlush(mp, dimensionId);
                     return;
                 }
             }
-            flushPendingUpdates(mp, dimensionId);
+            tickFlush(mp, dimensionId);
             if (this.dead) return;
             if (this.h.getCurrentCaveLayer != null
                     && (int) this.h.getCurrentCaveLayer.invoke(mp) != SURFACE_LAYER) {
@@ -812,6 +843,69 @@ final class XaeroMapCompat {
                 return;
             }
             drainEntries(mp, saveLoad, world, dimensionId, loadNew, update);
+        }
+    }
+
+    /**
+     * Per-frame flush (plan §17): the texture-rebuild phase runs at FRAME cadence —
+     * Xaero's own sweep scheduling — instead of bunched on the client tick, at most
+     * {@link #frameMaxRebuilds} recolor(s) per call. Mirrors the pump ladder's gate
+     * envelope exactly down to the dimension equality (a rebuild must never run under
+     * weaker gates than the pump's flush did); the settings and cave-layer gates sit
+     * BELOW the flush in the pump ladder (rebuilds are owed debt to already-committed
+     * tile chunks, not new writes) and are skipped here for the same reason. Never
+     * drains commits, never grants loads, never visits regions (tick-side — the 1 s
+     * park guard needs only pump cadence), and defers the world-change queue drop to
+     * the pump (it returns instead). Shares the pump's containment + death latch.
+     */
+    void frameFlush() {
+        if (this.dead || this.sessionEndPending || this.pendingUpdates.isEmpty()) return;
+        try {
+            frameLadder();
+        } catch (Throwable t) {
+            if (t instanceof Error err && !(t instanceof AssertionError)) throw err;
+            noteFailure(t);
+        }
+    }
+
+    private void frameLadder() throws Throwable {
+        Object session = this.h.getCurrentSession.invoke();
+        if (session == null || !(boolean) this.h.sessionIsUsable.invoke(session)) return;
+        Object mp = this.h.getMapProcessor.invoke(session);
+        if (mp == null) return;
+        if (this.h.crashGate != null) {
+            Object handler = this.h.crashGate.crashHandler().invoke();
+            if (handler != null && this.h.crashGate.getCrashedBy().invoke(handler) != null) {
+                return; // never touch a crashed Xaero; the pump owns the diag flag
+            }
+        }
+        Object renderPause = this.h.renderThreadPauseSync.invoke(mp);
+        synchronized (renderPause) {
+            if ((boolean) this.h.isWritingPaused.invoke(mp)) return;
+            if ((boolean) this.h.isWaitingForWorldUpdate.invoke(mp)) return;
+            if (!(boolean) this.h.isRegionDetectionComplete.invoke(this.h.getMapSaveLoad.invoke(mp))) return;
+            if (!(boolean) this.h.isCurrentMultiworldWritable.invoke(mp)) return;
+            Object world = this.h.getWorld.invoke(mp);
+            Object mapWorld = this.h.getMapWorld.invoke(mp);
+            if (world == null || (boolean) this.h.isCurrentMapLocked.invoke(mp)
+                    || (boolean) this.h.isCacheOnlyMode.invoke(mapWorld)) {
+                return;
+            }
+            String worldId = (String) this.h.getCurrentWorldId.invoke(mp);
+            if (worldId == null || (boolean) this.h.ignoreWorld.invoke(mp, world)) return;
+            if (this.lastWorldId != null && !this.lastWorldId.equals(worldId)) return;
+            Object dimensionId;
+            Object mainSync = this.h.mainStuffSync.invoke(mp);
+            synchronized (mainSync) {
+                if (this.h.mainWorld.invoke(mp) != world) return;
+                dimensionId = this.h.getCurrentDimensionId.invoke(mapWorld);
+                if (this.levelOps.dimension(world) != dimensionId) return;
+            }
+            // Past every gate the pump's flush would have run under: the tick's
+            // rebuild fallback stands down until the next pump.
+            this.frameFlushRan = true;
+            this.frameFlushes.incrementAndGet();
+            flushPendingUpdates(mp, dimensionId, this.updateNanosBudget, this.frameMaxRebuilds, false);
         }
     }
 
@@ -1288,6 +1382,7 @@ final class XaeroMapCompat {
         Object overlayManager;
         Object shapeCache;
         Object fastConfig;
+        int rebuilt; // actual updateBuffers calls this flush (the frame cap's meter)
         final java.util.Set<Object> notReadyRegions =
                 java.util.Collections.newSetFromMap(new java.util.IdentityHashMap<>());
     }
@@ -1295,9 +1390,12 @@ final class XaeroMapCompat {
     /**
      * Run the owed rebuilds that are DUE — idle for {@link #updateIdlePumps}, or
      * older than {@link #updateMaxDeferPumps} (the trickle ceiling), or the oldest
-     * beyond the soft cap, or previously stalled — oldest-touch first, within
-     * {@link #updateNanosBudget} (the first removing outcome of a pump is exempt,
-     * so the set always drains). Each rebuild re-runs the writer's region gates
+     * beyond the soft cap, or previously stalled — oldest-touch first, within the
+     * caller's {@code budget} and {@code maxRebuilds} (plan §17: the FRAME slice
+     * passes {@link #frameMaxRebuilds} with no region visits; the tick fallback
+     * passes the borrow-topped budget with no rebuild cap; a frames-active tick
+     * passes ZERO rebuilds — cheap drops/bookkeeping only — and the first removing
+     * outcome is budget-exempt, so the set always drains). Each rebuild re-runs the writer's region gates
      * ({@code writerThreadPauseSync} + {@code !isWritingPaused()}, the region
      * monitor, {@code isResting()}) — ONCE per region per flush for a not-ready
      * verdict (memoized, no budget): a not-resting region (being saved / cache
@@ -1310,25 +1408,41 @@ final class XaeroMapCompat {
      * textures. A tile chunk the native writer already consumed
      * ({@code !wasChanged()}) needs nothing.
      */
-    private void flushPendingUpdates(Object mp, Object dimensionId) {
+    /** The tick pump's flush call: consumes the frame marker — with frames flushing,
+     *  the tick runs ZERO rebuilds (drops/bookkeeping only); with no frame since the
+     *  last pump (loading screens, hidden window, headless test JVMs) it falls back
+     *  to the full pre-§17 budget-with-borrow rebuild behavior. */
+    private void tickFlush(Object mp, Object dimensionId) {
+        boolean frameActive = this.frameFlushRan;
+        this.frameFlushRan = false;
+        long budget;
+        if (frameActive) {
+            budget = this.updateNanosBudget; // bounds the cheap-class scan only
+        } else {
+            boolean queueEmpty;
+            synchronized (this.queueLock) {
+                queueEmpty = this.queue.isEmpty();
+            }
+            long borrow = queueEmpty ? this.updateBorrowNanos
+                    : this.pendingUpdates.size() > this.pendingUpdatesSoftCap ? this.updateBorrowNanos / 2 : 0;
+            budget = borrow > Long.MAX_VALUE - this.updateNanosBudget
+                    ? Long.MAX_VALUE : this.updateNanosBudget + borrow; // saturating (the seams take MAX)
+        }
+        flushPendingUpdates(mp, dimensionId, budget, frameActive ? 0 : Integer.MAX_VALUE, true);
+    }
+
+    private void flushPendingUpdates(Object mp, Object dimensionId, long budget,
+                                     int maxRebuilds, boolean keepVisited) {
         if (this.pendingUpdates.isEmpty()) {
             this.pendingUpdatesGauge = 0;
             return;
         }
         long start = System.nanoTime();
-        boolean queueEmpty;
-        synchronized (this.queueLock) {
-            queueEmpty = this.queue.isEmpty();
-        }
-        long borrow = queueEmpty ? this.updateBorrowNanos
-                : this.pendingUpdates.size() > this.pendingUpdatesSoftCap ? this.updateBorrowNanos / 2 : 0;
-        long budget = borrow > Long.MAX_VALUE - this.updateNanosBudget
-                ? Long.MAX_VALUE : this.updateNanosBudget + borrow; // saturating (the seams take MAX)
         var args = new RebuildArgs();
         String worldId;
         try {
             worldId = (String) this.h.getCurrentWorldId.invoke(mp);
-            keepOwedRegionsVisited(mp, worldId, dimensionId);
+            if (keepVisited) keepOwedRegionsVisited(mp, worldId, dimensionId);
         } catch (Throwable t) {
             if (t instanceof Error err && !(t instanceof AssertionError)) throw err;
             noteFailure(t);
@@ -1350,6 +1464,8 @@ final class XaeroMapCompat {
                 result = UpdateResult.DROPPED; // a previous Xaero session's objects
             } else if (pu.dimension != dimensionId) {
                 result = UpdateResult.NOT_READY;
+            } else if (maxRebuilds == 0) {
+                continue; // frames own the rebuilds while they flush — cheap classes only
             } else {
                 result = rebuildTileChunk(mp, pu, args);
             }
@@ -1381,6 +1497,7 @@ final class XaeroMapCompat {
                 }
             }
             if (this.dead) break;
+            if (maxRebuilds > 0 && args.rebuilt >= maxRebuilds) break;
         }
         this.pendingUpdatesGauge = this.pendingUpdates.size();
     }
@@ -1448,8 +1565,13 @@ final class XaeroMapCompat {
                             args.fastConfig = this.h.newMapUpdateFastConfig.invoke(mp);
                         }
                         // The boolean is the writer's detailed-debug flag (log-only).
+                        long rebuildStart = System.nanoTime();
                         this.h.tileChunkUpdateBuffers.invoke(pu.tileChunk, mp, args.tint,
                                 args.overlayManager, false, args.shapeCache, args.fastConfig);
+                        long rebuildTook = System.nanoTime() - rebuildStart;
+                        this.rebuildNanos.addAndGet(rebuildTook);
+                        if (rebuildTook > this.rebuildNanosMax) this.rebuildNanosMax = rebuildTook;
+                        args.rebuilt++;
                         this.h.tileChunkSetChanged.invoke(pu.tileChunk, false);
                         this.bufferUpdates.incrementAndGet();
                     }

--- a/xplat/src/main/java/dev/vox/lss/networking/client/ClientNetGlue.java
+++ b/xplat/src/main/java/dev/vox/lss/networking/client/ClientNetGlue.java
@@ -385,4 +385,11 @@ public final class ClientNetGlue {
         // main client thread, no-op unless Xaero is present with queued tiles.
         dev.vox.lss.compat.ModCompat.clientTick();
     }
+
+    /** Per-frame body (render thread) — the Xaero bridge's texture-rebuild slice
+     *  (xaero-map-bridge-plan.md §17): one budgeted recolor per frame, Xaero's own
+     *  sweep cadence, so rebuild cost never bunches on the client tick. */
+    public static void onRenderFrame() {
+        dev.vox.lss.compat.ModCompat.renderFrame();
+    }
 }


### PR DESCRIPTION
The §15 saver-crash fix ran Xaero texture rebuilds bunched on the client tick (5-7+ ms/tick during map fills — live-reported heavy stutter on 1.21.11). Rebuilds now run at frame cadence under the pump ladder's exact gate envelope: one recolor per frame (pressure-capped to 2-3 while frames are scarce), a per-tick-interval wall allowance metered by measured recolor nanos, and the full tick fallback whenever no frame flushed (loading screens, hidden window, headless JVMs). 2-Opus reviewed (scheduling + lock-invariants lenses), both MAJORs folded — plan §17/§17.1 is the record. New diag instruments: frame_flushes, rebuild_ms, rebuild_max_us.

🤖 Generated with [Claude Code](https://claude.com/claude-code)