### PR TITLE
fix(brand): route the last hard-coded LSS log strings through Brand + pin far-player privacy nodes in release_check

### DIFF
--- a/common/src/main/java/dev/vox/lss/common/compat/ViaProbe.java
+++ b/common/src/main/java/dev/vox/lss/common/compat/ViaProbe.java
@@ -71,7 +71,7 @@ public final class ViaProbe {
                 name -> Class.forName(name, false, ViaProbe.class.getClassLoader()),
                 (detail, cause) -> LSSLogger.warn("ViaVersion present but its API did not"
                         + " resolve (" + detail + ") — the cross-MC mismatch guard is"
-                        + " inactive; legacy LSS clients on other MC versions will not be"
+                        + " inactive; legacy " + dev.vox.lss.common.Brand.shortName() + " clients on other MC versions will not be"
                         + " detected", cause));
     }
 

--- a/common/src/main/java/dev/vox/lss/common/store/SqliteLodStore.java
+++ b/common/src/main/java/dev/vox/lss/common/store/SqliteLodStore.java
@@ -2039,7 +2039,7 @@ public final class SqliteLodStore implements LodStoreService {
                                 + " oldest rows (live " + (liveBytes >> 20) + " MB > cap "
                                 + (this.env.maxDbBytes() >> 20) + " MB) — the store is at "
                                 + "its size cap and will keep evicting silently; running "
-                                + "totals in '/lsslod store status' (evicted=), raise or "
+                                + "totals in '/" + Brand.serverCommand() + " store status' (evicted=), raise or "
                                 + "zero lodStoreMaxMB (0 = uncapped) for full retention");
                     }
                     liveBytes = logicalDbBytes();

