### PR TITLE
docs: v0.13.0 release notes + run sheet + staging corrections

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,8 +8,7 @@ LOD Server Support (LSS) — distributes LOD chunk data from servers to clients 
 
 ## Support tiers (v0.11.0+; docs/planning/neoforge-support-plan.md is normative)
 
-**Full** — Fabric + Paper on main (26.2): complete gauntlets (T1/T2/T3), 22-scenario
-soaks ×3 platforms, live-rig burn-in, first-priority triage. **Correct, not
+**Full** — Fabric + Paper on main (26.2): complete gauntlets (T1/T2/T3), 23-scenario soaks ×3 platforms, live-rig burn-in, first-priority triage. **Correct, not
 perfect** — the 26.1/1.21.11 lines: full builds + T1/T2 and representative smoke
 soaks, no live rig, no exhaustive gauntlets. **Best-effort** — NeoForge and the
 whole MC 1.21.1 line: they track the mainline feature set, but feature cuts are
@@ -454,7 +453,7 @@ Scenarios needing a base world auto-run `fresh-backfill` first. warm-rejoin, dir
 
 - `scripts/soak.sh` — orchestrator (stage → validate → run → collect → check)
 - `scripts/soak-scenarios/<name>.json` + `<name>-config.json` — driver timeline + sparse server-config overrides
-- `scripts/check_soak.py` — stdlib Python invariant checker (`--validate` pre-flight, post-run laws, per-run completion gates — a missing server `end` row OR a missing client `disconnect` row means that JVM died mid-run, `client_run_completion_violations` — `--selftest` 265 in-memory pass/catch cases incl. all four oldest named checks, the disconnect gate, the quiescence client mirror, and the xray config-key type branches). **The harness is v17-only:** `players[].backlog` is a required schema field and `service.superseded`/`range_filtered` are required + monotonic, so it will correctly reject any pre-v17 recording — re-record rather than debug.
+- `scripts/check_soak.py` — stdlib Python invariant checker (`--validate` pre-flight, post-run laws, per-run completion gates — a missing server `end` row OR a missing client `disconnect` row means that JVM died mid-run, `client_run_completion_violations` — `--selftest` 270 in-memory pass/catch cases incl. all four oldest named checks, the disconnect gate, the quiescence client mirror, and the xray config-key type branches). **The harness is v17-only:** `players[].backlog` is a required schema field and `service.superseded`/`range_filtered` are required + monotonic, so it will correctly reject any pre-v17 recording — re-record rather than debug.
 - `scripts/soak_report.py` — stdlib post-run anomaly digest (spikes/stalls, concerning-vs-mechanism counters, high-water marks, cadence/TPS, law margins, cross-identity audits); a lens, never a gate (`--strict` to exit nonzero on any anomaly; `--compare`, `--selftest`)
 - `scripts/check_move_trace.py` — stdlib validator for the move-desync tracer's JSONL (`--validate FILE...`, `--selftest` — 36 pass/catch cases over the shared `scripts/testdata/move-trace-rows.jsonl` fixture the Tier 1 goldens write; run it on collected traces BEFORE analysis)
 - `scripts/release_check.py` — release-jar safety gate (no dev-only benchmark/soak packages ship, incl. inside nested Jar-in-Jar entries and dev/vox/lss/common namespaces; stale-jar ambiguity guard + `--version` pinning; version expansion; mappings-namespace manifest; glob hygiene). Wired into `.github/workflows/build.yml` alongside the three `--selftest` runs.

--- a/docs/planning/hybrid-scan-plan.md
+++ b/docs/planning/hybrid-scan-plan.md
@@ -1,6 +1,6 @@
 # Hybrid scan: ring-major near, region-major far (v3.2 — §12.8/§12.9 supersede the §12 -1-on-blocked/refusal doctrine)
 
