### PR TITLE
CI: ship NeoForge on the 26.2 line + tag-backfill publish workflow

### DIFF
--- a/.github/line.env
+++ b/.github/line.env
@@ -20,14 +20,14 @@ LINE_GAME_VERSIONS_FABRIC=26.2
 LINE_GAME_VERSIONS_PAPER=26.2
 LINE_GAME_VERSIONS_NEOFORGE=26.2
 LINE_PAPER_LOADERS=paper purpur folia
-LINE_NEOFORGE_NAME=NeoForge (MC 26.2, server-side)
-# v0.11.0 release scope (user decision 2026-08-15): NeoForge SHIPS only on the
-# 1.21.1 line (the one line with a working client pairing — the community Voxy
-# port). false = the module still builds/tests in CI, but release.yml skips its
-# build + assets + Modrinth step and release_check does not require its families.
-# release_check.py DERIVES its SHIP_NEOFORGE from this value (R2-5) — one edit
-# here is the whole flip.
-LINE_SHIP_NEOFORGE=false
+LINE_NEOFORGE_NAME=NeoForge (MC 26.2)
+# v0.13.1 scope (user decision 2026-08-27): NeoForge SHIPS on this line — the
+# VoX/Foxy fork (Voxy-on-NeoForge, Windows natives fixed 2026-08-26) is the
+# working client pairing on 26.x, retiring v0.11.0's 1.21.1-only scope. true =
+# release.yml builds + attaches + Modrinth-publishes the module and
+# release_check requires its families. release_check.py DERIVES its
+# SHIP_NEOFORGE from this value (R2-5) — one edit here is the whole flip.
+LINE_SHIP_NEOFORGE=true
 # Fabric jar manifest mapping namespace (release_check derives): official on the
 # 26.x/1.21.11 toolchains; intermediary under loom-remap lines.
 LINE_FABRIC_MAPPING_NAMESPACE=official

--- a/.github/workflows/release-neoforge.yml
+++ b/.github/workflows/release-neoforge.yml
@@ -1,0 +1,118 @@
+name: Release NeoForge (backfill)
+
+# One-off publisher for the NeoForge artifact of an ALREADY-RELEASED tag. Built
+# for the 2026-08-27 decision to start shipping NeoForge on the 26.x lines (the
+# VoX/Foxy fork gives them a working Voxy client pairing) without re-running the
+# published v0.13.1 releases — a release.yml re-run rebuilds byte-different
+# fabric/paper jars, silently replaces the GitHub assets, and creates duplicate
+# Modrinth versions (the documented release pitfall). Future releases need none
+# of this: with LINE_SHIP_NEOFORGE=true, release.yml ships NeoForge normally.
+#
+# Dispatch it ON THE TAG'S OWN LINE BRANCH (main for v0.13.1,
+# support/mc26.1-v0.13 for v0.13.1+mc26.1): the workflow file + line.env are
+# read from the branch — which must already carry LINE_SHIP_NEOFORGE=true —
+# while the SOURCES are checked out from the tag. The guards make a duplicate
+# or wrong-line dispatch a loud no-op: suffix equality, the ship flag, the
+# release must exist, and it must not already carry a NeoForge asset.
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Existing release tag to backfill (e.g. v0.13.1 or v0.13.1+mc26.1)'
+        required: true
+        type: string
+
+jobs:
+  backfill:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Load line identity (from the branch)
+        run: grep -vE '^\s*(#|$)' .github/line.env >> "$GITHUB_ENV"
+
+      - name: Guards
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ inputs.tag }}
+        run: |
+          set -euo pipefail
+          BASE="${TAG%%+*}"
+          SUFFIX="${TAG#"$BASE"}"
+          if [ "${SUFFIX}" != "${LINE_TAG_SUFFIX}" ]; then
+            echo "::error::tag ${TAG} carries suffix '${SUFFIX}' but this branch declares '${LINE_TAG_SUFFIX}' — dispatch on the tag's own line branch"
+            exit 1
+          fi
+          if [ "${LINE_SHIP_NEOFORGE}" != "true" ]; then
+            echo "::error::this line does not ship NeoForge (LINE_SHIP_NEOFORGE='${LINE_SHIP_NEOFORGE}')"
+            exit 1
+          fi
+          MV="${TAG#v}"; MV="${MV%%+*}"
+          case "$MV" in
+            [0-9]*) ;;
+            *) echo "::error::'${TAG}' does not derive a numeric mod version ('${MV}')"; exit 1 ;;
+          esac
+          echo "MOD_VERSION=${MV}" >> "$GITHUB_ENV"
+          # Backfill only: the release must exist (gh fails loudly otherwise) and
+          # must not already carry the artifact — Modrinth accepts duplicate
+          # version ids silently, so the asset check is the dedupe.
+          ASSETS=$(gh release view "${TAG}" --json assets --jq '.assets[].name')
+          if grep -q "neoforge" <<< "${ASSETS}"; then
+            echo "::error::release ${TAG} already carries a NeoForge asset — refusing the duplicate"
+            exit 1
+          fi
+
+      - name: Check out the tag's sources
+        run: git checkout "refs/tags/${{ inputs.tag }}"
+
+      - name: Read the release notes (Modrinth changelog)
+        id: release_notes
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          {
+            echo "notes<<RELEASE_NOTES_EOF"
+            gh release view "${{ inputs.tag }}" --json body --jq .body
+            echo "RELEASE_NOTES_EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: ${{ env.LINE_JAVA_VERSION }}
+
+      - uses: gradle/actions/setup-gradle@v4
+
+      - name: Build NeoForge + contract tests
+        run: ./gradlew :neoforge:build -Pmod_version=${MOD_VERSION}
+
+      - name: Expand game-version list
+        run: |
+          {
+            echo "GV_NEOFORGE<<LINE_LIST_EOF"
+            tr ' ' '\n' <<< "${LINE_GAME_VERSIONS_NEOFORGE}"
+            echo "LINE_LIST_EOF"
+          } >> "$GITHUB_ENV"
+
+      - name: Attach to the GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release upload "${{ inputs.tag }}" neoforge/build/libs/lod-server-support-neoforge-*.jar
+
+      - name: Upload NeoForge to Modrinth
+        uses: Kir-Antipov/mc-publish@v3.3
+        with:
+          modrinth-id: lKiXKLvv
+          modrinth-token: ${{ secrets.MODRINTH_TOKEN }}
+          files: neoforge/build/libs/lod-server-support-neoforge-*.jar
+          name: v${{ env.MOD_VERSION }} - ${{ env.LINE_NEOFORGE_NAME }}
+          version: v${{ env.MOD_VERSION }}+neoforge+mc${{ env.LINE_MC_NEOFORGE }}
+          version-type: release
+          loaders: neoforge
+          game-versions: ${{ env.GV_NEOFORGE }}
+          changelog: ${{ steps.release_notes.outputs.notes }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,9 +16,10 @@ acceptable where the platform/version fights (cuts beyond the plan's
 pre-authorized list need a dated decisions-log entry — the §6.2 cut protocol; the
 release notes must name the tier and any cut). Best-effort is a SUPPORT-commitment
 axis, distinct from Folia's *experimental* (a correctness-confidence axis — see
-below). **v0.11.0 ships NeoForge on the 1.21.1 line ONLY** (the one line with a
-working client pairing — the community Voxy port; other lines' NeoForge clients
-have no Voxy route). Gated by `LINE_SHIP_NEOFORGE` in `.github/line.env`, from
+below). **NeoForge ships on the 1.21.1 line (since v0.11.0 — the community
+Voxy port is the client pairing) and on the 26.1/26.2 lines (since v0.13.1,
+user decision 2026-08-27 — the VoX/Foxy fork is the client pairing there); the
+1.21.11/1.21.10 lines still do not ship it (no Voxy route).** Gated by `LINE_SHIP_NEOFORGE` in `.github/line.env`, from
 which release.yml, release_check.py, and the contract tests all DERIVE (R2-5) —
 one line.env edit is the whole flip; build.yml still builds + tests the NeoForge
 module on EVERY line so the port stays maintained. **Wire compatibility is NEVER

