### PR TITLE
fix(neoforge): activate LOD serving on Open-to-LAN (#257)

### DIFF
--- a/docs/planning/release-tag-v0.14.0.txt
+++ b/docs/planning/release-tag-v0.14.0.txt
@@ -6,6 +6,7 @@
 
 ### Bug Fixes
 
+- **NeoForge: LOD serving when opening a world to LAN** — Opening a singleplayer world to LAN on the NeoForge build now activates LOD serving for players who join; previously LODs were served only on dedicated servers.
 - **Folia correctness hardening** — A batch of fixes for Folia servers from a full review of the regionized code paths: sturdier probe scheduling, safer player-lifecycle handling, and privacy checks that fail toward hidden.
 
 ### Compatibility

--- a/neoforge/src/main/java/dev/vox/lss/mixin/IntegratedServerLanHook.java
+++ b/neoforge/src/main/java/dev/vox/lss/mixin/IntegratedServerLanHook.java
@@ -1,0 +1,33 @@
+package dev.vox.lss.mixin;
+
+import dev.vox.lss.networking.server.LSSServerNetworking;
+import net.minecraft.client.server.IntegratedServer;
+import net.minecraft.server.MinecraftServer;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(IntegratedServer.class)
+public class IntegratedServerLanHook {
+    // LINE-FACT(26.2): the overload census below is THIS line's bytecode — re-derive
+    // on a port (LanHookContractTest resolves the pinned descriptor per line).
+    // MC 26.2 has two publishServer overloads. The 4-arg (scope, gameType, allowCheats,
+    // port) is a thin wrapper that delegates into THIS 2-arg overload — and the LAN screen
+    // (MultiplayerOptionsScreen.changeMultiplayerScope) calls the 2-arg one DIRECTLY, so
+    // hooking the 4-arg (the shipped v0.6.0–v0.8.0 target) never fired for "Open to LAN";
+    // only /publish worked. Injecting here covers both entry points exactly once. The full
+    // descriptor stays pinned so mixin resolution cannot drift to the wrapper; the
+    // descriptor-vs-real-overload agreement is enforced by LanHookContractTest.
+    @Inject(method = "publishServer(Lnet/minecraft/server/MinecraftServer$MultiplayerScope;I)Z",
+            at = @At("RETURN"))
+    private void lss$onLanPublished(MinecraftServer.MultiplayerScope scope, int port,
+                                     CallbackInfoReturnable<Boolean> cir) {
+        // getReturnValue() is read HERE, in the callback frame (false for scope-off,
+        // already-published, and listener IOException — no spurious starts); only the
+        // start itself is deferred (see startServiceForLan's server-thread hop).
+        if (cir.getReturnValue()) {
+            LSSServerNetworking.startServiceForLan((IntegratedServer) (Object) this);
+        }
+    }
+}

--- a/neoforge/src/main/java/dev/vox/lss/networking/client/LSSClientNetworking.java
+++ b/neoforge/src/main/java/dev/vox/lss/networking/client/LSSClientNetworking.java
@@ -83,9 +83,11 @@ public class LSSClientNetworking {
         ClientNetGlue.reportUndispatchedColumns(manager);
     }
 
-    /** No LAN hook on NeoForge v1 (plan §5.4) — nothing ever calls this here; the
-     *  same-FQN surface keeps the twins aligned. */
+    /** LAN host re-handshake (issue #257): the {@code IntegratedServerLanHook} mixin's
+     *  activation path calls this so the host — already "joined" its own world before the
+     *  service existed — re-sends its handshake and gets registered (shared body). */
     public static void triggerHostHandshake() {
+        ClientNetGlue.triggerHostHandshake();
     }
 
     // ---- Payload handlers (bound by the registrar; executesOn(MAIN)) ----

--- a/neoforge/src/main/java/dev/vox/lss/networking/server/LSSServerNetworking.java
+++ b/neoforge/src/main/java/dev/vox/lss/networking/server/LSSServerNetworking.java
@@ -2,11 +2,13 @@ package dev.vox.lss.networking.server;
 
 import dev.vox.lss.common.Brand;
 import dev.vox.lss.common.LSSLogger;
+import dev.vox.lss.networking.client.LSSClientNetworking;
 import dev.vox.lss.networking.payloads.BatchChunkRequestC2SPayload;
 import dev.vox.lss.networking.payloads.ClientInfoC2SPayload;
 import dev.vox.lss.networking.payloads.FarPlayerPrefsC2SPayload;
 import dev.vox.lss.networking.payloads.HandshakeC2SPayload;
 import dev.vox.lss.platform.LoaderServices;
+import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.level.chunk.ChunkAccess;
@@ -24,8 +26,9 @@ import net.neoforged.neoforge.network.handling.IPayloadContext;
  * owns the static service holder, the NeoForge event handlers ({@code LSSNeoMod}
  * registers them), and the payload-handler adapters the registrar binds.
  *
- * <p>No LAN hook on NeoForge v1 (recorded feature gap, plan §5.4): a
- * LAN-published integrated server does not start the service.
+ * <p>LAN activation (issue #257): the client {@code IntegratedServerLanHook}
+ * mixin twin starts the service when an integrated server is published to LAN,
+ * the same path fabric uses.
  */
 public class LSSServerNetworking {
     private static volatile RequestProcessingService requestService;
@@ -49,13 +52,39 @@ public class LSSServerNetworking {
     public static void onServerStarted(ServerStartedEvent event) {
         var server = event.getServer();
         if (!server.isDedicatedServer() && !Boolean.getBoolean("lss.test.integratedServer")) {
-            // The fabric line defers to the LAN hook here; NeoForge v1 has none.
-            LSSLogger.info(Brand.shortName() + " LOD request processing inactive on integrated servers"
-                    + " (no LAN hook on NeoForge v1)");
+            // Integrated server: the service starts only if/when the host opens to LAN
+            // (startServiceForLan, driven by the IntegratedServerLanHook client mixin).
+            LSSLogger.info(Brand.shortName() + " LOD request processing deferred until LAN");
             return;
         }
         LSSLogger.info("Starting " + Brand.shortName() + " LOD request processing service");
         requestService = new RequestProcessingService(server);
+    }
+
+    /**
+     * LAN activation (issue #257) — the twin of the fabric path. The client
+     * {@code IntegratedServerLanHook} mixin calls this at {@code publishServer} RETURN
+     * once the LAN listener is up. Construction is heavy (processing/save/disk-reader
+     * threads + a blocking {@code ColumnTimestampCache.load}) and the mixin fires on the
+     * render thread, so hop to the server thread — the same context the dedicated-server
+     * start uses. From the server thread itself ({@code /publish}) execute() runs inline.
+     */
+    public static void startServiceForLan(MinecraftServer server) {
+        server.execute(() -> startServiceForLanOnServerThread(server));
+    }
+
+    private static synchronized void startServiceForLanOnServerThread(MinecraftServer server) {
+        // A hop task queued in the last tick before Save-and-Quit runs AFTER
+        // onServerStopping nulled requestService (the server drains pending tasks on
+        // stop) — starting here would leave a zombie service bound to a dead server for
+        // the rest of the client JVM.
+        if (!server.isRunning()) return;
+        if (requestService != null) return;
+        LSSLogger.info(Brand.shortName() + " LOD request processing service starting (LAN server)");
+        requestService = new RequestProcessingService(server);
+        // The host was already in its own world before the service existed; re-handshake
+        // so it registers and starts receiving its own LODs.
+        LSSClientNetworking.triggerHostHandshake();
     }
 
     public static void onServerStopping(ServerStoppingEvent event) {

--- a/neoforge/src/main/resources/lss.neoforge.mixins.json
+++ b/neoforge/src/main/resources/lss.neoforge.mixins.json
@@ -16,6 +16,7 @@
     "ChunkSaveDataHook"
   ],
   "client": [
+    "IntegratedServerLanHook",
     "AccessorClientPacketListener",
     "AccessorBiomeManager"
   ]

--- a/neoforge/src/test/java/dev/vox/lss/neoforge/NeoForgeModuleContractTest.java
+++ b/neoforge/src/test/java/dev/vox/lss/neoforge/NeoForgeModuleContractTest.java
@@ -100,16 +100,18 @@ class NeoForgeModuleContractTest {
                 "AccessorServerChunkCache", "AccessorSimpleRegionStorage", "AccessorIOWorker",
                 "AccessorRegionFileStorage", "AccessorRegionFile", "AccessorConnection",
                 "AccessorServerCommonPacketListener", "ChunkSaveDataHook",
-                "AccessorClientPacketListener"}) {
+                "AccessorClientPacketListener", "IntegratedServerLanHook"}) {
             assertTrue(config.contains("\"" + required + "\""),
                     required + " missing from lss.neoforge.mixins.json — an unlisted accessor"
                             + " compiles but never applies, so every use ClassCastExceptions"
                             + " at runtime (disk reads / channel pressure / dirty detection)");
         }
-        // Deliberately ABSENT: the fabric-only IntegratedServerLanHook (no LAN hook on
-        // NeoForge v1 — plan §5.4) and the trace mixins (tracer deferred).
-        assertFalse(config.contains("IntegratedServerLanHook"),
-                "the LAN hook is fabric-only; listing it here would hard-fail mixin apply");
+        // The LAN hook (issue #257) is a byte-identical twin of the fabric mixin
+        // (loaderSurfaceFreeTwinsAreByteIdentical pins it), so its @Inject descriptor is
+        // exactly the one LanHookContractTest resolves against the real publishServer
+        // overload. Deliberately ABSENT: the trace mixins (tracer deferred).
+        assertFalse(config.contains("MovementRejectHook"),
+                "the trace mixins are fabric-only here; listing them would hard-fail mixin apply");
     }
 
     @Test
@@ -206,12 +208,15 @@ class NeoForgeModuleContractTest {
      * Same-FQN twins with NO loader surface — byte-identical by contract (a fix landing
      * in one tree only is silent drift the compile cannot see; both compile fine alone):
      * ScopedCarrier (V-2/S5 — a version-volatile whole-file swap at port time, but on ONE
-     * line the same file) and the legacy-Sodium options stack
+     * line the same file), the LAN hook (issue #257 — publishServer @Inject, per-line
+     * descriptor but identical across the two loaders of one line), and the legacy-Sodium
+     * options stack
      * (sodium-options-page-generations-plan.md D4/D5 — the probe, the reflective
      * builder, the constructor hook, and the mixin config, whose compatibilityLevel is
      * per-LINE data but identical across the two loaders of one line).
      */
     private static final String[] BYTE_IDENTICAL_TWINS = {
+            "src/main/java/dev/vox/lss/mixin/IntegratedServerLanHook.java",
             "src/main/java/dev/vox/lss/compat/ScopedCarrier.java",
             "src/main/java/dev/vox/lss/config/menu/SodiumGeneration.java",
             "src/main/java/dev/vox/lss/config/menu/LegacySodiumPage.java",


### PR DESCRIPTION
## Problem

Issue #257 — a NeoForge client (the reporter is on **NeoForge 1.21.1**, LSS 0.13.1) opening a singleplayer world to LAN sees no LOD terrain. The NeoForge module never activated `RequestProcessingService` on an integrated/LAN server — a recorded feature gap (plan §5.4). The reporter's own log names it:

```
[Server thread/INFO] [LSS/]: LSS LOD request processing inactive on integrated servers (no LAN hook on NeoForge v1)
[CHAT] LSS LOD request processing is not active
```

Fabric activates on LAN-publish via the `IntegratedServerLanHook` client mixin; NeoForge had no equivalent.

## Fix

Brings NeoForge to Fabric parity:

- **New `IntegratedServerLanHook` mixin (NeoForge)** — byte-identical twin of the Fabric mixin (loader-surface-free: only same-FQN `LSSServerNetworking` + MC + mixin-lib refs). Registered in the `client` array of `lss.neoforge.mixins.json`.
- **`LSSServerNetworking.startServiceForLan`** — mirrors Fabric exactly: server-thread hop (construction is heavy + the mixin fires on the render thread), `isRunning()` + already-started guards, then `triggerHostHandshake()` so the host registers for its own LODs.
- **`triggerHostHandshake`** — the previously-dead NeoForge stub now delegates to the shared `ClientNetGlue` body.

## Pinning

- The mixin joins `NeoForgeModuleContractTest`'s byte-identical-twin set, so its `@Inject` descriptor is transitively pinned to the exact overload `LanHookContractTest` resolves against the real `IntegratedServer.publishServer` — no per-loader descriptor drift.
- The mixin-config census now **requires** the hook present (the old test pinned its absence).

## Scope

Pure-singleplayer (a world never opened to LAN) LOD stays out of scope on both loaders — that is a separate feature request, not this bug.

## Test

`:neoforge:build` + `:neoforge:runGameTestServer` green (contract suite incl. the inverted pin + byte-identical twin; 8/8 gametest smoke). Client-mixin apply is validated at runtime by the identical `AccessorClientPacketListener` client mixin already in this config; a live NeoForge-client Open-to-LAN confirmation is recommended on the 1.21.1 line (the reporter's platform).

🤖 Generated with [Claude Code](https://claude.com/claude-code)