--- a/fabric/src/main/java/dev/vox/lss/config/LSSConfigMenu.java
+++ b/fabric/src/main/java/dev/vox/lss/config/LSSConfigMenu.java
@@ -52,7 +52,7 @@ public class LSSConfigMenu implements ConfigEntryPoint {
         // VSS jar brands this screen without a code fork. MOD_ID stays the registration key.
         var displayName = container
                 .map(c -> c.getMetadata().getName())
-                .orElse("LOD Server Support");
+                .orElse(dev.vox.lss.common.Brand.displayName());
         var mod = builder.registerModOptions(LSSConstants.MOD_ID, displayName, version)
                 .setIcon(iconFromMetadata(container));
         // ONE handler per SaveHook, shared by every option that uses it: Sodium keeps the

--- a/fabric/src/main/java/dev/vox/lss/config/menu/LegacySodiumPage.java
+++ b/fabric/src/main/java/dev/vox/lss/config/menu/LegacySodiumPage.java
@@ -135,7 +135,7 @@ public final class LegacySodiumPage {
         } catch (Throwable t) {
             if (!buildFailureLogged) {
                 buildFailureLogged = true;
-                LSSLogger.warn("LSS options page: could not build the Sodium settings pages — "
+                LSSLogger.warn(Brand.shortName() + " options page: could not build the Sodium settings pages — "
                         + "config files still work (" + t + ")");
             }
             return List.of();
@@ -164,7 +164,7 @@ public final class LegacySodiumPage {
             // modularized Sodium): latch, warn once, and let build() stay quiet about it.
             resolveFailed = true;
             buildFailureLogged = true;
-            LSSLogger.warn("LSS options page: this Sodium (" + prefix + ") has a different internal"
+            LSSLogger.warn(Brand.shortName() + " options page: this Sodium (" + prefix + ") has a different internal"
                     + " options API shape — settings page skipped, config files still work (" + e + ")");
             throw e;
         }
@@ -362,7 +362,7 @@ public final class LegacySodiumPage {
             return;
         }
         proxyFailureLogged = true;
-        LSSLogger.warn("LSS options page: " + what + (t == null ? "" : " (" + t + ")"));
+        LSSLogger.warn(Brand.shortName() + " options page: " + what + (t == null ? "" : " (" + t + ")"));
     }
 
     private static Component component(Label label) {

--- a/neoforge/src/main/java/dev/vox/lss/config/LSSConfigMenu.java
+++ b/neoforge/src/main/java/dev/vox/lss/config/LSSConfigMenu.java
@@ -51,7 +51,7 @@ public class LSSConfigMenu implements ConfigEntryPoint {
         Optional<IModInfo> info = ModList.get().getModContainerById(LSSConstants.MOD_ID)
                 .map(c -> c.getModInfo());
         var version = info.map(i -> i.getVersion().toString()).orElse("unknown");
-        var displayName = info.map(IModInfo::getDisplayName).orElse("LOD Server Support");
+        var displayName = info.map(IModInfo::getDisplayName).orElse(dev.vox.lss.common.Brand.displayName());
         var mod = builder.registerModOptions(LSSConstants.MOD_ID, displayName, version)
                 .setIcon(iconFromMetadata(info));
         // ONE handler per SaveHook, shared by every option that uses it (see the Fabric

--- a/neoforge/src/main/java/dev/vox/lss/config/menu/LegacySodiumPage.java
+++ b/neoforge/src/main/java/dev/vox/lss/config/menu/LegacySodiumPage.java
@@ -135,7 +135,7 @@ public final class LegacySodiumPage {
         } catch (Throwable t) {
             if (!buildFailureLogged) {
                 buildFailureLogged = true;
-                LSSLogger.warn("LSS options page: could not build the Sodium settings pages — "
+                LSSLogger.warn(Brand.shortName() + " options page: could not build the Sodium settings pages — "
                         + "config files still work (" + t + ")");
             }
             return List.of();
@@ -164,7 +164,7 @@ public final class LegacySodiumPage {
             // modularized Sodium): latch, warn once, and let build() stay quiet about it.
             resolveFailed = true;
             buildFailureLogged = true;
-            LSSLogger.warn("LSS options page: this Sodium (" + prefix + ") has a different internal"
+            LSSLogger.warn(Brand.shortName() + " options page: this Sodium (" + prefix + ") has a different internal"
                     + " options API shape — settings page skipped, config files still work (" + e + ")");
             throw e;
         }
@@ -362,7 +362,7 @@ public final class LegacySodiumPage {
             return;
         }
         proxyFailureLogged = true;
-        LSSLogger.warn("LSS options page: " + what + (t == null ? "" : " (" + t + ")"));
+        LSSLogger.warn(Brand.shortName() + " options page: " + what + (t == null ? "" : " (" + t + ")"));
     }
 
     private static Component component(Label label) {

--- a/paper/src/main/java/dev/vox/lss/paper/PaperChannelPressure.java
+++ b/paper/src/main/java/dev/vox/lss/paper/PaperChannelPressure.java
@@ -46,7 +46,7 @@ public final class PaperChannelPressure {
                 connection = null;
                 channel = null;
                 LSSLogger.warn("Outbound-buffer gauge unavailable (" + t + ") —"
-                        + " /lsslod diag will show obuf=n/a and transport deference stays inert");
+                        + " /" + dev.vox.lss.common.Brand.serverCommand() + " diag will show obuf=n/a and transport deference stays inert");
             }
             CONNECTION = connection;
             CHANNEL = channel;

--- a/paper/src/main/java/dev/vox/lss/paper/PaperXrayMaskManager.java
+++ b/paper/src/main/java/dev/vox/lss/paper/PaperXrayMaskManager.java
@@ -96,7 +96,7 @@ final class PaperXrayMaskManager {
                 // routes to the LSS config-key mask — fail-safe, masking stays ON.
                 LSSLogger.warn("Paper anti-xray config unreadable for "
                         + level.dimension().identifier() + " — LOD masking falls back to the "
-                        + "LSS xrayHiddenBlocks config keys", t);
+                        + dev.vox.lss.common.Brand.shortName() + " xrayHiddenBlocks config keys", t);
                 return new EngineConfig(true, List.of(), 0);
             }
         });
@@ -150,7 +150,7 @@ final class PaperXrayMaskManager {
                 // would silently leak, so fall back to the LSS keys (design §3 Detection).
                 LSSLogger.warn("Paper anti-xray is enabled for " + dimension + " but its "
                         + "hidden-blocks list resolved empty — LOD masking falls back to "
-                        + "the LSS xrayHiddenBlocks config key for this world");
+                        + "the " + dev.vox.lss.common.Brand.shortName() + " xrayHiddenBlocks config key for this world");
                 engineMask = null;
             }
         }

--- a/scripts/release_check.py
+++ b/scripts/release_check.py
@@ -879,6 +879,20 @@ def check_vss_pair_paper(lss_jar, vss_jar, problems):
                                 "jars (the enforcement requires both, and Bukkit resolves an "
                                 "undeclared node to the op default, so a missing declaration "
                                 "denies every non-op)")
+    # The far-player privacy nodes get the SAME dual-jar belt (Fable VSS branding review
+    # 2026-08-28): unlike the service gate, only vss.farplayers.hidden was positively pinned
+    # present (in the VSS jar) — lss.farplayers.hidden was never pinned in either jar. A widened
+    # rewrite that RENAMED lss.farplayers.hidden -> vss.farplayers.hidden (mirroring the
+    # lss.admin rename rule) would drop the lss. spelling from the VSS jar; undeclared, it
+    # resolves to Bukkit's OP default (TRUE), and hiddenFor's OR-check then hides every OP as a
+    # far player. Require BOTH spellings present in BOTH jars, symmetric with the service gate.
+    for jar_text, jar_name in ((ltext, os.path.basename(lss_jar)), (vtext, vbase)):
+        for tok in ("lss.farplayers.hidden", "vss.farplayers.hidden"):
+            if tok not in jar_text:
+                problems.append(f"{jar_name}: plugin.yml is missing the far-player privacy node "
+                                f"{tok!r} — BOTH brand spellings must be declared in BOTH jars "
+                                "(an undeclared node resolves to Bukkit's op default TRUE, so a "
+                                "dropped declaration silently hides every op as a far player)")
 
 
 # ---------------------------------------------------------------- brand.properties + wire

--- a/xplat/src/main/java/dev/vox/lss/benchmark/SoakStoreDowngrade.java
+++ b/xplat/src/main/java/dev/vox/lss/benchmark/SoakStoreDowngrade.java
@@ -36,7 +36,7 @@ final class SoakStoreDowngrade {
 
     static void run(MinecraftServer server) {
         Path db = server.getWorldPath(LevelResource.ROOT).normalize()
-                .resolve("lss-lod").resolve("store.db");
+                .resolve(dev.vox.lss.common.Brand.lowerShortName() + "-lod").resolve("store.db");
         if (!Files.isRegularFile(db)) {
             throw new IllegalStateException("[Soak] downgradeStoreToV19: no store at " + db
                     + " — stage a warmed store (SOAK_WORLD_FROM) before arming the flag");

--- a/xplat/src/main/java/dev/vox/lss/compat/AntiXrayCompat.java
+++ b/xplat/src/main/java/dev/vox/lss/compat/AntiXrayCompat.java
@@ -201,7 +201,7 @@ public final class AntiXrayCompat {
 
     private static void warnEngineUnreadable(Throwable t) {
         LSSLogger.warn("AntiXray is installed but its per-world obfuscation config could not "
-                + "be read — LOD masking falls back to the LSS xrayHiddenBlocks/"
+                + "be read — LOD masking falls back to the " + dev.vox.lss.common.Brand.shortName() + " xrayHiddenBlocks/"
                 + "xrayMaxBlockHeight config keys for every world.", t);
     }
 }

--- a/xplat/src/main/java/dev/vox/lss/compat/VoxyCompat.java
+++ b/xplat/src/main/java/dev/vox/lss/compat/VoxyCompat.java
@@ -750,7 +750,8 @@ class VoxyCompat {
             resetDomainState = -1;
             LSSLogger.warn("Voxy reset unavailable on this Voxy version — /"
                     + dev.vox.lss.common.Brand.clientCommand()
-                    + " reset will clear only the LSS half (" + e + ")");
+                    + " reset will clear only the " + dev.vox.lss.common.Brand.shortName()
+                    + " half (" + e + ")");
             return false;
         }
     }

--- a/xplat/src/main/java/dev/vox/lss/networking/client/FarPlayerClientSupport.java
+++ b/xplat/src/main/java/dev/vox/lss/networking/client/FarPlayerClientSupport.java
@@ -91,11 +91,14 @@ public final class FarPlayerClientSupport {
                 config.farPlayersWithSeeU);
         if (!gate && config.farPlayersEnabled && isSeeuPresent() && !seeuInfoLogged) {
             seeuInfoLogged = true;
-            LSSLogger.info("SeeU detected — LSS stops drawing far players to avoid"
+            LSSLogger.info("SeeU detected — " + dev.vox.lss.common.Brand.shortName()
+                    + " stops drawing far players to avoid"
                     + " double proxies (your own Share My Position setting still"
-                    + " applies); set farPlayersWithSeeU=true in lss-client-config.json"
-                    + " (the 'Prefer LSS Far Players' option in the Sodium screen)"
-                    + " to use LSS instead");
+                    + " applies); set farPlayersWithSeeU=true in "
+                    + dev.vox.lss.common.Brand.lowerShortName() + "-client-config.json"
+                    + " (the 'Prefer " + dev.vox.lss.common.Brand.shortName()
+                    + " Far Players' option in the Sodium screen)"
+                    + " to use " + dev.vox.lss.common.Brand.shortName() + " instead");
         }
         return gate;
     }

--- a/xplat/src/main/java/dev/vox/lss/networking/server/FabricChannelPressure.java
+++ b/xplat/src/main/java/dev/vox/lss/networking/server/FabricChannelPressure.java
@@ -99,7 +99,7 @@ public final class FabricChannelPressure {
             if (!warned) {
                 warned = true;
                 LSSLogger.warn("Outbound-buffer gauge unavailable (" + t + ") —"
-                        + " /lsslod diag will show obuf=n/a and transport deference stays inert");
+                        + " /" + dev.vox.lss.common.Brand.serverCommand() + " diag will show obuf=n/a and transport deference stays inert");
             }
             return null;
         }

