### PR TITLE
feat(xaero): §18 dropped-tile heal — far-radius map holes become bounded re-serves

### DIFF
--- a/docs/planning/xaero-map-bridge-plan.md
+++ b/docs/planning/xaero-map-bridge-plan.md
@@ -1385,3 +1385,80 @@ Recorded, not changed:
   on at least one line.
 - **Iris shadow-pass double-fire** can run the frame slice twice per frame —
   each invocation is capped and allowance-metered, so the ceiling holds.
+
+## 18. The dropped-tile heal (2026-08-24, field-test round 4 — far-radius drops)
+
+Field report (26.2 and expected on all lines, 91-minute 34 GB fill session):
+`written=892459, dropped=159512` — ~15% of all tiles dropped, visibly missing
+from the map, onset ~5979 blocks (~chunk ring 374) and "a lot" beyond. The §14
+round widened the survival window (8192-entry queue, 8-deep load window,
+priority front-inserts) but the far-radius regime still overwhelms it: a ring
+at r≈380 crosses ~95 regions at once, a re-stream over EXISTING map files is
+expensive-load-bound at the loader's ~10/s drain, and Xaero's limiter parks
+far regions between loads — tiles pile up awaiting their regions and the
+bounded queue evicts the oldest (plus ladder-ready `DEFER_CAP` expiries). The
+drops were PERMANENT: the positions are stamped client-side and nothing ever
+re-serves them.
+
+Why not report at drop time: `LSSApi.reportIngestFailure` is the designed
+bounded re-serve channel (`ColumnStateMap.MAX_INGEST_FAILURES` = 3, then the
+position parks) — but re-serves land ~1-2 s after a report, while a far-radius
+saturation phase persists for minutes; naive report-on-drop burns all three
+retries into the same full queue and parks the holes anyway (with 2-3× the
+serve traffic as pure waste).
+
+The heal (`enableXaeroMapBridgeHeal`, client config, default ON; inert with
+the bridge off):
+
+- **The ledger**: dropped positions are remembered per region — a
+  `DroppedLedger` of 1024 bits over the region's 32×32 chunk grid (~160 B),
+  keyed by region in insertion order, guarded by `queueLock` (decode-thread
+  evictions and the offerColumn full-queue pre-gate record; main-thread
+  deferral expiries record via a brief lock). Capped at `LEDGER_MAX_REGIONS`
+  (4096, ≈ a radius-1000 disc): beyond it the oldest region's holes stay
+  permanent — the pre-§18 behavior.
+- **Flush only when committable**: after the drain and before the grants
+  (`healPhase`), regions that COMMITTED this pump flush their ledger sets
+  first (the region is provably accepting writes); then ONE further ledger
+  region per pump is probed under the commit probe's monitors — loaded (state
+  2) flushes now (plus a `registerVisit` to hold the park off), requestable/
+  parked joins the GRANT list at zero cluster size (real queue work outranks
+  it in the largest-first window sort) and stays at the ledger head so the
+  granted load flushes within a few pumps (a 100-probe belt rotates a wedged
+  head to the tail; a head in another dimension rotates immediately and
+  flushes after the player returns). Reports run inline on the main thread,
+  ≤ `LEDGER_FLUSH_PER_PUMP` (256) per pump; bits are cleared under the lock,
+  reports fire outside it. The heal phase is skipped while the rebuild hard
+  cap has commits paused — never add re-serves to an overloaded pump.
+- **Stale-dimension drain drops report immediately** (no ledger): their region
+  is only ever probed under the CURRENT map dimension, so a ledger entry would
+  rot; the re-serve lands after the player returns to that dimension.
+- **Teardowns never heal**: every `clearQueue` caller (session end, world-id
+  change, the death latch, the enable toggle, both-switches-off) clears the
+  ledger uncounted.
+- **The idle pump keeps running**: the pump's empty-early-return now also
+  requires an empty ledger — post-saturation (empty queue, no owed rebuilds)
+  the heal phase is what drains the backlog, at up to 20 probed regions/s and
+  the loader's ~10/s for loads, i.e. a 159k-drop session heals in a couple of
+  minutes of idling near the terrain.
+- **Bounds**: each healed position costs exactly one re-serve (one column,
+  ~30 KB) when it can land; re-dropped positions re-enter the ledger and burn
+  one of their 3 client retries per cycle — the client cap is the loop bound,
+  and it now bounds honest attempts instead of being burned by timing.
+  Client-side `ingest_failed` climbing during heavy map fills is EXPECTED with
+  the heal on (each report counts there).
+- **Instruments**: diag gains `dropped_overflow=`/`dropped_expired=` (the old
+  `dropped=` aggregate hid which class fired — the field report's 159k was
+  indistinguishable), `heal_pending=` (ledger positions owed) and
+  `heal_reported=`; all in `counterForTest` + the house-style pin. Seams:
+  `maxQueue`, `deferCap` (the §18 tests drive overflow/expiry without 8192
+  offers).
+
+Expected field shape on the 26.2 rig: during the far fill `heal_pending` grows
+into the thousands while `dropped_overflow` climbs; after the fill both drain
+toward zero as `heal_reported` catches up to the drop count, `ingest_failed`
+climbs by ≈ the same amount, and the map holes fill in. A `heal_pending` stuck
+high with `load_requests` flat means the probe/grant leg regressed; stuck with
+loads climbing means Xaero's loader is refusing (limiter pressure — check the
+region cache setting).
+

--- a/docs/planning/xaero-map-bridge-plan.md
+++ b/docs/planning/xaero-map-bridge-plan.md
@@ -1422,14 +1422,18 @@ the bridge off):
   first (the region is provably accepting writes); then ONE further ledger
   region per pump is probed under the commit probe's monitors — loaded (state
   2) flushes now (plus a `registerVisit` to hold the park off), requestable/
-  parked joins the GRANT list at zero cluster size (real queue work outranks
-  it in the largest-first window sort) and stays at the ledger head so the
-  granted load flushes within a few pumps (a 100-probe belt rotates a wedged
-  head to the tail; a head in another dimension rotates immediately and
-  flushes after the player returns). Reports run inline on the main thread,
-  ≤ `LEDGER_FLUSH_PER_PUMP` (256) per pump; bits are cleared under the lock,
-  reports fire outside it. The heal phase is skipped while the rebuild hard
-  cap has commits paused — never add re-serves to an overloaded pump.
+  parked joins the GRANT list ONLY when the drain has no real waiting work
+  (§18.1) and stays at the ledger head so the granted load flushes within a
+  few pumps (a 100-probe belt rotates a wedged head to the tail; foreign-
+  dimension heads rotate through a bounded 8-entry scan and flush after the
+  player returns). Reports run inline on the main thread,
+  ≤ `LEDGER_FLUSH_PER_PUMP` (40 — matched to the client's ~800 col/s
+  re-serve channel, §18.1) per pump; bits are cleared under the lock, reports
+  fire outside it, each contained. The heal phase is skipped at the rebuild
+  hard cap, past the drain's nanos budget, and — the §18.1 headline — while
+  the QUEUE lacks headroom (size or bytes above half cap): the drop condition
+  is a global queue condition, so a region-only proof would re-serve straight
+  back into the saturated queue.
 - **Stale-dimension drain drops report immediately** (no ledger): their region
   is only ever probed under the CURRENT map dimension, so a ledger entry would
   rot; the re-serve lands after the player returns to that dimension.
@@ -1438,9 +1442,9 @@ the bridge off):
   ledger uncounted.
 - **The idle pump keeps running**: the pump's empty-early-return now also
   requires an empty ledger — post-saturation (empty queue, no owed rebuilds)
-  the heal phase is what drains the backlog, at up to 20 probed regions/s and
-  the loader's ~10/s for loads, i.e. a 159k-drop session heals in a couple of
-  minutes of idling near the terrain.
+  the heal phase is what drains the backlog (see the corrected §18.1
+  arithmetic: ledger leg ~3-5 regions/s load-bound; the heal itself is
+  channel-bound at ~800 col/s).
 - **Bounds**: each healed position costs exactly one re-serve (one column,
   ~30 KB) when it can land; re-dropped positions re-enter the ledger and burn
   one of their 3 client retries per cycle — the client cap is the loop bound,
@@ -1454,11 +1458,65 @@ the bridge off):
   `maxQueue`, `deferCap` (the §18 tests drive overflow/expiry without 8192
   offers).
 