--- a/paper/src/test/java/dev/vox/lss/paper/ReleaseWorkflowContractTest.java
+++ b/paper/src/test/java/dev/vox/lss/paper/ReleaseWorkflowContractTest.java
@@ -305,13 +305,14 @@ class ReleaseWorkflowContractTest {
 
     @Test
     void neoforgeShippingIsGatedPerLine() {
-        // v0.11.0 scope (user decision 2026-08-15): NeoForge ships ONLY on the 1.21.1
-        // line. This 26.2 line does NOT ship it — the value pin makes re-enabling a
-        // conscious per-line decision, and the step gates keep release.yml
-        // branch-invariant (the V-1 principle: behavior from line.env data).
-        assertEquals("false", env("LINE_SHIP_NEOFORGE"),
-                "this line must not ship NeoForge at v0.11.0 — flip line.env AND"
-                        + " release_check.py SHIP_NEOFORGE together, consciously");
+        // v0.13.1 scope (user decision 2026-08-27): NeoForge ships on this line too —
+        // the VoX/Foxy fork gives 26.x a working Voxy client pairing, retiring the
+        // v0.11.0 1.21.1-only scope. The value pin keeps any future flip a conscious
+        // per-line decision, and the step gates keep release.yml branch-invariant
+        // (the V-1 principle: behavior from line.env data).
+        assertEquals("true", env("LINE_SHIP_NEOFORGE"),
+                "this line ships NeoForge since v0.13.1 (Foxy-fork client pairing) —"
+                        + " flip line.env consciously (release_check derives from it)");
         assertTrue(stepBlock("- name: Build NeoForge + contract tests")
                         .contains("if: env.LINE_SHIP_NEOFORGE == 'true'"),
                 "the release-pipeline NeoForge build must be flag-gated");


### PR DESCRIPTION
Flips LINE_SHIP_NEOFORGE=true on main (user decision 2026-08-27 — the VoX/Foxy fork is the working 26.x Voxy client pairing), updates the conscious-flip contract pin, and adds a workflow_dispatch backfill publisher so the already-released v0.13.1 tag gains its NeoForge artifact without re-running release.yml (which would rebuild byte-different jars and duplicate Modrinth versions). Contract test + release_check green with the flip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)