--- a/xplat/src/main/java/dev/vox/lss/networking/server/RequestProcessingService.java
+++ b/xplat/src/main/java/dev/vox/lss/networking/server/RequestProcessingService.java
@@ -245,7 +245,7 @@ public class RequestProcessingService {
                 : dev.vox.lss.common.store.LodStoreMode.OFF;
         if (!config.enabled && !dev.vox.lss.common.store.LodStoreMode
                 .normalize(config.lodStore).equals(dev.vox.lss.common.store.LodStoreMode.OFF)) {
-            LSSLogger.info("LSS is disabled (enabled=false) — the LOD store and its "
+            LSSLogger.info(dev.vox.lss.common.Brand.shortName() + " is disabled (enabled=false) — the LOD store and its "
                     + "backfill stay off; no store is created and no regions are walked");
         }
         if (storeMode == dev.vox.lss.common.store.LodStoreMode.OFF) {

--- a/xplat/src/main/java/dev/vox/lss/networking/server/XrayMaskManager.java
+++ b/xplat/src/main/java/dev/vox/lss/networking/server/XrayMaskManager.java
@@ -140,7 +140,7 @@ public final class XrayMaskManager {
                         // once, guaranteed by the computeIfAbsent mapping.
                         LSSLogger.warn("AntiXray engine stayed unreadable (transient) for "
                                 + d + " after " + TRANSIENT_PROBE_LATCH + " probes — caching "
-                                + "the LSS-config fallback mask for this session");
+                                + "the " + dev.vox.lss.common.Brand.shortName() + "-config fallback mask for this session");
                     }
                     return Optional.ofNullable(evaluate(d, v, false));
                 })