-**Status: PLANNED, NOT EXECUTED** (user directive 2026-08-24: write + review only).
+**Status: EXECUTED (as-built §12.6-§12.9, §13-§13.1) and PORTED to all four support lines 2026-08-26 (v0.13.0 round)** — the header below is the original planning framing.
 Follow-up to `region-scan-plan.md` (§14/§14.1 = the region round's as-built + review
 records). **v2 folds the 4-agent plan review** (3 Opus: design/geometry,
 cadence+server+boundary, tests+consistency; 1 Fable: holistic/premise — §11 is the

--- a/docs/planning/region-scan-plan.md
+++ b/docs/planning/region-scan-plan.md
@@ -476,7 +476,7 @@ unchanged. Pinned by carrying the existing latch tests over the interface.
 
 ## 11. Rollout
 
-Main/26.2 only. Implementation lands behind `enableRegionScan=true` via PR
+Originally main/26.2 only [ported fleet-wide 2026-08-26]. Implementation lands behind `enableRegionScan=true` via PR
 after the 2-Fable + 3-Opus implementation review; dev jar to lss-test-26.2;
 backports and any v0.13.0 packaging wait for the user's live approval. The
 v0.12.1 staged tags are NOT touched by this round.

--- a/docs/planning/release-tag-v0.13.0-mc1.21.1.txt
+++ b/docs/planning/release-tag-v0.13.0-mc1.21.1.txt
@@ -1,0 +1,18 @@
+### New Features
+
+- **Smarter terrain scanning** — nearby terrain fills in clean rings around you while distant terrain streams in efficiently, region by region.
+- **Xaero's World Map keeps up** — map writing now paces the LOD download instead of dropping tiles during big fills; short download pauses while the map is busy are normal.
+
+### Bug Fixes
+
+- **Fixes a crash in Xaero's World Map saving** — map region saves no longer race the bridge's tile writes.
+- **Smoother frames while the map catches up** — map texture rebuilds are spread across frames instead of bunching into single-frame stutters.
+- **The in-game settings page now works on older Sodium versions** — the LSS options render on the Sodium 0.6/0.7 generation this line uses.
+
+### Configuration
+
+- **Two new client options, both on by default** — `enableRegionScan` (the new scanning order) and `enableXaeroMapBackpressure` (the map pacing); set either to false to get the previous behavior.
+
+### Compatibility
+
+- Mixed client/server versions remain fully compatible in both directions; this line (Fabric, Paper, and NeoForge) is supported best-effort.

--- a/docs/planning/release-tag-v0.13.0-mc1.21.10.txt
+++ b/docs/planning/release-tag-v0.13.0-mc1.21.10.txt
@@ -1,0 +1,18 @@
+### New Features
+
+- **Smarter terrain scanning** — nearby terrain fills in clean rings around you while distant terrain streams in efficiently, region by region.
+- **Xaero's World Map keeps up** — map writing now paces the LOD download instead of dropping tiles during big fills; short download pauses while the map is busy are normal.
+
+### Bug Fixes
+
+- **Fixes a crash in Xaero's World Map saving** — map region saves no longer race the bridge's tile writes.
+- **Smoother frames while the map catches up** — map texture rebuilds are spread across frames instead of bunching into single-frame stutters.
+- **The in-game settings page now works on older Sodium versions** — the LSS options render on Sodium 0.6/0.7 as well as 0.8+.
+
+### Configuration
+
+- **Two new client options, both on by default** — `enableRegionScan` (the new scanning order) and `enableXaeroMapBackpressure` (the map pacing); set either to false to get the previous behavior.
+
+### Compatibility
+
+- Mixed client/server versions remain fully compatible in both directions; Folia support remains experimental.

--- a/docs/planning/release-tag-v0.13.0-mc1.21.11.txt
+++ b/docs/planning/release-tag-v0.13.0-mc1.21.11.txt
@@ -1,0 +1,18 @@
+### New Features
+
+- **Smarter terrain scanning** — nearby terrain fills in clean rings around you while distant terrain streams in efficiently, region by region.
+- **Xaero's World Map keeps up** — map writing now paces the LOD download instead of dropping tiles during big fills; short download pauses while the map is busy are normal.
+
+### Bug Fixes
+
+- **Fixes a crash in Xaero's World Map saving** — map region saves no longer race the bridge's tile writes.
+- **Smoother frames while the map catches up** — map texture rebuilds are spread across frames instead of bunching into single-frame stutters.
+- **The in-game settings page now works on older Sodium versions** — the LSS options render on Sodium 0.6/0.7 as well as 0.8+.
+
+### Configuration
+
+- **Two new client options, both on by default** — `enableRegionScan` (the new scanning order) and `enableXaeroMapBackpressure` (the map pacing); set either to false to get the previous behavior.
+
+### Compatibility
+
+- Mixed client/server versions remain fully compatible in both directions; Folia support remains experimental.

--- a/docs/planning/release-tag-v0.13.0-mc26.1.txt
+++ b/docs/planning/release-tag-v0.13.0-mc26.1.txt
@@ -1,0 +1,18 @@
+### New Features
+
+- **Smarter terrain scanning** — nearby terrain fills in clean rings around you while distant terrain streams in efficiently, region by region.
+- **Xaero's World Map keeps up** — map writing now paces the LOD download instead of dropping tiles during big fills; short download pauses while the map is busy are normal.
+
+### Bug Fixes
+
+- **Fixes a crash in Xaero's World Map saving** — map region saves no longer race the bridge's tile writes.
+- **Smoother frames while the map catches up** — map texture rebuilds are spread across frames instead of bunching into single-frame stutters.
+- **The in-game settings page now works on older Sodium versions** — the LSS options render on Sodium 0.6/0.7 as well as 0.8+.
+
+### Configuration
+
+- **Two new client options, both on by default** — `enableRegionScan` (the new scanning order) and `enableXaeroMapBackpressure` (the map pacing); set either to false to get the previous behavior.
+
+### Compatibility
+
+- Mixed client/server versions remain fully compatible in both directions; Folia support remains experimental.

--- a/docs/planning/release-tag-v0.13.0.txt
+++ b/docs/planning/release-tag-v0.13.0.txt
@@ -1,0 +1,18 @@
+### New Features
+
+- **Smarter terrain scanning** — nearby terrain fills in clean rings around you while distant terrain streams in efficiently, region by region.
+- **Xaero's World Map keeps up** — map writing now paces the LOD download instead of dropping tiles during big fills; short download pauses while the map is busy are normal.
+
+### Bug Fixes
+
+- **Fixes a crash in Xaero's World Map saving** — map region saves no longer race the bridge's tile writes.
+- **Smoother frames while the map catches up** — map texture rebuilds are spread across frames instead of bunching into single-frame stutters.
+- **The in-game settings page now works on older Sodium versions** — the LSS options render on Sodium 0.6/0.7 as well as 0.8+.
+
+### Configuration
+
+- **Two new client options, both on by default** — `enableRegionScan` (the new scanning order) and `enableXaeroMapBackpressure` (the map pacing); set either to false to get the previous behavior.
+
+### Compatibility
+
+- Mixed client/server versions remain fully compatible in both directions; Folia support remains experimental.

--- a/docs/planning/v0-13-0-run-sheet.md
+++ b/docs/planning/v0-13-0-run-sheet.md
@@ -1,0 +1,77 @@
+# v0.13.0 — manual-test run sheet + release staging (2026-08-26)
+
+Everything below is STAGED; nothing has been tagged or published. The release
+run is yours, after the manual pass. State at handover: main merged (PR #245);
+four port PRs merged to the canonical line branches; all gates green per line
+(T1/T2/checker/pre-flight/release_check/CI incl. Tier 3 where the line has it;
+fresh-backfill smokes on 26.1, 1.21.11, 1.21.1; hybrid-boundary green on main);
+2-Opus port reviews folded (0 code MAJORs on every line); the five local
+v0.12.1 tags DELETED.
+
+## 1. Manual test — one line at a time (server ports collide across lines)
+
+Per line: start the test servers from that line's worktree, launch the matching
+Prism instance, join :25564 (Fabric) and/or :25566 (Paper), fly around, run
+`/lss diag`. Stop the servers (Ctrl+C) before switching lines.
+
+| line | worktree (servers: `./test-server.sh`) | Prism instance | client jar installed |
+|---|---|---|---|
+| 26.2 | ~/projects/lss-main-deploy | lss-test-26.2 | refreshed from merged main |
+| 26.1 | ~/projects/lss-port-26.1 | 26.1.2 | 0.13.0 rc |
+| 1.21.11 | ~/projects/lss-port-1.21.11 | 1.21.11 | 0.13.0 rc |
+| 1.21.10 | ~/projects/lss-port-1.21.10 | (none exists — see note) | — |
+| 1.21.1 | ~/projects/lss-port-1.21.1 | 1.21.1 (needs stack check — see note) | see note |
+
+- **1.21.10**: no Prism instance exists. Its port is byte-identical to main's
+  stack, CI (incl. Tier 3) is green — say the word if you want an instance
+  created for an eyeball anyway.
+- **1.21.1**: the instance currently carries NO LSS jar (the NeoForge
+  fork-Voxy stack used a nosqlite variant historically). Left untouched — tell
+  me which shape you want installed (standard rc vs nosqlite) or install by
+  hand from `~/projects/lss-port-1.21.1/fabric/build/libs/`.
+
+### What to look for (the new surface)
+
+- Near terrain fills in CONCENTRIC RINGS around you; far terrain arrives in
+  region-sized blocks. `/lss diag` Scan line: `near_rings=` active during near
+  fill then ~0, `region_span=` ≤2 during far fill, `audit_heals=0`.
+- With Xaero's map on: the map fills with `dropped=0` and `drops_reported≈0`;
+  `bp=` shows a fraction (a `(blocked)` suffix during heavy map activity is
+  the mechanism working); `-1(wedged)` persisting >10 s at a time would be a
+  real finding. Brief full pauses of the LOD download while the map is busy
+  are DESIGNED (≤7 s per window).
+- On a legacy-Sodium instance (26.1/1.21.11/1.21.1): open the LSS options page
+  and HOVER THE XAERO TOGGLE — the rewritten tooltip is long (~767 chars) and
+  the legacy renderer has a fixed pane (review flag; if it clips, I'll shorten
+  the string per line).
+- A/B lever if anything looks wrong: `enableRegionScan=false` in
+  lss-client-config.json reverts to the legacy walk; `enableXaeroMapBackpressure=false`
+  disarms the map pacing.
+
+## 2. Release run (after your manual pass) — commands staged, NOT executed
+
+Notes files (short user-facing bullets, per line):
+`docs/planning/release-tag-v0.13.0.txt` + `-mc26.1/-mc1.21.10/-mc1.21.11/-mc1.21.1.txt`.
+
+Per line, in its worktree, ON the canonical branch after the PR merge
+(main / support/mc26.1-v0.13 / support/mc1.21.11-v0.13 / support/mc1.21.10 /
+support/mc1.21.1):
+
+```bash
+# 1. re-run the line's CLAUDE.md pre-flight verbatim with -Pmod_version=0.13.0  (all green as of staging)
+# 2. tag (annotated, verbatim cleanup):
+git tag -a v0.13.0            -F docs/planning/release-tag-v0.13.0.txt            --cleanup=verbatim   # main
+git tag -a v0.13.0+mc26.1     -F docs/planning/release-tag-v0.13.0-mc26.1.txt     --cleanup=verbatim
+git tag -a v0.13.0+mc1.21.11  -F docs/planning/release-tag-v0.13.0-mc1.21.11.txt  --cleanup=verbatim
+git tag -a v0.13.0+mc1.21.10  -F docs/planning/release-tag-v0.13.0-mc1.21.10.txt  --cleanup=verbatim
+git tag -a v0.13.0+mc1.21.1   -F docs/planning/release-tag-v0.13.0-mc1.21.1.txt   --cleanup=verbatim
+# 3. verify headers survived:  git for-each-ref --format='%(contents)' refs/tags/<tag> | head
+# 4. push ONE TAG AT A TIME (>3 in one push fires ZERO workflow events):
+git push origin v0.13.0        # wait for the run:  gh run watch --exit-status
+git push origin v0.13.0+mc26.1 # ...one at a time, main first then the lines
+# 5. after each publish: gh release view <tag>  (headers rendered?) + Modrinth check
+```
+
+Standing cautions: never `gh run rerun` a partially-published release; VSS
+publish stays blocked on the expired MODRINTH_PAT (separate decision); the
+Modrinth live-server deploy is a separate post-release step.


### PR DESCRIPTION
Docs-only (skips build.yml): the five release-notes files (short user-facing bullets per the notes-style rule), the manual-test run sheet + staged tag commands, and the fleet-wide doc corrections the port reviews found on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)