-Expected field shape on the 26.2 rig: during the far fill `heal_pending` grows
-into the thousands while `dropped_overflow` climbs; after the fill both drain
-toward zero as `heal_reported` catches up to the drop count, `ingest_failed`
-climbs by ≈ the same amount, and the map holes fill in. A `heal_pending` stuck
-high with `load_requests` flat means the probe/grant leg regressed; stuck with
-loads climbing means Xaero's loader is refusing (limiter pressure — check the
-region cache setting).
+Expected field shape on the 26.2 rig (arithmetic corrected by §18.1): during
+the far fill `heal_pending` grows into the thousands while `dropped_overflow`
+climbs — the heal deliberately does almost nothing yet (queue-headroom gate).
+After the fill, the ledger leg drains load-bound at ~3-5 regions/s (the probe
+is head-parked serial: request → in-flight pumps → flush), but the HEAL is
+bound by the client's re-serve channel (~800 col/s = WANT_SET_BUDGET × 1 Hz ≈
+the 25 MiB/s default cap): a 159k-drop session needs ≥3.5 min of idling near
+the terrain and re-downloads ~5 GB. SUCCESS is judged by `ingest_parked` (the
+client Columns diag line) staying ≈ 0 and `heal_redropped` staying low —
+`heal_reported` alone cannot distinguish a completed heal from one whose every
+re-delivery re-dropped and parked (§18.1 B-M2). `heal_pending` stuck high with
+`load_requests` flat means the probe/grant leg regressed; with loads climbing,
+Xaero's loader is refusing (limiter pressure — check the region cache
+setting). One `valve=` bump at heal onset is EXPECTED (the reopen valve trips
+once on ~139 reopened rings); the 4 Hz fast re-scan stays disarmed while
+retry marks exist, which is part of why the heal is 1 Hz-paced.
+
+### 18.1 Review fold (2026-08-24, 2-Opus — loop-safety/locks + field-effectiveness)
+
+Converged MAJOR family, both reviewers: the first cut's flush was mis-rated
+and mis-gated. (A-M1) "committable REGION" is not "admissible QUEUE" — during
+saturation commits continue while the queue sheds, so committed-region flushes
+fired ~5120 reports/s into a still-full queue, burning the 3-strike budget
+the design exists to protect (fix: the queue-headroom gate above). (B-M1) the
+flush ceiling 256/pump = 5120/s was 6.4× the ~800 col/s channel that consumes
+reports, so the committable proof went stale in a 100k+ report backlog whose
+re-deliveries landed minutes later (fix: `LEDGER_FLUSH_PER_PUMP` 40). B also
+corrected the design rationale: strikes count DELIVERIES, not reports
+(`onIngestFailed`'s `old == -1` absorbs duplicate reports free) — the gate's
+entire value is timing the re-DELIVERY into a non-saturated queue. (A-M2) the
+dimension-conflict path reported un-gated/un-capped under `queueLock` (and,
+via the bulk deferral-expiry site, under a Xaero monitor), and foreign
+dimensions could enter the ledger through that bulk site: foreign expiries now
+take the stale route, the conflict DISCARDS counted, and `reportWholeLedger`
+is deleted. (B-M2) outcome instruments added: `ingest_parked` (ColumnStateMap
+cap-park count — the definitive permanent-hole signal, on the client Columns
+diag line), `heal_redropped` (the re-drop probability meter: permanent loss ≈
+p³), `heal_regions`, `heal_abandoned` (teardowns/cap/conflicts/kill-switch,
+so a cut-short heal is visible). (B-M3) the drain/heal arithmetic above.
+
+Minors folded: the kill switch now stops an in-progress heal (abandon,
+counted); the probe requires `isResting` like the commit probe (a stuck saver
+must not draw re-serves that re-expire); the heal runs under the drain's
+nanos clock; per-report throws are contained (an LSS-side throw must never
+feed the XAERO bridge's death latch); the ledger cap evicts the NEWEST region,
+never the probe's head; ledger loads are granted only when the drain's
+waiting list is empty (no §14-window/`setBeingWritten` pressure while real
+work waits); the both-switches-off path now KEEPS the ledger (not a teardown
+— the heal resumes when map writing is switched back on); the orphaned
+Outcome javadoc moved back. Recorded, not changed: a foreign-dimension-only
+ledger keeps the idle pump running the reflective ladder (~tens of µs/tick,
+session-bounded, heals on return); `ColumnStateMap.ingestFailures`/
+`persistentRemovals` reach disc scale under a heavy heal (~5 MB, comment
+updated); the one-shot reopen-valve trip; duplicate `WaitingRegion`/in-flight
+under-count slack (§14's accepted one-window-per-pump bound); the 100-probe
+belt ships untested (6 lines, low risk — the bounded head scan covers the
+foreign-head half). Tests: the vacuous grant assert replaced (the ledger
+region's load is now asserted by count on an idle pump), plus pins for the
+headroom hold, the conflict discard, the deferral-expiry split, negative
+coordinates, the cap's newest-eviction, the re-drop meter, and the
+mid-session kill-switch flip.
 

--- a/fabric/src/test/java/dev/vox/lss/compat/XaeroMapCompatTest.java
+++ b/fabric/src/test/java/dev/vox/lss/compat/XaeroMapCompatTest.java
@@ -82,6 +82,8 @@ class XaeroMapCompatTest {
     private final Set<Long> loadedChunks = new HashSet<>();
     private boolean enabled = true;
     private boolean sessionActive = true;
+    private boolean healEnabled = true;
+    private final List<Object[]> reports = new ArrayList<>();
     private final List<dev.vox.lss.api.VoxelColumnConsumer> registered = new ArrayList<>();
     private XaeroMapCompat bridge;
 
@@ -119,13 +121,18 @@ class XaeroMapCompatTest {
         this.enabled = true;
         this.sessionActive = true;
         this.registered.clear();
+        this.healEnabled = true;
+        this.reports.clear();
         this.bridge = new XaeroMapCompat(
                 XaeroMapCompat.Handles.resolve(Class::forName),
                 this.fakeLevelOps,
                 () -> this.enabled,
                 () -> this.sessionActive,
                 this.registered::add,
-                this.registered::remove);
+                this.registered::remove,
+                () -> this.healEnabled,
+                (dimension, chunkX, chunkZ) ->
+                        this.reports.add(new Object[]{dimension, chunkX, chunkZ}));
         this.bridge.pumpNanosBudget = Long.MAX_VALUE; // neutralize MethodHandle warmup
         this.bridge.updateNanosBudget = Long.MAX_VALUE;
         this.bridge.maybeRegister();
@@ -936,6 +943,102 @@ class XaeroMapCompatTest {
         assertEquals(2, this.bridge.counterForTest("buffer_updates"),
                 "a gated frame leaves the tick fallback armed — else closed gates wedge the set");
         assertEquals(0, this.bridge.counterForTest("commit_failures"), "gates defer, never fail");
+    }
+
+    // ---- the §18 dropped-tile heal ----
+
+    @Test
+    void anEvictedTileIsHealedOnceItsRegionCommits() {
+        this.bridge.maxQueue = 2;
+        offer(64, 64);
+        offer(65, 64);
+        offer(66, 64); // over the cap: (64,64) — the oldest — is evicted into the ledger
+        assertEquals(1, this.bridge.counterForTest("dropped_overflow"));
+        assertEquals(1, this.bridge.counterForTest("heal_pending"));
+        assertTrue(this.reports.isEmpty(), "no report at drop time — retries must not burn"
+                + " while the region bottleneck persists");
+        this.bridge.pump(); // the survivors commit; their region is committable → flush
+        assertEquals(2, this.bridge.counterForTest("written"));
+        assertEquals(0, this.bridge.counterForTest("heal_pending"));
+        assertEquals(1, this.bridge.counterForTest("heal_reported"));
+        assertEquals(1, this.reports.size());
+        org.junit.jupiter.api.Assertions.assertSame(OVERWORLD, this.reports.get(0)[0]);
+        assertEquals(64, this.reports.get(0)[1]);
+        assertEquals(64, this.reports.get(0)[2]);
+    }
+
+    @Test
+    void theHealWaitsForItsRegionAndRidesTheGrantWindow() {
+        this.processor.createdRegionLoadState = 0; // detection creates unloaded regions
+        this.bridge.maxQueue = 1;
+        offer(64, 64);
+        offer(70, 64); // same region (2,2): (64,64) is evicted into the ledger
+        this.bridge.pump(); // the survivor awaits the region load; the heal probe joins the grant
+        assertEquals(0, this.bridge.counterForTest("written"));
+        assertTrue(this.bridge.counterForTest("load_requests") >= 1,
+                "the awaiting region must be load-requested");
+        assertEquals(1, this.bridge.counterForTest("heal_pending"),
+                "the ledger holds while its region is not committable");
+        assertTrue(this.reports.isEmpty());
+        theRegion().loadState = 2; // the load lands
+        this.bridge.pump(); // the survivor commits; the committed-region flush heals the drop
+        assertEquals(1, this.bridge.counterForTest("written"));
+        assertEquals(0, this.bridge.counterForTest("heal_pending"));
+        assertEquals(1, this.reports.size());
+        assertEquals(64, this.reports.get(0)[1]);
+    }
+
+    @Test
+    void anIdleBridgeStillDrainsItsLedger() {
+        this.processor.createdRegionLoadState = 0;
+        this.bridge.updateIdlePumps = 1;
+        this.bridge.maxQueue = 1;
+        offer(64, 64);  // region (2,2) — will be evicted into the ledger
+        offer(96, 64);  // region (3,2) — survives
+        this.bridge.pump(); // (3,2) is unloaded too: both wait... load (3,2) first
+        this.processor.regions.get((3L << 32) | 2L).loadState = 2;
+        this.bridge.pump(); // (96,64) commits; rebuild owed
+        assertEquals(1, this.bridge.counterForTest("written"));
+        this.bridge.pump(); // the rebuild flushes: queue AND pendingUpdates now empty
+        assertEquals(0, this.bridge.counterForTest("pending_updates"));
+        assertEquals(1, this.bridge.counterForTest("heal_pending"));
+        this.processor.regions.get((2L << 32) | 2L).loadState = 2; // the granted load lands
+        this.bridge.pump(); // idle except the ledger — the pump must still run the heal
+        assertEquals(0, this.bridge.counterForTest("heal_pending"),
+                "an idle bridge (empty queue, no owed rebuilds) must still drain its ledger");
+        assertEquals(1, this.reports.size());
+    }
+
+    @Test
+    void theKillSwitchAndSessionTeardownEmptyTheHeal() {
+        this.healEnabled = false;
+        this.bridge.maxQueue = 1;
+        offer(64, 64);
+        offer(70, 64);
+        assertEquals(1, this.bridge.counterForTest("dropped_overflow"));
+        assertEquals(0, this.bridge.counterForTest("heal_pending"), "switch off: no ledger");
+        this.healEnabled = true;
+        offer(75, 64); // evicts (70,64) into the ledger
+        assertEquals(1, this.bridge.counterForTest("heal_pending"));
+        this.bridge.onSessionEnd();
+        this.bridge.pump();
+        assertEquals(0, this.bridge.counterForTest("heal_pending"),
+                "the ledger dies with the session, uncounted");
+        assertTrue(this.reports.isEmpty(), "teardown never reports");
+    }
+
+    @Test
+    void aStaleDimensionDropReportsImmediately() {
+        offer(64, 64);
+        this.bridge.offerPrepared(net.minecraft.world.level.Level.NETHER, tile(70, 64));
+        this.bridge.pump(); // (70,64) belongs to another dimension: dropped stale + reported now
+        assertEquals(1, this.bridge.counterForTest("dropped_stale"));
+        assertEquals(1, this.bridge.counterForTest("heal_reported"));
+        assertEquals(1, this.reports.size());
+        org.junit.jupiter.api.Assertions.assertSame(
+                net.minecraft.world.level.Level.NETHER, this.reports.get(0)[0]);
+        assertEquals(0, this.bridge.counterForTest("heal_pending"), "stale never enters the ledger");
+        assertEquals(1, this.bridge.counterForTest("written"), "the current dimension's tile commits");
     }
 
     private MapRegion theRegion() {
@@ -1942,7 +2045,8 @@ class XaeroMapCompatTest {
         // covered only by the owed live `optional_unbound` diag check.)
         assertEquals("crash-gate settings-gate", handles.optionalMissing);
         var reduced = new XaeroMapCompat(handles, this.fakeLevelOps, () -> this.enabled,
-                () -> this.sessionActive, this.registered::add, this.registered::remove);
+                () -> this.sessionActive, this.registered::add, this.registered::remove,
+                () -> this.healEnabled, (d, x, z) -> this.reports.add(new Object[]{d, x, z}));
         reduced.pumpNanosBudget = Long.MAX_VALUE;
         reduced.updateNanosBudget = Long.MAX_VALUE;
         reduced.maybeRegister();
@@ -1963,7 +2067,8 @@ class XaeroMapCompatTest {
         var handles = XaeroMapCompat.Handles.resolve(Class::forName);
         assertEquals(7, handles.interpretationVersion);
         var bridge7 = new XaeroMapCompat(handles, this.fakeLevelOps, () -> this.enabled,
-                () -> this.sessionActive, this.registered::add, this.registered::remove);
+                () -> this.sessionActive, this.registered::add, this.registered::remove,
+                () -> this.healEnabled, (d, x, z) -> this.reports.add(new Object[]{d, x, z}));
         bridge7.pumpNanosBudget = Long.MAX_VALUE;
         bridge7.updateNanosBudget = Long.MAX_VALUE;
         bridge7.maybeRegister();
@@ -1983,7 +2088,9 @@ class XaeroMapCompatTest {
                 && line.contains(", pending_updates=") && line.contains(", dropped_updates=")
                 && line.contains(", dropped_unloaded=") && line.contains(", skipped_settings=")
                 && line.contains(", cave_layer_waits=") && line.contains(", frame_flushes=")
-                && line.contains(", rebuild_ms=") && line.contains(", rebuild_max_us="), line);
+                && line.contains(", rebuild_ms=") && line.contains(", rebuild_max_us=")
+                && line.contains(", dropped_overflow=") && line.contains(", dropped_expired=")
+                && line.contains(", heal_pending=") && line.contains(", heal_reported="), line);
         assertFalse(line.contains("xaero_crashed"), "the crash token appears only while latched");
         assertFalse(line.contains("optional_unbound"), "every optional group binds against the stubs");
         this.enabled = false;

--- a/fabric/src/test/java/dev/vox/lss/compat/XaeroMapCompatTest.java
+++ b/fabric/src/test/java/dev/vox/lss/compat/XaeroMapCompatTest.java
@@ -945,7 +945,7 @@ class XaeroMapCompatTest {
         assertEquals(0, this.bridge.counterForTest("commit_failures"), "gates defer, never fail");
     }
 
-    // ---- the §18 dropped-tile heal ----
+    // ---- the §18 dropped-tile heal (+ the §18.1 review fold) ----
 
     @Test
     void anEvictedTileIsHealedOnceItsRegionCommits() {
@@ -955,9 +955,10 @@ class XaeroMapCompatTest {
         offer(66, 64); // over the cap: (64,64) — the oldest — is evicted into the ledger
         assertEquals(1, this.bridge.counterForTest("dropped_overflow"));
         assertEquals(1, this.bridge.counterForTest("heal_pending"));
+        assertEquals(1, this.bridge.counterForTest("heal_regions"));
         assertTrue(this.reports.isEmpty(), "no report at drop time — retries must not burn"
                 + " while the region bottleneck persists");
-        this.bridge.pump(); // the survivors commit; their region is committable → flush
+        this.bridge.pump(); // the survivors commit; queue drained + region committable → flush
         assertEquals(2, this.bridge.counterForTest("written"));
         assertEquals(0, this.bridge.counterForTest("heal_pending"));
         assertEquals(1, this.bridge.counterForTest("heal_reported"));
@@ -968,20 +969,20 @@ class XaeroMapCompatTest {
     }
 
     @Test
-    void theHealWaitsForItsRegionAndRidesTheGrantWindow() {
+    void theHealHoldsWhileSaturatedAndFlushesOnceItsRegionCommits() {
         this.processor.createdRegionLoadState = 0; // detection creates unloaded regions
         this.bridge.maxQueue = 1;
         offer(64, 64);
         offer(70, 64); // same region (2,2): (64,64) is evicted into the ledger
-        this.bridge.pump(); // the survivor awaits the region load; the heal probe joins the grant
+        this.bridge.pump(); // the survivor awaits its region load; the QUEUE is saturated
         assertEquals(0, this.bridge.counterForTest("written"));
-        assertTrue(this.bridge.counterForTest("load_requests") >= 1,
-                "the awaiting region must be load-requested");
+        assertTrue(this.bridge.counterForTest("load_requests") >= 1);
         assertEquals(1, this.bridge.counterForTest("heal_pending"),
-                "the ledger holds while its region is not committable");
+                "§18.1 A-M1: no heal work while the queue is shedding — a re-delivery"
+                        + " would be re-dropped");
         assertTrue(this.reports.isEmpty());
         theRegion().loadState = 2; // the load lands
-        this.bridge.pump(); // the survivor commits; the committed-region flush heals the drop
+        this.bridge.pump(); // the survivor commits, the queue drains: flush on the proof
         assertEquals(1, this.bridge.counterForTest("written"));
         assertEquals(0, this.bridge.counterForTest("heal_pending"));
         assertEquals(1, this.reports.size());
@@ -989,28 +990,30 @@ class XaeroMapCompatTest {
     }
 
     @Test
-    void anIdleBridgeStillDrainsItsLedger() {
+    void anIdleBridgeStillDrainsItsLedgerThroughTheGrantWindow() {
         this.processor.createdRegionLoadState = 0;
         this.bridge.updateIdlePumps = 1;
         this.bridge.maxQueue = 1;
-        offer(64, 64);  // region (2,2) — will be evicted into the ledger
+        offer(64, 64);  // region (2,2) — evicted into the ledger
         offer(96, 64);  // region (3,2) — survives
-        this.bridge.pump(); // (3,2) is unloaded too: both wait... load (3,2) first
+        this.bridge.pump(); // (3,2) awaits its load; heal held (queue saturated)
         this.processor.regions.get((3L << 32) | 2L).loadState = 2;
-        this.bridge.pump(); // (96,64) commits; rebuild owed
+        this.bridge.pump(); // (96,64) commits; probe grants the LEDGER region's load
         assertEquals(1, this.bridge.counterForTest("written"));
-        this.bridge.pump(); // the rebuild flushes: queue AND pendingUpdates now empty
+        long loads = this.bridge.counterForTest("load_requests");
+        assertTrue(loads >= 2, "idle heal must load-request the ledger region, got " + loads);
+        this.bridge.pump(); // rebuild flushes; ledger region still loading
         assertEquals(0, this.bridge.counterForTest("pending_updates"));
         assertEquals(1, this.bridge.counterForTest("heal_pending"));
         this.processor.regions.get((2L << 32) | 2L).loadState = 2; // the granted load lands
-        this.bridge.pump(); // idle except the ledger — the pump must still run the heal
+        this.bridge.pump(); // fully idle except the ledger — the pump must still heal
         assertEquals(0, this.bridge.counterForTest("heal_pending"),
                 "an idle bridge (empty queue, no owed rebuilds) must still drain its ledger");
         assertEquals(1, this.reports.size());
     }
 
     @Test
-    void theKillSwitchAndSessionTeardownEmptyTheHeal() {
+    void theKillSwitchAndSessionTeardownEmptyTheHealCounted() {
         this.healEnabled = false;
         this.bridge.maxQueue = 1;
         offer(64, 64);
@@ -1023,8 +1026,23 @@ class XaeroMapCompatTest {
         this.bridge.onSessionEnd();
         this.bridge.pump();
         assertEquals(0, this.bridge.counterForTest("heal_pending"),
-                "the ledger dies with the session, uncounted");
+                "the ledger dies with the session");
+        assertEquals(1, this.bridge.counterForTest("heal_abandoned"),
+                "abandoned heal debt must be visible (§18.1 A-m6)");
         assertTrue(this.reports.isEmpty(), "teardown never reports");
+    }
+
+    @Test
+    void aMidSessionKillSwitchFlipAbandonsTheLedgerCounted() {
+        this.bridge.maxQueue = 1;
+        offer(64, 64);
+        offer(70, 64); // (64,64) into the ledger
+        assertEquals(1, this.bridge.counterForTest("heal_pending"));
+        this.healEnabled = false;
+        this.bridge.pump(); // §18.1 A-m1: the phase must stop cleanly, counted
+        assertEquals(0, this.bridge.counterForTest("heal_pending"));
+        assertEquals(1, this.bridge.counterForTest("heal_abandoned"));
+        assertTrue(this.reports.isEmpty());
     }
 
     @Test
@@ -1039,6 +1057,83 @@ class XaeroMapCompatTest {
                 net.minecraft.world.level.Level.NETHER, this.reports.get(0)[0]);
         assertEquals(0, this.bridge.counterForTest("heal_pending"), "stale never enters the ledger");
         assertEquals(1, this.bridge.counterForTest("written"), "the current dimension's tile commits");
+    }
+
+    @Test
+    void aCrossDimensionConflictAbandonsTheOldSetCounted() {
+        this.bridge.maxQueue = 1;
+        offer(64, 64);
+        offer(70, 64); // (64,64) → ledger[(2,2)] as OVERWORLD
+        this.bridge.offerPrepared(net.minecraft.world.level.Level.NETHER, tile(65, 64));
+        // evicted (70,64) is OVERWORLD too — count 2 under the OVERWORLD set
+        assertEquals(2, this.bridge.counterForTest("heal_pending"));
+        this.bridge.offerPrepared(net.minecraft.world.level.Level.NETHER, tile(66, 64));
+        // evicts the NETHER (65,64): same region key, other dimension → the OVERWORLD
+        // set is DISCARDED counted, never reported (§18.1 A-MAJOR-2)
+        assertEquals(2, this.bridge.counterForTest("heal_abandoned"));
+        assertEquals(1, this.bridge.counterForTest("heal_pending"));
+        assertTrue(this.reports.isEmpty());
+    }
+
+    @Test
+    void aDeferralExpiryEntersTheLedgerAndForeignEntriesReportStale() {
+        this.bridge.deferCap = 1;
+        var region = new MapRegion();
+        region.resting = false; // region-scoped busy: the whole bucket defers
+        this.processor.regions.put((2L << 32) | 2L, region);
+        offer(64, 64);
+        this.bridge.offerPrepared(net.minecraft.world.level.Level.NETHER, tile(68, 64));
+        this.bridge.pump(); // burn 1 — under the cap
+        this.bridge.pump(); // burn 2 — both expire: ours to the ledger, the foreign one stale
+        assertEquals(2, this.bridge.counterForTest("dropped_expired"));
+        assertEquals(1, this.bridge.counterForTest("heal_pending"));
+        assertEquals(1, this.reports.size());
+        org.junit.jupiter.api.Assertions.assertSame(
+                net.minecraft.world.level.Level.NETHER, this.reports.get(0)[0]);
+        region.resting = true; // the saver finishes
+        this.bridge.pump(); // the idle probe finds the region committable → flush
+        assertEquals(0, this.bridge.counterForTest("heal_pending"));
+        assertEquals(2, this.reports.size());
+        assertEquals(64, this.reports.get(1)[1]);
+    }
+
+    @Test
+    void negativeCoordinatesRoundTripThroughTheLedger() {
+        this.bridge.maxQueue = 1;
+        offer(-33, -1);
+        offer(-34, -1); // same region (-2,-1): (-33,-1) is evicted
+        this.bridge.pump(); // the survivor commits → flush
+        assertEquals(1, this.bridge.counterForTest("written"));
+        assertEquals(1, this.reports.size());
+        assertEquals(-33, this.reports.get(0)[1], "chunkX must round-trip for negatives");
+        assertEquals(-1, this.reports.get(0)[2], "chunkZ must round-trip for negatives");
+    }
+
+    @Test
+    void theLedgerCapEvictsTheNewestRegionCounted() {
+        this.bridge.ledgerMaxRegions = 2;
+        this.bridge.maxQueue = 1;
+        offer(64, 64);
+        offer(96, 64);  // ledger [A=(2,2)]
+        offer(128, 64); // ledger [A, B=(3,2)]
+        offer(160, 64); // C=(4,2) drop: the cap evicts the NEWEST (B), never the head (§18.1 B-m6)
+        assertEquals(1, this.bridge.counterForTest("heal_abandoned"));
+        assertEquals(2, this.bridge.counterForTest("heal_pending"));
+        assertEquals(2, this.bridge.counterForTest("heal_regions"));
+    }
+
+    @Test
+    void aReDropAfterAReportCountsOnTheRedropMeter() {
+        this.bridge.maxQueue = 1;
+        offer(64, 64);
+        offer(70, 64); // (64,64) → ledger
+        this.bridge.pump(); // survivor commits → (64,64) reported (history marked)
+        assertEquals(1, this.bridge.counterForTest("heal_reported"));
+        assertEquals(0, this.bridge.counterForTest("heal_redropped"));
+        offer(64, 64); // the re-serve arrives...
+        offer(70, 64); // ...and is dropped AGAIN
+        assertEquals(1, this.bridge.counterForTest("heal_redropped"),
+                "the re-drop meter is the field's p estimate (§18.1 B-M2)");
     }
 
     private MapRegion theRegion() {
@@ -2090,7 +2185,9 @@ class XaeroMapCompatTest {
                 && line.contains(", cave_layer_waits=") && line.contains(", frame_flushes=")
                 && line.contains(", rebuild_ms=") && line.contains(", rebuild_max_us=")
                 && line.contains(", dropped_overflow=") && line.contains(", dropped_expired=")
-                && line.contains(", heal_pending=") && line.contains(", heal_reported="), line);
+                && line.contains(", heal_pending=") && line.contains(", heal_regions=")
+                && line.contains(", heal_reported=") && line.contains(", heal_redropped=")
+                && line.contains(", heal_abandoned="), line);
         assertFalse(line.contains("xaero_crashed"), "the crash token appears only while latched");
         assertFalse(line.contains("optional_unbound"), "every optional group binds against the stubs");
         this.enabled = false;

--- a/fabric/src/test/java/dev/vox/lss/config/ConfigValidationTest.java
+++ b/fabric/src/test/java/dev/vox/lss/config/ConfigValidationTest.java
@@ -791,6 +791,24 @@ class ConfigValidationTest {
     }
 
     @Test
+    void xaeroMapBridgeHealDefaultsOnAndRoundTripsThroughJson() {
+        // The §18 dropped-tile heal ships ON (the bridge itself stays opt-in — the heal
+        // is only consulted while the bridge runs, so the cautious default is the
+        // healing one, not a second opt-in).
+        var c = clientConfig();
+        assertTrue(c.enableXaeroMapBridgeHeal);
+        c.validate();
+        assertTrue(c.enableXaeroMapBridgeHeal, "validate() must not touch the boolean");
+        var gson = new com.google.gson.Gson();
+        String saved = gson.toJson(clientConfig());
+        assertTrue(saved.contains("\"enableXaeroMapBridgeHeal\":true"), saved);
+        var loaded = gson.fromJson(saved.replace(
+                "\"enableXaeroMapBridgeHeal\":true", "\"enableXaeroMapBridgeHeal\":false"),
+                dev.vox.lss.config.LSSClientConfig.class);
+        assertFalse(loaded.enableXaeroMapBridgeHeal, "a saved false must bind back as false");
+    }
+
+    @Test
     void scanPrefixRetentionDefaultsOnAndRoundTripsThroughJson() {
         // Scan prefix retention (docs/planning/scanner-reopened-rings-plan.md) ships ON —
         // a silent default-off revert would pass CI green (unit rigs set the seam

--- a/xplat/src/main/java/dev/vox/lss/compat/XaeroMapCompat.java
+++ b/xplat/src/main/java/dev/vox/lss/compat/XaeroMapCompat.java
@@ -167,6 +167,17 @@ final class XaeroMapCompat {
      *  never disarms). Under a degenerate zero budget, ready work behind more than
      *  this many not-ready regions waits for the tick fallback — accepted. */
     static final int FLUSH_PROBE_EXEMPT_FLOOR = 8;
+    /** Dropped-tile heal (plan §18): overflow-evicted and deferral-expired tiles are
+     *  remembered per region (one bit each, ~160 B/region) and reported to
+     *  {@code LSSApi.reportIngestFailure} only once their region is COMMITTABLE —
+     *  reporting at drop time would burn the client's MAX_INGEST_FAILURES (3) retries
+     *  inside one saturation phase (re-serves land ~1-2 s apart while the far-radius
+     *  region-load bottleneck persists for minutes) and park the holes anyway. Beyond
+     *  this many ledger regions the oldest is discarded uncounted — its holes stay
+     *  permanent, the pre-§18 behavior. */
+    static final int LEDGER_MAX_REGIONS = 4096;
+    /** Heal reports per pump — they run inline on the main thread. */
+    static final int LEDGER_FLUSH_PER_PUMP = 256;
     /** Consecutive failures (commit-side or extraction-side) before the bridge
      *  latches dead for the SESSION (re-armed at disconnect). */
     static final int THROW_LATCH = 5;
@@ -193,6 +204,13 @@ final class XaeroMapCompat {
     interface LevelOps {
         Object dimension(Object world);
         boolean isChunkLoaded(Object world, int chunkX, int chunkZ);
+    }
+
+    /** The §18 heal's report sink ({@code LSSApi.reportIngestFailure} in production —
+     *  an injectable seam because the static API hops through Minecraft.getInstance()). */
+    @FunctionalInterface
+    interface DropReporter {
+        void report(Object dimension, int chunkX, int chunkZ);
     }
 
     static final LevelOps PRODUCTION_LEVEL_OPS = new LevelOps() {
@@ -228,7 +246,9 @@ final class XaeroMapCompat {
             var bridge = new XaeroMapCompat(h, PRODUCTION_LEVEL_OPS,
                     () -> LSSClientConfig.CONFIG.enableXaeroMapBridge,
                     LSSApi::isServerEnabled,
-                    LSSApi::registerColumnConsumer, LSSApi::removeColumnConsumer);
+                    LSSApi::registerColumnConsumer, LSSApi::removeColumnConsumer,
+                    () -> LSSClientConfig.CONFIG.enableXaeroMapBridgeHeal,
+                    XaeroMapCompat::reportDroppedProduction);
             bridge.maybeRegister();
             instance = bridge;
             LSSLogger.info(LSSClientConfig.CONFIG.enableXaeroMapBridge
@@ -259,6 +279,14 @@ final class XaeroMapCompat {
     static void renderFrame() {
         var bridge = instance;
         if (bridge != null) bridge.frameFlush();
+    }
+
+    /** Production {@link DropReporter}: forgets the client stamp so the position
+     *  re-serves (plan §18) — safe from any thread, bounded by the client's
+     *  per-position ingest-failure cap. */
+    @SuppressWarnings("unchecked")
+    private static void reportDroppedProduction(Object dimension, int chunkX, int chunkZ) {
+        LSSApi.reportIngestFailure((ResourceKey<Level>) dimension, chunkX, chunkZ);
     }
 
     /** Disconnect body — session teardown (queue, latches, registration). */
@@ -293,6 +321,10 @@ final class XaeroMapCompat {
     private final BooleanSupplier sessionActive;
     private final java.util.function.Consumer<VoxelColumnConsumer> registrar;
     private final java.util.function.Consumer<VoxelColumnConsumer> deregistrar;
+    /** The §18 heal's kill switch (client config {@code enableXaeroMapBridgeHeal}). */
+    private final BooleanSupplier healEnabled;
+    /** Reports a dropped position back to LSS for its bounded re-serve — test seam. */
+    private final DropReporter dropReporter;
     private final VoxelColumnConsumer consumer;
     /** Whether the consumer is currently registered with LSSApi. Main thread only. */
     private boolean registered;
@@ -301,6 +333,11 @@ final class XaeroMapCompat {
     /** Packed chunk pos → entry; insertion-ordered, latest tile wins in place. */
     private final LinkedHashMap<Long, Entry> queue = new LinkedHashMap<>();
     private long queuedBytes; // under queueLock
+    /** Region key → dropped-position set (plan §18) — under {@link #queueLock}
+     *  (decode-thread evictions record; the main-thread heal phase flushes).
+     *  Insertion order is the heal probe's rotation order. */
+    private final LinkedHashMap<Long, DroppedLedger> dropLedger = new LinkedHashMap<>();
+    private int ledgerTotal; // under queueLock
 
     private final AtomicLong written = new AtomicLong();
     private final AtomicLong skippedNative = new AtomicLong();
@@ -328,6 +365,8 @@ final class XaeroMapCompat {
     int updateMaxDeferPumps = UPDATE_MAX_DEFER_PUMPS;
     long updateBorrowNanos = UPDATE_BORROW_NANOS;
     int frameMaxRebuilds = FRAME_MAX_REBUILDS;
+    int maxQueue = MAX_QUEUE;
+    int deferCap = DEFER_CAP;
     /** Tile chunks committed but not yet texture-rebuilt, keyed by tile-chunk
      *  coords and ordered by LAST TOUCH (a re-touch re-inserts at the tail, so
      *  idle-due entries are always a prefix). Main thread only. */
@@ -367,6 +406,9 @@ final class XaeroMapCompat {
     private final AtomicLong skippedSettings = new AtomicLong();
     /** Pumps that waited because Xaero was rendering a cave layer (diag). */
     private final AtomicLong caveLayerWaits = new AtomicLong();
+    /** Positions reported back to LSS by the §18 dropped-tile heal. */
+    private final AtomicLong healReported = new AtomicLong();
+    private volatile int healPendingGauge;
     /** The settings read threw once this session: both switches read as ON from then on
      *  (warned once). Session-scoped like the other latches; reset at session end. */
     private volatile boolean settingsGateBroken;
@@ -445,13 +487,16 @@ final class XaeroMapCompat {
     XaeroMapCompat(Handles h, LevelOps levelOps, BooleanSupplier enabled,
                    BooleanSupplier sessionActive,
                    java.util.function.Consumer<VoxelColumnConsumer> registrar,
-                   java.util.function.Consumer<VoxelColumnConsumer> deregistrar) {
+                   java.util.function.Consumer<VoxelColumnConsumer> deregistrar,
+                   BooleanSupplier healEnabled, DropReporter dropReporter) {
         this.h = h;
         this.levelOps = levelOps;
         this.enabled = enabled;
         this.sessionActive = sessionActive;
         this.registrar = registrar;
         this.deregistrar = deregistrar;
+        this.healEnabled = healEnabled;
+        this.dropReporter = dropReporter;
         this.consumer = buildConsumer();
     }
 
@@ -557,8 +602,9 @@ final class XaeroMapCompat {
             // cap only: the byte cap (which binds first on overlay-heavy tiles — sweep C
             // N3) needs the tile's size, unknown before extraction, and past it the
             // enqueue evicts the OLDEST entry, so that extraction is not wasted.
-            if (this.queue.size() >= MAX_QUEUE && !this.queue.containsKey(key)) {
+            if (this.queue.size() >= this.maxQueue && !this.queue.containsKey(key)) {
                 this.droppedOverflow.incrementAndGet();
+                recordDroppedLocked(dimension, key);
                 return;
             }
         }
@@ -606,12 +652,14 @@ final class XaeroMapCompat {
                 this.queue.remove(key);
             }
             while (!this.queue.isEmpty()
-                    && (this.queue.size() >= MAX_QUEUE
+                    && (this.queue.size() >= this.maxQueue
                         || this.queuedBytes + bytes > MAX_QUEUE_BYTES)) {
                 var it = this.queue.entrySet().iterator();
-                this.queuedBytes -= it.next().getValue().bytes;
+                var evicted = it.next();
+                this.queuedBytes -= evicted.getValue().bytes;
                 it.remove();
                 this.droppedOverflow.incrementAndGet();
+                recordDroppedLocked(evicted.getValue().dimension, evicted.getKey());
             }
             this.queuedBytes += bytes;
             this.queue.put(key, new Entry(dimension, tile, bytes));
@@ -624,6 +672,12 @@ final class XaeroMapCompat {
             int n = this.queue.size();
             this.queue.clear();
             this.queuedBytes = 0;
+            // Every clearQueue caller is a teardown (session end, world-id change, the
+            // death latch, toggles): the heal ledger dies with the queue, uncounted
+            // (plan §18) — a teardown must never trigger re-serves.
+            this.dropLedger.clear();
+            this.ledgerTotal = 0;
+            this.healPendingGauge = 0;
             return n;
         }
     }
@@ -696,6 +750,8 @@ final class XaeroMapCompat {
             case "frame_flushes" -> this.frameFlushes.get();
             case "rebuild_nanos_total" -> this.rebuildNanos.get();
             case "rebuild_nanos_max" -> this.rebuildNanosMax;
+            case "heal_pending" -> this.healPendingGauge;
+            case "heal_reported" -> this.healReported.get();
             case "dropped_updates" -> this.droppedUpdates.get();
             case "dropped_unloaded" -> this.droppedUnloaded.get();
             case "skipped_settings" -> this.skippedSettings.get();
@@ -715,6 +771,8 @@ final class XaeroMapCompat {
                 + ", skipped_native=" + this.skippedNative.get()
                 + ", defer_events=" + this.deferEvents.get()
                 + ", dropped=" + dropped
+                + ", dropped_overflow=" + this.droppedOverflow.get()
+                + ", dropped_expired=" + this.droppedExpired.get()
                 + ", commit_failures=" + this.commitFailures.get()
                 + ", load_requests=" + this.loadRequests.get()
                 + ", regions_waiting=" + this.regionsWaiting
@@ -727,6 +785,8 @@ final class XaeroMapCompat {
                 + ", dropped_unloaded=" + this.droppedUnloaded.get()
                 + ", skipped_settings=" + this.skippedSettings.get()
                 + ", cave_layer_waits=" + this.caveLayerWaits.get()
+                + ", heal_pending=" + this.healPendingGauge
+                + ", heal_reported=" + this.healReported.get()
                 + (this.xaeroCrashed ? ", xaero_crashed=true" : "")
                 + (this.settingsGateBroken ? ", settings_gate=broken" : "")
                 + (this.h.optionalMissing != null ? ", optional_unbound=" + this.h.optionalMissing : "");
@@ -760,7 +820,10 @@ final class XaeroMapCompat {
             if (this.pendingUpdates.isEmpty()) return;
         } else {
             synchronized (this.queueLock) {
-                if (this.queue.isEmpty() && this.pendingUpdates.isEmpty()) {
+                if (this.queue.isEmpty() && this.pendingUpdates.isEmpty()
+                        && this.dropLedger.isEmpty()) {
+                    // An idle bridge with an owed ledger still pumps: the heal phase is
+                    // what drains it post-saturation (plan §18).
                     this.regionsWaiting = 0;
                     return;
                 }
@@ -1037,6 +1100,7 @@ final class XaeroMapCompat {
 
         var bucketKeys = new ArrayList<>(buckets.keySet());
         var waiting = new ArrayList<WaitingRegion>();
+        var committedRegions = new java.util.LinkedHashSet<Long>();
         int commits = 0;
         boolean progressed = false;
         int size = bucketKeys.size();
@@ -1061,6 +1125,11 @@ final class XaeroMapCompat {
                     // Can never become valid — the pump-side stale-dimension drop (§2.5).
                     if (removeIfCurrent(pending.key(), pending.entry(), pending.tile())) {
                         this.droppedStale.incrementAndGet();
+                        // §18: report NOW — its region is only ever probed under the
+                        // CURRENT map dimension, so a ledger entry would rot; the
+                        // re-serve lands after the player returns to that dimension.
+                        reportStaleDropped(pending.entry().dimension,
+                                pending.tile().chunkX(), pending.tile().chunkZ());
                     }
                     progressed = true;
                     continue;
@@ -1082,6 +1151,7 @@ final class XaeroMapCompat {
                         this.written.incrementAndGet();
                         this.consecutiveFailures = 0;
                         commits++;
+                        committedRegions.add(regionKey); // §18: provably committable
                     }
                     case DEFERRED_TILE -> {
                         // TILE-CHUNK-scoped busy (its 4×4 loadState / PBO download):
@@ -1090,9 +1160,10 @@ final class XaeroMapCompat {
                         // region-wide burn expired whole buckets over one busy
                         // tile chunk).
                         this.deferEvents.incrementAndGet();
-                        if (++pending.entry().ladderReadyDeferrals > DEFER_CAP
+                        if (++pending.entry().ladderReadyDeferrals > this.deferCap
                                 && removeIfCurrent(pending.key(), pending.entry(), pending.tile())) {
                             this.droppedExpired.incrementAndGet();
+                            recordDropped(pending.entry().dimension, pending.key());
                         }
                     }
                     case DEFERRED -> {
@@ -1101,9 +1172,10 @@ final class XaeroMapCompat {
                         // (cap semantics preserved) and move on.
                         this.deferEvents.incrementAndGet();
                         for (var p : bucket) {
-                            if (++p.entry().ladderReadyDeferrals > DEFER_CAP
+                            if (++p.entry().ladderReadyDeferrals > this.deferCap
                                     && removeIfCurrent(p.key(), p.entry(), p.tile())) {
                                 this.droppedExpired.incrementAndGet();
+                                recordDropped(p.entry().dimension, p.key());
                             }
                         }
                         continue bucketLoop;
@@ -1135,6 +1207,7 @@ final class XaeroMapCompat {
         if (!capped) {
             this.regionsWaiting = waiting.size(); // a capped pass probed nothing: keep the last gauge
         }
+        healPhase(mp, dimensionId, committedRegions, waiting, capped);
         grantLoads(mp, saveLoad, waiting);
     }
 
@@ -1254,6 +1327,205 @@ final class XaeroMapCompat {
      *  tile-chunk-scoped (siblings keep committing); the three AWAITING flavors
      *  carry the region's requestability — Xaero's own state, read inside the
      *  probe's region monitor — into the grant phase's memoryless window. */
+    // ---- the §18 dropped-tile heal ----
+
+    /** One region's dropped-position set — 1024 bits over its 32×32 chunk grid. */
+    private static final class DroppedLedger {
+        final Object dimension;
+        final long[] bits = new long[16]; // under queueLock
+        int count; // under queueLock
+        int probes; // main thread only — the heal phase's wedged-head belt
+        DroppedLedger(Object dimension) {
+            this.dimension = dimension;
+        }
+    }
+
+    private void recordDropped(Object dimension, long packedChunk) {
+        synchronized (this.queueLock) {
+            recordDroppedLocked(dimension, packedChunk);
+        }
+    }
+
+    /** Remember a dropped position for the committable-region heal (plan §18).
+     *  Caller holds {@link #queueLock}. */
+    private void recordDroppedLocked(Object dimension, long packedChunk) {
+        if (!this.healEnabled.getAsBoolean()) return;
+        int chunkX = (int) (packedChunk >> 32);
+        int chunkZ = (int) packedChunk;
+        long regionKey = (((long) (chunkX >> 5)) << 32) | ((chunkZ >> 5) & 0xFFFFFFFFL);
+        var ledger = this.dropLedger.get(regionKey);
+        if (ledger != null && ledger.dimension != dimension) {
+            // Another dimension's set under this key can never flush through this
+            // dimension's probes — report it now (enqueue-only off the main thread)
+            // and start fresh.
+            this.dropLedger.remove(regionKey);
+            this.ledgerTotal -= ledger.count;
+            reportWholeLedger(regionKey, ledger);
+            ledger = null;
+        }
+        if (ledger == null) {
+            while (this.dropLedger.size() >= LEDGER_MAX_REGIONS) {
+                var it = this.dropLedger.entrySet().iterator();
+                this.ledgerTotal -= it.next().getValue().count;
+                it.remove(); // beyond the cap the oldest region's holes stay permanent (pre-§18)
+            }
+            ledger = new DroppedLedger(dimension);
+            this.dropLedger.put(regionKey, ledger);
+        }
+        int bit = ((chunkX & 31) << 5) | (chunkZ & 31);
+        long m = 1L << (bit & 63);
+        if ((ledger.bits[bit >> 6] & m) == 0) {
+            ledger.bits[bit >> 6] |= m;
+            ledger.count++;
+            this.ledgerTotal++;
+        }
+        this.healPendingGauge = this.ledgerTotal;
+    }
+
+    /** Report one whole set (already detached from the map). Caller holds
+     *  {@link #queueLock}; safe because off-main reports are queue hops. */
+    private void reportWholeLedger(long regionKey, DroppedLedger ledger) {
+        int regionX = (int) (regionKey >> 32);
+        int regionZ = (int) regionKey;
+        for (int bit = 0; bit < 1024; bit++) {
+            if ((ledger.bits[bit >> 6] & (1L << (bit & 63))) == 0) continue;
+            this.dropReporter.report(ledger.dimension,
+                    (regionX << 5) | (bit >> 5), (regionZ << 5) | (bit & 31));
+        }
+        this.healReported.addAndGet(ledger.count);
+        this.healPendingGauge = this.ledgerTotal;
+    }
+
+    /** A drain-time stale-dimension drop reports immediately (see the call site). */
+    private void reportStaleDropped(Object dimension, int chunkX, int chunkZ) {
+        if (!this.healEnabled.getAsBoolean()) return;
+        this.dropReporter.report(dimension, chunkX, chunkZ);
+        this.healReported.incrementAndGet();
+    }
+
+    /**
+     * The §18 heal phase (after the drain, before the grants): flush ledger sets whose
+     * regions are provably committable, reporting each position ONCE via the
+     * {@link DropReporter} so its bounded client-side re-serve
+     * ({@code ColumnStateMap.MAX_INGEST_FAILURES} = 3) lands when it can actually
+     * commit. Committed-this-pump regions flush first; then ONE further ledger region
+     * is probed per pump — loaded flushes now, requestable/parked joins the grant list
+     * at ZERO cluster size (real queue work outranks it in the window sort) and the
+     * probe stays at the ledger head so the granted load flushes within a few pumps
+     * (a 100-probe belt rotates a wedged head to the tail). Reports run inline on the
+     * main thread, capped at {@link #LEDGER_FLUSH_PER_PUMP} per pump. Skipped while
+     * the rebuild hard cap has commits paused — never add re-serves to an overloaded
+     * pump.
+     */
+    private void healPhase(Object mp, Object dimensionId, java.util.Set<Long> committedRegions,
+                           List<WaitingRegion> waiting, boolean capped) {
+        if (capped) return;
+        int budget = LEDGER_FLUSH_PER_PUMP;
+        for (Long regionKey : committedRegions) {
+            if (budget <= 0) return;
+            budget -= flushLedgerRegion(regionKey, dimensionId, budget);
+        }
+        if (budget <= 0) return;
+        Long probeKey;
+        DroppedLedger probe;
+        synchronized (this.queueLock) {
+            var it = this.dropLedger.entrySet().iterator();
+            if (!it.hasNext()) return;
+            var e = it.next();
+            probeKey = e.getKey();
+            probe = e.getValue();
+        }
+        if (probe.dimension != dimensionId) {
+            rotateLedgerToTail(probeKey); // flushes only after the player returns
+            return;
+        }
+        switch (probeRegionForHeal(mp, probeKey)) {
+            case COMMITTED -> flushLedgerRegion(probeKey, dimensionId, budget);
+            case AWAITING_REQUESTABLE, AWAITING_PARKED -> {
+                waiting.add(new WaitingRegion(probeKey, 0, Outcome.AWAITING_REQUESTABLE));
+                if (++probe.probes >= 100) {
+                    probe.probes = 0;
+                    rotateLedgerToTail(probeKey);
+                }
+            }
+            default -> {
+                if (++probe.probes >= 100) {
+                    probe.probes = 0;
+                    rotateLedgerToTail(probeKey);
+                }
+            }
+        }
+    }
+
+    private void rotateLedgerToTail(long regionKey) {
+        synchronized (this.queueLock) {
+            var ledger = this.dropLedger.remove(regionKey);
+            if (ledger != null) this.dropLedger.put(regionKey, ledger);
+        }
+    }
+
+    /** Flush up to {@code budget} positions of one region's set (bits cleared under
+     *  the lock, reports outside it); returns positions reported. */
+    private int flushLedgerRegion(long regionKey, Object dimensionId, int budget) {
+        long[] toReport;
+        Object dimension;
+        int n = 0;
+        synchronized (this.queueLock) {
+            var ledger = this.dropLedger.get(regionKey);
+            if (ledger == null || ledger.dimension != dimensionId) return 0;
+            dimension = ledger.dimension;
+            int regionX = (int) (regionKey >> 32);
+            int regionZ = (int) regionKey;
+            toReport = new long[Math.min(budget, ledger.count)];
+            for (int bit = 0; bit < 1024 && n < toReport.length; bit++) {
+                long m = 1L << (bit & 63);
+                if ((ledger.bits[bit >> 6] & m) == 0) continue;
+                ledger.bits[bit >> 6] &= ~m;
+                ledger.count--;
+                toReport[n++] = (((long) ((regionX << 5) | (bit >> 5))) << 32)
+                        | (((long) ((regionZ << 5) | (bit & 31))) & 0xFFFFFFFFL);
+            }
+            if (ledger.count == 0) this.dropLedger.remove(regionKey);
+            this.ledgerTotal -= n;
+            this.healPendingGauge = this.ledgerTotal;
+        }
+        for (int i = 0; i < n; i++) {
+            this.dropReporter.report(dimension, (int) (toReport[i] >> 32), (int) toReport[i]);
+        }
+        this.healReported.addAndGet(n);
+        return n;
+    }
+
+    /** Classify one region for the heal phase under the commit probe's monitors.
+     *  COMMITTED = loaded (flushable now — the re-serve takes the normal path later,
+     *  so resting is not required); the visit holds the park off while we flush. */
+    private Outcome probeRegionForHeal(Object mp, long regionKey) {
+        try {
+            Object region = this.h.getLeafMapRegion.invoke(mp, SURFACE_LAYER,
+                    (int) (regionKey >> 32), (int) regionKey, true);
+            if (region == null) return Outcome.DEFERRED;
+            Object writerPause = this.h.writerThreadPauseSync.invoke(region);
+            synchronized (writerPause) {
+                if ((boolean) this.h.regionIsWritingPaused.invoke(region)) return Outcome.DEFERRED;
+                synchronized (region) {
+                    byte loadState = (byte) this.h.getLoadState.invoke(region);
+                    if (loadState == 2) {
+                        this.h.registerVisit.invoke(region);
+                        return Outcome.COMMITTED;
+                    }
+                    if ((boolean) this.h.canRequestReload.invoke(region)) {
+                        return Outcome.AWAITING_REQUESTABLE;
+                    }
+                    return loadState == 3 ? Outcome.AWAITING_PARKED : Outcome.AWAITING_IN_FLIGHT;
+                }
+            }
+        } catch (Throwable t) {
+            if (t instanceof Error err && !(t instanceof AssertionError)) throw err;
+            noteFailure(t);
+            return Outcome.DEFERRED;
+        }
+    }
+
     private enum Outcome {
         COMMITTED, DEFERRED, DEFERRED_TILE,
         AWAITING_REQUESTABLE, AWAITING_PARKED, AWAITING_IN_FLIGHT,

--- a/xplat/src/main/java/dev/vox/lss/compat/XaeroMapCompat.java
+++ b/xplat/src/main/java/dev/vox/lss/compat/XaeroMapCompat.java
@@ -176,8 +176,14 @@ final class XaeroMapCompat {
      *  this many ledger regions the oldest is discarded uncounted — its holes stay
      *  permanent, the pre-§18 behavior. */
     static final int LEDGER_MAX_REGIONS = 4096;
-    /** Heal reports per pump — they run inline on the main thread. */
-    static final int LEDGER_FLUSH_PER_PUMP = 256;
+    /** Heal reports per pump — they run inline on the main thread, and the ceiling is
+     *  MATCHED to the channel that consumes them (§18.1 fold, reviewer B): a report
+     *  becomes a re-serve only through the client's ~800 col/s declaration/bandwidth
+     *  channel (WANT_SET_BUDGET × 1 Hz ≈ the default 25 MiB/s cap), so 40 × 20 pumps
+     *  ≈ 800/s keeps the report backlog — and therefore the staleness of the
+     *  committable proof — near zero. The first cut's 256 (5120/s) built a 100k+
+     *  backlog whose re-deliveries landed minutes after their proof. */
+    static final int LEDGER_FLUSH_PER_PUMP = 40;
     /** Consecutive failures (commit-side or extraction-side) before the bridge
      *  latches dead for the SESSION (re-armed at disconnect). */
     static final int THROW_LATCH = 5;
@@ -337,6 +343,9 @@ final class XaeroMapCompat {
      *  (decode-thread evictions record; the main-thread heal phase flushes).
      *  Insertion order is the heal probe's rotation order. */
     private final LinkedHashMap<Long, DroppedLedger> dropLedger = new LinkedHashMap<>();
+    /** Positions already REPORTED this session, per region (the re-drop meter's
+     *  memory) — under {@link #queueLock}, capped like the ledger, cleared with it. */
+    private final LinkedHashMap<Long, long[]> reportedHistory = new LinkedHashMap<>();
     private int ledgerTotal; // under queueLock
 
     private final AtomicLong written = new AtomicLong();
@@ -367,6 +376,7 @@ final class XaeroMapCompat {
     int frameMaxRebuilds = FRAME_MAX_REBUILDS;
     int maxQueue = MAX_QUEUE;
     int deferCap = DEFER_CAP;
+    int ledgerMaxRegions = LEDGER_MAX_REGIONS;
     /** Tile chunks committed but not yet texture-rebuilt, keyed by tile-chunk
      *  coords and ordered by LAST TOUCH (a re-touch re-inserts at the tail, so
      *  idle-due entries are always a prefix). Main thread only. */
@@ -408,7 +418,14 @@ final class XaeroMapCompat {
     private final AtomicLong caveLayerWaits = new AtomicLong();
     /** Positions reported back to LSS by the §18 dropped-tile heal. */
     private final AtomicLong healReported = new AtomicLong();
+    /** Ledger positions discarded unreported (teardowns, the cap, dimension
+     *  conflicts, the kill switch) — permanent holes, visible (§18.1 fold). */
+    private final AtomicLong healAbandoned = new AtomicLong();
+    /** Recorded drops whose position was already reported once this session — the
+     *  re-drop probability meter (§18.1 fold: p³ is the permanent-loss rate). */
+    private final AtomicLong healRedropped = new AtomicLong();
     private volatile int healPendingGauge;
+    private volatile int healRegionsGauge;
     /** The settings read threw once this session: both switches read as ON from then on
      *  (warned once). Session-scoped like the other latches; reset at session end. */
     private volatile boolean settingsGateBroken;
@@ -668,18 +685,37 @@ final class XaeroMapCompat {
 
     /** @return how many entries were dropped (the both-switches-off path counts them). */
     int clearQueue() {
+        return clearQueue(false);
+    }
+
+    /** @param keepLedger true only for the both-switches-off path (§18.1 fold,
+     *  reviewer A m6): the user toggling Xaero's map writing off is NOT a teardown —
+     *  the heal debt survives and resumes when writing is switched back on (the heal
+     *  phase is unreachable while both switches are off, so nothing reports). */
+    int clearQueue(boolean keepLedger) {
         synchronized (this.queueLock) {
             int n = this.queue.size();
             this.queue.clear();
             this.queuedBytes = 0;
-            // Every clearQueue caller is a teardown (session end, world-id change, the
-            // death latch, toggles): the heal ledger dies with the queue, uncounted
-            // (plan §18) — a teardown must never trigger re-serves.
-            this.dropLedger.clear();
-            this.ledgerTotal = 0;
-            this.healPendingGauge = 0;
+            if (!keepLedger) {
+                // Teardown (session end, world-id change, the death latch, the enable
+                // toggle): the ledger dies with the queue — never report from a
+                // teardown; the loss is COUNTED (heal_abandoned) so a heal cut short
+                // is distinguishable from a completed one (§18.1 fold).
+                abandonLedgerLocked();
+            }
             return n;
         }
+    }
+
+    /** Caller holds {@link #queueLock}. */
+    private void abandonLedgerLocked() {
+        if (this.ledgerTotal > 0) this.healAbandoned.addAndGet(this.ledgerTotal);
+        this.dropLedger.clear();
+        this.reportedHistory.clear();
+        this.ledgerTotal = 0;
+        this.healPendingGauge = 0;
+        this.healRegionsGauge = 0;
     }
 
     /**
@@ -751,7 +787,10 @@ final class XaeroMapCompat {
             case "rebuild_nanos_total" -> this.rebuildNanos.get();
             case "rebuild_nanos_max" -> this.rebuildNanosMax;
             case "heal_pending" -> this.healPendingGauge;
+            case "heal_regions" -> this.healRegionsGauge;
             case "heal_reported" -> this.healReported.get();
+            case "heal_redropped" -> this.healRedropped.get();
+            case "heal_abandoned" -> this.healAbandoned.get();
             case "dropped_updates" -> this.droppedUpdates.get();
             case "dropped_unloaded" -> this.droppedUnloaded.get();
             case "skipped_settings" -> this.skippedSettings.get();
@@ -786,7 +825,10 @@ final class XaeroMapCompat {
                 + ", skipped_settings=" + this.skippedSettings.get()
                 + ", cave_layer_waits=" + this.caveLayerWaits.get()
                 + ", heal_pending=" + this.healPendingGauge
+                + ", heal_regions=" + this.healRegionsGauge
                 + ", heal_reported=" + this.healReported.get()
+                + ", heal_redropped=" + this.healRedropped.get()
+                + ", heal_abandoned=" + this.healAbandoned.get()
                 + (this.xaeroCrashed ? ", xaero_crashed=true" : "")
                 + (this.settingsGateBroken ? ", settings_gate=broken" : "")
                 + (this.h.optionalMissing != null ? ", optional_unbound=" + this.h.optionalMissing : "");
@@ -925,7 +967,7 @@ final class XaeroMapCompat {
                             + " treating both as on for this session", t);
                 }
                 if (!loadNew && !update) {
-                    this.skippedSettings.addAndGet(clearQueue());
+                    this.skippedSettings.addAndGet(clearQueue(true)); // §18.1: not a teardown
                     this.regionsWaiting = 0;
                     tickFlush(mp, dimensionId);
                     return;
@@ -1163,6 +1205,8 @@ final class XaeroMapCompat {
                         if (++pending.entry().ladderReadyDeferrals > this.deferCap
                                 && removeIfCurrent(pending.key(), pending.entry(), pending.tile())) {
                             this.droppedExpired.incrementAndGet();
+                            // Dimension-safe: this entry passed the per-entry stale
+                            // filter above (unlike the bulk burn below).
                             recordDropped(pending.entry().dimension, pending.key());
                         }
                     }
@@ -1175,7 +1219,17 @@ final class XaeroMapCompat {
                             if (++p.entry().ladderReadyDeferrals > this.deferCap
                                     && removeIfCurrent(p.key(), p.entry(), p.tile())) {
                                 this.droppedExpired.incrementAndGet();
-                                recordDropped(p.entry().dimension, p.key());
+                                // §18.1 fold (reviewer A MAJOR-2a): the bulk burn reaches
+                                // entries the per-entry stale filter has not seen — a
+                                // foreign dimension must never enter this dimension's
+                                // ledger (it would conflict-thrash it); it takes the
+                                // stale route instead.
+                                if (p.entry().dimension == dimensionId) {
+                                    recordDropped(p.entry().dimension, p.key());
+                                } else {
+                                    reportStaleDropped(p.entry().dimension,
+                                            p.tile().chunkX(), p.tile().chunkZ());
+                                }
                             }
                         }
                         continue bucketLoop;
@@ -1207,7 +1261,7 @@ final class XaeroMapCompat {
         if (!capped) {
             this.regionsWaiting = waiting.size(); // a capped pass probed nothing: keep the last gauge
         }
-        healPhase(mp, dimensionId, committedRegions, waiting, capped);
+        healPhase(mp, dimensionId, committedRegions, waiting, capped, start);
         grantLoads(mp, saveLoad, waiting);
     }
 
@@ -1323,10 +1377,6 @@ final class XaeroMapCompat {
         return true;
     }
 
-    /** Region-scoped outcomes short-circuit the whole bucket; DEFERRED_TILE is
-     *  tile-chunk-scoped (siblings keep committing); the three AWAITING flavors
-     *  carry the region's requestability — Xaero's own state, read inside the
-     *  probe's region monitor — into the grant phase's memoryless window. */
     // ---- the §18 dropped-tile heal ----
 
     /** One region's dropped-position set — 1024 bits over its 32×32 chunk grid. */
@@ -1356,18 +1406,23 @@ final class XaeroMapCompat {
         var ledger = this.dropLedger.get(regionKey);
         if (ledger != null && ledger.dimension != dimension) {
             // Another dimension's set under this key can never flush through this
-            // dimension's probes — report it now (enqueue-only off the main thread)
-            // and start fresh.
+            // dimension's probes. DISCARD it, counted (§18.1 fold, reviewer A MAJOR-2:
+            // the first cut reported it here — un-gated, un-capped, under queueLock and
+            // possibly under a Xaero monitor; a conflict is a teardown-grade event).
             this.dropLedger.remove(regionKey);
             this.ledgerTotal -= ledger.count;
-            reportWholeLedger(regionKey, ledger);
+            this.healAbandoned.addAndGet(ledger.count);
             ledger = null;
         }
         if (ledger == null) {
-            while (this.dropLedger.size() >= LEDGER_MAX_REGIONS) {
-                var it = this.dropLedger.entrySet().iterator();
-                this.ledgerTotal -= it.next().getValue().count;
-                it.remove(); // beyond the cap the oldest region's holes stay permanent (pre-§18)
+            while (this.dropLedger.size() >= this.ledgerMaxRegions) {
+                // Evict the NEWEST (tail) region, never the head the probe is working
+                // (§18.1 fold, reviewer B m6) — counted: its holes stay permanent.
+                Long tail = null;
+                for (Long k : this.dropLedger.keySet()) tail = k;
+                var evicted = this.dropLedger.remove(tail);
+                this.ledgerTotal -= evicted.count;
+                this.healAbandoned.addAndGet(evicted.count);
             }
             ledger = new DroppedLedger(dimension);
             this.dropLedger.put(regionKey, ledger);
@@ -1378,71 +1433,99 @@ final class XaeroMapCompat {
             ledger.bits[bit >> 6] |= m;
             ledger.count++;
             this.ledgerTotal++;
+            long[] history = this.reportedHistory.get(regionKey);
+            if (history != null && (history[bit >> 6] & m) != 0) {
+                // Reported once already this session and dropped AGAIN — the re-drop
+                // probability meter (§18.1: permanent loss ≈ p³ of the drop count).
+                this.healRedropped.incrementAndGet();
+            }
         }
         this.healPendingGauge = this.ledgerTotal;
+        this.healRegionsGauge = this.dropLedger.size();
     }
 
-    /** Report one whole set (already detached from the map). Caller holds
-     *  {@link #queueLock}; safe because off-main reports are queue hops. */
-    private void reportWholeLedger(long regionKey, DroppedLedger ledger) {
-        int regionX = (int) (regionKey >> 32);
-        int regionZ = (int) regionKey;
-        for (int bit = 0; bit < 1024; bit++) {
-            if ((ledger.bits[bit >> 6] & (1L << (bit & 63))) == 0) continue;
-            this.dropReporter.report(ledger.dimension,
-                    (regionX << 5) | (bit >> 5), (regionZ << 5) | (bit & 31));
-        }
-        this.healReported.addAndGet(ledger.count);
-        this.healPendingGauge = this.ledgerTotal;
-    }
-
-    /** A drain-time stale-dimension drop reports immediately (see the call site). */
+    /** A drain-time stale-dimension drop reports immediately (see the call sites).
+     *  Contained per report (§18.1 fold, reviewer A m7): an LSS-side report throw
+     *  must never feed the XAERO bridge's death latch. */
     private void reportStaleDropped(Object dimension, int chunkX, int chunkZ) {
         if (!this.healEnabled.getAsBoolean()) return;
-        this.dropReporter.report(dimension, chunkX, chunkZ);
-        this.healReported.incrementAndGet();
+        try {
+            this.dropReporter.report(dimension, chunkX, chunkZ);
+            this.healReported.incrementAndGet();
+        } catch (Throwable t) {
+            if (t instanceof Error err && !(t instanceof AssertionError)) throw err;
+            long n = COMMIT_FAIL_WARN.recordAndTryAcquire(System.nanoTime() / 1_000_000);
+            if (n > 0) LSSLogger.warn("Xaero map heal: a drop report threw (contained)", t);
+        }
     }
 
     /**
-     * The §18 heal phase (after the drain, before the grants): flush ledger sets whose
-     * regions are provably committable, reporting each position ONCE via the
-     * {@link DropReporter} so its bounded client-side re-serve
-     * ({@code ColumnStateMap.MAX_INGEST_FAILURES} = 3) lands when it can actually
-     * commit. Committed-this-pump regions flush first; then ONE further ledger region
-     * is probed per pump — loaded flushes now, requestable/parked joins the grant list
-     * at ZERO cluster size (real queue work outranks it in the window sort) and the
-     * probe stays at the ledger head so the granted load flushes within a few pumps
-     * (a 100-probe belt rotates a wedged head to the tail). Reports run inline on the
-     * main thread, capped at {@link #LEDGER_FLUSH_PER_PUMP} per pump. Skipped while
-     * the rebuild hard cap has commits paused — never add re-serves to an overloaded
-     * pump.
+     * The §18 heal phase (after the drain, before the grants), as reshaped by the
+     * §18.1 two-reviewer fold: flush ledger sets ONLY when their region is provably
+     * committable AND the bridge itself has queue headroom — the drop condition is a
+     * GLOBAL queue condition, so a region-only proof re-served straight back into the
+     * saturated queue and burned the client's 3-strike budget (reviewer A MAJOR-1) —
+     * and at most {@link #LEDGER_FLUSH_PER_PUMP} reports per pump, matched to the
+     * client's ~800 col/s re-serve channel so the committable proof cannot go stale
+     * in a report backlog (reviewer B MAJOR-1). Committed-this-pump regions flush
+     * first; then ONE ledger region is probed per pump — loaded+resting flushes,
+     * requestable/parked joins the grant list ONLY when the drain has no real
+     * waiting work (reviewer B m7: never spend the 8-window or setBeingWritten on
+     * heal regions while queue work waits), staying at the head so the granted load
+     * flushes within a few pumps (a {@code 100}-probe belt rotates a wedged head;
+     * foreign-dimension heads rotate through a bounded scan instead of consuming the
+     * pump). Runs under the drain's nanos clock (reviewer A m5) and is skipped at
+     * the rebuild hard cap. The kill switch abandons the ledger, counted.
      */
     private void healPhase(Object mp, Object dimensionId, java.util.Set<Long> committedRegions,
-                           List<WaitingRegion> waiting, boolean capped) {
-        if (capped) return;
-        int budget = LEDGER_FLUSH_PER_PUMP;
-        for (Long regionKey : committedRegions) {
-            if (budget <= 0) return;
-            budget -= flushLedgerRegion(regionKey, dimensionId, budget);
-        }
-        if (budget <= 0) return;
-        Long probeKey;
-        DroppedLedger probe;
-        synchronized (this.queueLock) {
-            var it = this.dropLedger.entrySet().iterator();
-            if (!it.hasNext()) return;
-            var e = it.next();
-            probeKey = e.getKey();
-            probe = e.getValue();
-        }
-        if (probe.dimension != dimensionId) {
-            rotateLedgerToTail(probeKey); // flushes only after the player returns
+                           List<WaitingRegion> waiting, boolean capped, long start) {
+        if (!this.healEnabled.getAsBoolean()) {
+            synchronized (this.queueLock) {
+                abandonLedgerLocked(); // mid-session off-flip: stop cleanly, counted
+            }
             return;
         }
+        if (capped || System.nanoTime() - start > this.pumpNanosBudget) return;
+        synchronized (this.queueLock) {
+            if (this.dropLedger.isEmpty()) return;
+            // Reviewer A MAJOR-1: "committable region" is not "admissible queue" — while
+            // the bridge is shedding, any re-delivery would be re-dropped; hold the
+            // whole phase until the queue has real headroom.
+            if (this.queue.size() > this.maxQueue / 2
+                    || this.queuedBytes > MAX_QUEUE_BYTES / 2) {
+                return;
+            }
+        }
+        int budget = LEDGER_FLUSH_PER_PUMP;
+        for (Long regionKey : committedRegions) {
+            if (budget <= 0 || System.nanoTime() - start > this.pumpNanosBudget) return;
+            budget -= flushLedgerRegion(regionKey, dimensionId, budget);
+        }
+        if (budget <= 0 || System.nanoTime() - start > this.pumpNanosBudget) return;
+        // Bounded head scan: take the first CURRENT-dimension owed region within a few
+        // rotations (foreign heads rotate to the tail and heal after the player
+        // returns — they must not consume the pump, reviewer A m3).
+        Long probeKey = null;
+        DroppedLedger probe = null;
+        synchronized (this.queueLock) {
+            for (int scan = 0; scan < 8 && !this.dropLedger.isEmpty(); scan++) {
+                var e = this.dropLedger.entrySet().iterator().next();
+                if (e.getValue().dimension == dimensionId) {
+                    probeKey = e.getKey();
+                    probe = e.getValue();
+                    break;
+                }
+                var rotated = this.dropLedger.remove(e.getKey());
+                this.dropLedger.put(e.getKey(), rotated);
+            }
+        }
+        if (probe == null) return;
         switch (probeRegionForHeal(mp, probeKey)) {
             case COMMITTED -> flushLedgerRegion(probeKey, dimensionId, budget);
             case AWAITING_REQUESTABLE, AWAITING_PARKED -> {
-                waiting.add(new WaitingRegion(probeKey, 0, Outcome.AWAITING_REQUESTABLE));
+                if (waiting.isEmpty()) {
+                    waiting.add(new WaitingRegion(probeKey, 0, Outcome.AWAITING_REQUESTABLE));
+                }
                 if (++probe.probes >= 100) {
                     probe.probes = 0;
                     rotateLedgerToTail(probeKey);
@@ -1488,11 +1571,41 @@ final class XaeroMapCompat {
             if (ledger.count == 0) this.dropLedger.remove(regionKey);
             this.ledgerTotal -= n;
             this.healPendingGauge = this.ledgerTotal;
+            this.healRegionsGauge = this.dropLedger.size();
+            // Remember what was reported — the re-drop meter's memory (capped with the
+            // ledger; coordinate-keyed, so a cross-dimension re-drop can over-count by
+            // one, an accepted counter-only inaccuracy).
+            long[] history = this.reportedHistory.get(regionKey);
+            if (history == null) {
+                while (this.reportedHistory.size() >= this.ledgerMaxRegions) {
+                    var hit = this.reportedHistory.entrySet().iterator();
+                    hit.next();
+                    hit.remove();
+                }
+                history = new long[16];
+                this.reportedHistory.put(regionKey, history);
+            }
+            for (int i = 0; i < n; i++) {
+                int cx = (int) (toReport[i] >> 32);
+                int cz = (int) toReport[i];
+                int hbit = ((cx & 31) << 5) | (cz & 31);
+                history[hbit >> 6] |= 1L << (hbit & 63);
+            }
         }
+        int reported = 0;
         for (int i = 0; i < n; i++) {
-            this.dropReporter.report(dimension, (int) (toReport[i] >> 32), (int) toReport[i]);
+            try {
+                this.dropReporter.report(dimension, (int) (toReport[i] >> 32), (int) toReport[i]);
+                reported++;
+            } catch (Throwable t) {
+                // Contained per report (§18.1, reviewer A m7): an LSS-side throw must
+                // never feed the XAERO bridge's death latch or stop the batch.
+                if (t instanceof Error err && !(t instanceof AssertionError)) throw err;
+                long w = COMMIT_FAIL_WARN.recordAndTryAcquire(System.nanoTime() / 1_000_000);
+                if (w > 0) LSSLogger.warn("Xaero map heal: a drop report threw (contained)", t);
+            }
         }
-        this.healReported.addAndGet(n);
+        this.healReported.addAndGet(reported);
         return n;
     }
 
@@ -1511,7 +1624,11 @@ final class XaeroMapCompat {
                     byte loadState = (byte) this.h.getLoadState.invoke(region);
                     if (loadState == 2) {
                         this.h.registerVisit.invoke(region);
-                        return Outcome.COMMITTED;
+                        // §18.1 (reviewer A m4): require resting like the commit probe —
+                        // a permanently non-resting region (a stuck saver, DEFER_CAP's
+                        // own scenario) must not flush re-serves that just re-expire.
+                        return (boolean) this.h.isResting.invoke(region)
+                                ? Outcome.COMMITTED : Outcome.DEFERRED;
                     }
                     if ((boolean) this.h.canRequestReload.invoke(region)) {
                         return Outcome.AWAITING_REQUESTABLE;
@@ -1526,6 +1643,10 @@ final class XaeroMapCompat {
         }
     }
 
+    /** Region-scoped outcomes short-circuit the whole bucket; DEFERRED_TILE is
+     *  tile-chunk-scoped (siblings keep committing); the three AWAITING flavors
+     *  carry the region's requestability — Xaero's own state, read inside the
+     *  probe's region monitor — into the grant phase's memoryless window. */
     private enum Outcome {
         COMMITTED, DEFERRED, DEFERRED_TILE,
         AWAITING_REQUESTABLE, AWAITING_PARKED, AWAITING_IN_FLIGHT,

--- a/xplat/src/main/java/dev/vox/lss/config/LSSClientConfig.java
+++ b/xplat/src/main/java/dev/vox/lss/config/LSSClientConfig.java
@@ -94,6 +94,12 @@ public class LSSClientConfig extends JsonConfig {
     // Default OFF for v0.12.0 (user decision 2026-08-23): opt-in while the feature is new —
     // map writes are persistent saved data, so the surprise default is the cautious one.
     public boolean enableXaeroMapBridge = false;
+    // The bridge's dropped-tile heal (xaero-map-bridge-plan.md §18): tiles the bridge had
+    // to drop under far-radius region-load saturation (queue overflow / deferral expiry)
+    // are re-requested — bounded, at most 3 attempts per position — once their Xaero map
+    // region can actually accept them, instead of staying permanent map holes. Consulted
+    // only while the bridge itself is enabled; inert without the mod.
+    public boolean enableXaeroMapBridgeHeal = true;
     // Ingest-pressure request pacing (issue #71, docs/planning/ingest-backpressure-design.md):
     // scale the want-set budget down — and halt declarations entirely at a threshold — when a
     // registered LOD consumer reports a pending ingest backlog (Voxy's ingest queue depth via

--- a/xplat/src/main/java/dev/vox/lss/networking/client/ClientCommandActions.java
+++ b/xplat/src/main/java/dev/vox/lss/networking/client/ClientCommandActions.java
@@ -127,8 +127,9 @@ public final class ClientCommandActions {
         int empty = manager.getEmptyColumnCount();
         int dirty = manager.getDirtyColumnCount();
         feedback.accept(Component.literal(String.format(
-                "Columns: received=%d, empty=%d, dirty=%d, ingest_failed=%d",
-                receivedCols, empty, dirty, manager.getTotalIngestFailures()
+                "Columns: received=%d, empty=%d, dirty=%d, ingest_failed=%d, ingest_parked=%d",
+                receivedCols, empty, dirty, manager.getTotalIngestFailures(),
+                manager.getIngestParkedCount()
         )).withStyle(ChatFormatting.GRAY));
 
         // Responses line

--- a/xplat/src/main/java/dev/vox/lss/networking/client/ColumnStateMap.java
+++ b/xplat/src/main/java/dev/vox/lss/networking/client/ColumnStateMap.java
@@ -107,6 +107,15 @@ class ColumnStateMap {
     // Per-position ingest-failure counts; bounds the reject -> re-serve loop a permanently
     // failing consumer would otherwise drive forever (see onIngestFailed).
     private final Long2IntOpenHashMap ingestFailures = new Long2IntOpenHashMap();
+    /** Positions parked at {@link #MAX_INGEST_FAILURES} this session — the definitive
+     *  "this hole is now permanent" signal (the §18 Xaero heal's success criterion:
+     *  a completed heal and a total failure are otherwise indistinguishable from the
+     *  report/failure counters alone). */
+    private long ingestParked;
+
+    long ingestParkedCount() {
+        return this.ingestParked;
+    }
     // Positions whose last authoritative delivery was a 0-section CLEAR (content->air), mapped to
     // the PRE-CLEAR content stamp. If the consumer rejects a clear, onIngestFailed must re-request
     // with that pre-clear stamp (a real server-issued value, < the server's cached clear stamp) so
@@ -626,7 +635,10 @@ class ColumnStateMap {
         leaf.recomputeNeeds();
     }
 
-    /** Re-serve attempts allowed per position per session before parking it. */
+    /** Re-serve attempts allowed per position per session before parking it. Note
+     *  (§18.1): under the Xaero dropped-tile heal, {@code ingestFailures} can reach
+     *  disc scale (~150k entries ≈ 3 MB) in a heavy far-radius session — bounded by
+     *  the disc, no longer only by rare failures. */
     static final int MAX_INGEST_FAILURES = 3;
 
     /**
@@ -686,6 +698,7 @@ class ColumnStateMap {
 
         int priorFailures = this.ingestFailures.addTo(packed, 1);
         if (priorFailures + 1 > MAX_INGEST_FAILURES) {
+            this.ingestParked++;
             long parkPreStamp = this.clearedResync.getOrDefault(packed, -1L);
             if (parkPreStamp > 0) {
                 // Parking a lost CLEAR: the consumer still HOLDS the pre-clear content (it

--- a/xplat/src/main/java/dev/vox/lss/networking/client/LodRequestManager.java
+++ b/xplat/src/main/java/dev/vox/lss/networking/client/LodRequestManager.java
@@ -1016,6 +1016,12 @@ public class LodRequestManager {
      * it with ts=-1 — the server's honest re-resolution then re-serves it instead of
      * answering up-to-date. Main client thread only.
      */
+    /** Positions parked at the ingest-failure cap this session (§18.1 — the heal's
+     *  definitive permanent-hole count, diag {@code ingest_parked=}). */
+    public long getIngestParkedCount() {
+        return this.columns.ingestParkedCount();
+    }
+
     public void onIngestFailure(ResourceKey<Level> dimension, long packed) {
         if (this.lastDimension == null || !this.lastDimension.equals(dimension)) {
             // A report for another dimension (a consumer rejected asynchronously after the


### PR DESCRIPTION
Live 26.2 session: 15% of map tiles (159k) dropped beyond ~ring 374 — permanent holes (positions stay stamped; nothing re-serves). The heal records drops in a per-region bitmap ledger and reports them via the bounded reportIngestFailure channel (3 strikes/position) only when the region is committable AND the bridge queue has headroom, at a rate matched to the client's ~800 col/s re-serve channel. 2-Opus reviewed (loop-safety + field-effectiveness), all MAJORs folded (§18/§18.1 are the record). Kill switch enableXaeroMapBridgeHeal (default on). New instruments: heal_pending/regions/reported/redropped/abandoned + ingest_parked on the client Columns line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)