@@ -208,7 +208,7 @@ public final class XrayMaskManager {
             if (!quiet) {
                 LSSLogger.info("AntiXray engine mode 2/3 detected for " + dimension
                         + " — its obfuscation list includes replacement terrain, so LOD masking "
-                        + "uses the LSS xrayHiddenBlocks list at the engine's height instead");
+                        + "uses the " + dev.vox.lss.common.Brand.shortName() + " xrayHiddenBlocks list at the engine's height instead");
             }
         } else {
             mask = fallbackMask();

--- a/xplat/src/main/java/dev/vox/lss/trace/MoveDesyncTracer.java
+++ b/xplat/src/main/java/dev/vox/lss/trace/MoveDesyncTracer.java
@@ -71,7 +71,7 @@ public final class MoveDesyncTracer {
         this.bootId = newBootId();
         this.queue = new ArrayBlockingQueue<>(queueCapacity);
         this.testSink = null;
-        this.writerThread = new Thread(this::writerLoop, "LSS-MoveTrace");
+        this.writerThread = new Thread(this::writerLoop, dev.vox.lss.common.Brand.shortName() + "-MoveTrace");
         this.writerThread.setDaemon(true);
         if (startWriter) {
             this.writerThread.start();


### PR DESCRIPTION
Routes the ~15 hard-coded `LSS`/`/lsslod`/display-name strings that leaked into log lines, warnings, and one user-facing SeeU-coexist message through `common/Brand`, so VSS-branded jars print `VSS`/`/vsslod`/`Voxy Server Side` consistently. Wire surface untouched (mod id `lss`, `lss:*` channels unchanged) — these are all local/display surfaces.

The most user-visible fix: the SeeU-coexist INFO in `FarPlayerClientSupport` named `LSS` and `lss-client-config.json` verbatim, actively misdirecting a VSS user to the wrong config file.

Also hardens `scripts/release_check.py`: the dual-jar plugin.yml pin loop now also requires both `lss.farplayers.hidden` and `vss.farplayers.hidden` in both jars (previously only the `lss.use`/`vss.use` service nodes were pinned; the privacy nodes must be dual-declared for the same op-default reason).

Runtime branding defaults to LSS when the properties resource is absent, so every test/checker (which run unbranded) sees byte-identical output — no behavior change on the LSS path.

Landed identically on all four support lines (mc26.1-v0.14, mc1.21.11-v0.14, mc1.21.10, mc1.21.1); the branding strings are line-invariant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)