### PR TITLE
docs: recommend the Roxy path for NeoForge 1.21.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,12 +18,9 @@ Clients use the Fabric mod on every version; on 26.2, 26.1, and 1.21.1 a NeoForg
 | 1.21.10 | ✅ | ✅ | - | - |
 | 1.21.1 | ✅ | ✅ | - | ✅ |
 
-On NeoForge (1.21.1) there are two tested client paths, depending on your Sodium version:
+On NeoForge (1.21.1) use [Roxy](https://modrinth.com/mod/roxy) to load the Fabric Voxy jar. Tested working with Roxy 0.2.0, Voxy 0.2.16-beta (the 1.21.11 build), Sodium 0.8.12, and [Forgified Fabric API](https://modrinth.com/mod/forgified-fabric-api) 0.116.15. If distant Voxy chunks do not show up, turn off environmental fog in your video settings.
 
-- **Sodium 0.6.13**: the community [Voxy NeoForge port](https://github.com/j-shelfwood/voxy-neoforge) with [Forgified Fabric API](https://modrinth.com/mod/forgified-fabric-api) in place of Fabric API. Tested working with Forgified Fabric API 0.116.15 and Voxy NeoForge port 0.2.9-alpha.
-- **Sodium 0.8.12** (required by current Create Aeronautics / Sable packs): the Fabric [Voxy 1.21.1 branch for Sodium 0.8.12](https://github.com/m3t4f1v3/voxy/tree/mc_1211-sodium0.8.12) (0.2.15-beta, built from source) loaded through [Sinytra Connector](https://modrinth.com/mod/connector) with Forgified Fabric API. Tested working inside a large Create pack with Connector 2.0.0-beta.14, Forgified Fabric API 0.116.15, and Sodium 0.8.12-beta.1.
-
-The in-game settings page (Sodium's Video Settings → the LSS entry or tabs; on Fabric also ModMenu's Configure button) renders on both Sodium generations from v0.13.0: on Sodium 0.8+ it appears under LSS's own entry in the settings screen; on Sodium 0.6/0.7 (MC ≤1.21.10 and the 1.21.1 Voxy-fork pairing) it appears as LSS tabs beside Sodium's own. On NeoForge the page renders on both generations too — the 0.6/0.7 tabs on the Voxy-fork pairing, and LSS's own entry on native NeoForge Sodium 0.8+ builds (what the Connector stack pairs with) — without the far-player render options, which NeoForge does not render yet.
+The in-game settings page (Sodium's Video Settings → the LSS entry or tabs; on Fabric also ModMenu's Configure button) renders on both Sodium generations from v0.13.0: on Sodium 0.8+ it appears under LSS's own entry in the settings screen; on Sodium 0.6/0.7 (MC ≤1.21.10) it appears as LSS tabs beside Sodium's own. On NeoForge the page renders under LSS's own entry (native Sodium 0.8+), without the far-player render options, which NeoForge does not render yet.
 
 Compatible with [AntiXray](https://modrinth.com/mod/anti-xray), [Moonrise](https://modrinth.com/mod/moonrise-opt), [C2ME](https://modrinth.com/mod/c2me-fabric), [ViaVersion](https://modrinth.com/plugin/viaversion)/[ViaBackwards](https://modrinth.com/plugin/viabackwards), and most other mods. Can be run alongside Distant Horizons on the same server to support DH clients and Voxy clients simultaneously. 
 


### PR DESCRIPTION
Updates the README's NeoForge 1.21.1 client-path guidance to the single tested Roxy setup, replacing the two older paths (the Sodium 0.6.13 Voxy-neoforge port, and the Sodium 0.8.12 Voxy-fork-through-Connector build).

Recommended setup: [Roxy](https://modrinth.com/mod/roxy) 0.2.0 + Voxy 0.2.16-beta (the 1.21.11 build, the version Roxy verifies against) + Sodium 0.8.12 + Forgified Fabric API. Also notes turning off environmental fog so the distant Voxy chunks are visible, and drops the stale Voxy-fork / Connector references from the settings-page paragraph.

Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)